### PR TITLE
feat: add widget endpoint returning GitHub widget content

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -15,6 +15,8 @@
     }, {
       "source": "/api/goodreads-updates", "function": "getGoodreadsUpdates"
     }, {
+      "source": "/api/widget-content", "function": "getWidgetContent"
+    }, {
       "source": "/api/summaries", "function": "getSummaries"
     } ]
   }

--- a/functions/getWidgetContent.js
+++ b/functions/getWidgetContent.js
@@ -1,0 +1,32 @@
+"use strict";
+
+const getGitHubWidgetContent = require('./lib/get-github-widget-content');
+
+const widgetHandlerMap = {
+	github: getGitHubWidgetContent
+};
+
+const getWidgetContent = async ({ context, req }) => {
+  const {
+    query: { widget }
+  } = req;
+
+  if (!widgetHandlerMap[widget]) {
+	return {
+        status: "error",
+        code: 400,
+        error: "Widget type unrecognized or missing."
+      };
+  }
+
+  const widgetHandler = widgetHandlerMap[widget];
+  const payload = await widgetHandler({ context });
+
+  return {
+	status: "ok",
+	code: 200,
+	payload
+  };
+};
+
+module.exports = getWidgetContent;

--- a/functions/getWidgetContent.js
+++ b/functions/getWidgetContent.js
@@ -1,9 +1,9 @@
 "use strict";
 
-const getGitHubWidgetContent = require('./lib/get-github-widget-content');
+const getGitHubWidgetContent = require("./lib/get-github-widget-content");
 
 const widgetHandlerMap = {
-	github: getGitHubWidgetContent
+  github: getGitHubWidgetContent
 };
 
 const getWidgetContent = async ({ context, req }) => {
@@ -12,21 +12,13 @@ const getWidgetContent = async ({ context, req }) => {
   } = req;
 
   if (!widgetHandlerMap[widget]) {
-	return {
-        status: "error",
-        code: 400,
-        error: "Widget type unrecognized or missing."
-      };
+    throw new Error("Widget type unrecognized or missing.");
   }
 
   const widgetHandler = widgetHandlerMap[widget];
   const payload = await widgetHandler({ context });
 
-  return {
-	status: "ok",
-	code: 200,
-	payload
-  };
+  return payload;
 };
 
 module.exports = getWidgetContent;

--- a/functions/index.js
+++ b/functions/index.js
@@ -78,4 +78,3 @@ exports.getGoodreadsUpdates = functions.https
       res.status(200).send(updates);
     })
   });
-  

--- a/functions/index.js
+++ b/functions/index.js
@@ -68,13 +68,23 @@ exports.getGoodreadsUpdates = functions.https
     })
   });
 
-
-  exports.getWidgetContent = functions.https
+exports.getWidgetContent = functions.https
   .onRequest(async (req, res) => {
     return cors(req, res, async () => {
-      const response = await getWidgetContent({ context, req });
-      res.set('Cache-Control', 'public, max-age=3600, s-maxage=14400');
-      res.set('Access-Control-Allow-Origin', '*');
-      res.status(200).send(response);
+      try {
+        const response = await getWidgetContent({ context, req });
+        res.set('Cache-Control', 'public, max-age=3600, s-maxage=14400');
+        res.set('Access-Control-Allow-Origin', '*');
+        res.status(200).send({
+          ok: true,
+          payload: response
+        });
+      } catch (error) {
+        const { message } = error;
+        res.status(400).send({
+          ok: false,
+          error: { message }
+        });
+      }
     })
   });

--- a/functions/index.js
+++ b/functions/index.js
@@ -72,9 +72,9 @@ exports.getGoodreadsUpdates = functions.https
   exports.getWidgetContent = functions.https
   .onRequest(async (req, res) => {
     return cors(req, res, async () => {
-      const updates = await getWidgetContent({ context, req });
+      const response = await getWidgetContent({ context, req });
       res.set('Cache-Control', 'public, max-age=3600, s-maxage=14400');
       res.set('Access-Control-Allow-Origin', '*');
-      res.status(200).send(updates);
+      res.status(200).send(response);
     })
   });

