### PR TITLE
fix: missing updated date in book review status object

### DIFF
--- a/functions/lib/get-review.js
+++ b/functions/lib/get-review.js
@@ -22,12 +22,10 @@ const getAuthor = author => {
       _: imageURL = '',
       nophoto: hasImageURL = false
     } = {},
-    link,
     small_image_url: {
       _: smallImageURL = '',
       nophoto: hasSmallImageURL = false
     } = {},
-    name,
     ratingsCount: ratingsCount,
     text_reviews_count: textReviewCount
   } = author;
@@ -74,7 +72,7 @@ const getReview = update => {
       book
     },
     type,
-    updatedAt: updated
+    updated_at: updated
   } = update;
 
   return {

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "personal-metrics",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "personal-metrics",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Personal metrics. A life-tracking hobby project.",
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
Fixes a typo preventing the `updated` property from being included in the book review status object.