--- a/functions/index.js
+++ b/functions/index.js
@@ -78,3 +78,4 @@ exports.getGoodreadsUpdates = functions.https
       res.status(200).send(updates);
     })
   });
+  

--- a/functions/index.js
+++ b/functions/index.js
@@ -8,6 +8,7 @@ const cors = require('cors')({
 
 const getGoodreadsUpdates = require('./getGoodreadsUpdates');
 const getPinnedRepositories = require('./getPinnedRepositories');
+const getWidgetContent = require('./getWidgetContent');
 const syncAllStats = require('./syncAllStats');
 const syncAllSummaries = require('./syncAllSummaries');
 const syncYesterdaysCodeSummary = require('./syncYesterdaysCodeSummary');
@@ -61,6 +62,17 @@ exports.getGoodreadsUpdates = functions.https
   .onRequest(async (req, res) => {
     return cors(req, res, async () => {
       const updates = await getGoodreadsUpdates(context);
+      res.set('Cache-Control', 'public, max-age=3600, s-maxage=14400');
+      res.set('Access-Control-Allow-Origin', '*');
+      res.status(200).send(updates);
+    })
+  });
+
+
+  exports.getWidgetContent = functions.https
+  .onRequest(async (req, res) => {
+    return cors(req, res, async () => {
+      const updates = await getWidgetContent({ context, req });
       res.set('Cache-Control', 'public, max-age=3600, s-maxage=14400');
       res.set('Access-Control-Allow-Origin', '*');
       res.status(200).send(updates);

--- a/functions/lib/get-github-widget-content.js
+++ b/functions/lib/get-github-widget-content.js
@@ -1,94 +1,28 @@
 const graphqlGot = require("graphql-got");
+const fs = require("fs");
+const path = require("path");
 
-const query = `
-query getGitHubWidgetContent($username: String!) {
-	user(login: $username) {
-    login
-    name
-		status {
-		  id
-      createdAt
-      message
-		}
-    projectsUrl
-    location
-    avatarUrl
-    pinnedRepositories(last: 10){
-			totalCount
-			nodes {
-				createdAt
-				description
-				descriptionHTML
-				hasIssuesEnabled
-				hasWikiEnabled
-				homepageUrl
-				licenseInfo {
-					name
-					nickname
-					key
-					url
-				}
-				name
-				nameWithOwner
-				openGraphImageUrl
-				primaryLanguage {
-					color
-					name
-				}
-				updatedAt
-				pushedAt
-				url
-				usesCustomOpenGraphImage
-			}
-		}
-    pullRequests(last: 1, states: MERGED) {
-      nodes {
-        labels(last: 10) {
-          edges {
-            node {
-              id
-              color
-              name
-            }
-          }
-        }
-        lastEditedAt
-        authorAssociation
-        url
-        closed
-        closedAt
-        createdAt
-        merged
-        number
-        repository {
-          name
-          id
-          url
-        }
-        title
-        url
-        viewerDidAuthor
-      }
-    }
-	}
-}`;
+const query = fs.readFileSync(
+  path.resolve(__dirname, "../queries/github-widget-content.gql"),
+  "utf8"
+);
 
 const getGitHubWidgetContent = async ({ context }) => {
-    const {
-        config: {
-          github: { access_token: token, username }
-        }
-      } = context;
-    
-      const { body } = await graphqlGot("https://api.github.com/graphql", {
-        query,
-        token,
-        variables: {
-          username
-        }
-      });
+  const {
+    config: {
+      github: { access_token: token, username }
+    }
+  } = context;
 
-      return body;
+  const { body } = await graphqlGot("https://api.github.com/graphql", {
+    query,
+    token,
+    variables: {
+      username
+    }
+  });
+
+  return body;
 };
 
 module.exports = getGitHubWidgetContent;

--- a/functions/lib/get-github-widget-content.js
+++ b/functions/lib/get-github-widget-content.js
@@ -1,0 +1,94 @@
+const graphqlGot = require("graphql-got");
+
+const query = `
+query getGitHubWidgetContent($username: String!) {
+	user(login: $username) {
+    login
+    name
+		status {
+		  id
+      createdAt
+      message
+		}
+    projectsUrl
+    location
+    avatarUrl
+    pinnedRepositories(last: 10){
+			totalCount
+			nodes {
+				createdAt
+				description
+				descriptionHTML
+				hasIssuesEnabled
+				hasWikiEnabled
+				homepageUrl
+				licenseInfo {
+					name
+					nickname
+					key
+					url
+				}
+				name
+				nameWithOwner
+				openGraphImageUrl
+				primaryLanguage {
+					color
+					name
+				}
+				updatedAt
+				pushedAt
+				url
+				usesCustomOpenGraphImage
+			}
+		}
+    pullRequests(last: 1, states: MERGED) {
+      nodes {
+        labels(last: 10) {
+          edges {
+            node {
+              id
+              color
+              name
+            }
+          }
+        }
+        lastEditedAt
+        authorAssociation
+        url
+        closed
+        closedAt
+        createdAt
+        merged
+        number
+        repository {
+          name
+          id
+          url
+        }
+        title
+        url
+        viewerDidAuthor
+      }
+    }
+	}
+}`;
+
+const getGitHubWidgetContent = async ({ context }) => {
+    const {
+        config: {
+          github: { access_token: token, username }
+        }
+      } = context;
+    
+      const { body } = await graphqlGot("https://api.github.com/graphql", {
+        query,
+        token,
+        variables: {
+          username
+        }
+      });
+
+      return body;
+};
+
+module.exports = getGitHubWidgetContent;

--- a/functions/queries/github-widget-content.gql
+++ b/functions/queries/github-widget-content.gql
@@ -1,0 +1,96 @@
+query GitHubWidgetQuery($username: String!) {
+  user(login: $username) {
+    login
+    name
+    createdAt
+    bio
+    followers {
+      totalCount
+    }
+    following {
+      totalCount
+    }
+    url
+    status {
+      emoji
+      updatedAt
+      createdAt
+      expiresAt
+      message
+    }
+    projectsUrl
+    location
+    avatarUrl
+    pinnedItems(last: 10) {
+      totalCount
+      nodes {
+        __typename
+        ... on Gist {
+          url
+          id
+          name
+          updatedAt
+          pushedAt
+        }
+        ... on Repository {
+          createdAt
+          description
+          hasIssuesEnabled
+          hasWikiEnabled
+          homepageUrl
+          id
+          licenseInfo {
+            name
+            nickname
+            key
+            url
+          }
+          name
+          nameWithOwner
+          openGraphImageUrl
+          primaryLanguage {
+            id
+            color
+            name
+          }
+          updatedAt
+          pushedAt
+          url
+          usesCustomOpenGraphImage
+        }
+      }
+    }
+    repositories {
+      totalCount
+    }
+    pullRequests(last: 1, states: MERGED) {
+      nodes {
+        labels(last: 10) {
+          edges {
+            node {
+              id
+              color
+              name
+            }
+          }
+        }
+        lastEditedAt
+        url
+        closed
+        closedAt
+        createdAt
+        id
+        merged
+        number
+        repository {
+          name
+          id
+          url
+        }
+        title
+        url
+        viewerDidAuthor
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a new endpoint that returns widget data. The GitHub widget data is included as the first type of content that can be requested.

### Screenshot

Preview showing the endpoint called on local env.

<img width="1292" alt="Screen Shot 2019-11-01 at 8 35 32 AM" src="https://user-images.githubusercontent.com/1934719/68036327-abd01680-fc82-11e9-9669-ead40e11276f.png">
