### PR TITLE
WIP: explicitly request 12+ books in latest books request

### DIFF
--- a/functions/api/goodreads/fetch-recently-read-books.js
+++ b/functions/api/goodreads/fetch-recently-read-books.js
@@ -43,7 +43,7 @@ module.exports = async () => {
   const { goodreads: { key, user_id: userID } = {} } = config
 
   const { body } = await got(
-    `https://www.goodreads.com/review/list/${userID}.xml?key=${key}&v=2&shelf=read&sort=date_read`
+    `https://www.goodreads.com/review/list/${userID}.xml?key=${key}&v=2&shelf=read&sort=date_read&per_page=18`
   )
 
   let rawReviewsResponse

--- a/functions/api/goodreads/fetch-recently-read-books.js
+++ b/functions/api/goodreads/fetch-recently-read-books.js
@@ -1,11 +1,11 @@
 const convertToHttps = require('to-https')
-const functions = require('firebase-functions')
-const got = require('got')
-const { parseString } = require('xml2js')
-
 const fetchBookFromGoogle = require('../google-books/fetch-book')
-
-const isString = (subject) => typeof subject === 'string'
+const functions = require('firebase-functions')
+const get = require('lodash/get')
+const got = require('got')
+const isArray = require('lodash/isArray')
+const isString = require('lodash/isString')
+const { parseString } = require('xml2js')
 
 const transformBookData = (book) => {
   const {
@@ -38,37 +38,8 @@ const transformBookData = (book) => {
   }
 }
 
-const transformReview = (books, book) => {
-  const {
-    read_at: [date],
-  } = book
-
-  if (!isString(date) && date.length > 3) {
-    return
-  }
-
-  const {
-    book: bookData,
-    rating: [rating],
-  } = book
-  const [{ isbn: isbnArr = [], isbn13: isbn13Arr = [] }] = bookData
-  const [isbn10] = isbnArr
-  const [isbn13] = isbn13Arr
-
-  const isbn = isString(isbn13) ? isbn13 : isString(isbn10) ? isbn10 : false
-  if (Array.isArray(books) && isString(isbn)) {
-    books.push({
-      isbn,
-      rating,
-    })
-  }
-
-  return books
-}
-
 module.exports = async () => {
   const config = functions.config()
-
   const { goodreads: { key, user_id: userID } = {} } = config
 
   const { body } = await got(
@@ -77,14 +48,42 @@ module.exports = async () => {
 
   let rawReviewsResponse
 
+  /**
+   * Transforms Goodreads Book Reviews response from XML into JSON
+   */
   const bookReviews = await new Promise((resolve, reject) => {
-    parseString(body, (error, result) => {
+    parseString(body, (error, response) => {
       if (error) {
         reject(error)
       }
 
-      const reviewsResponse = result.GoodreadsResponse.reviews[0].review
-      const transformedReviews = reviewsResponse.reduce(transformReview, [])
+      const reviewsResponse = get(response, 'GoodreadsResponse.reviews[0].review', [])
+      const transformedReviews = reviewsResponse.reduce((books, book) => {
+        const {
+          read_at: [date],
+        } = book
+      
+        if (!isString(date) && date.length > 3) {
+          return
+        }
+      
+        const {
+          book: bookData,
+          rating: [rating],
+        } = book
+      
+        const [{ isbn: [isbn10] = [], isbn13: [isbn13] = [] }] = bookData  
+        const isbn = isbn13 || isbn10
+      
+        if (isArray(books) && isString(isbn)) {
+          books.push({
+            isbn,
+            rating,
+          })
+        }
+      
+        return books
+      }, [])
 
       rawReviewsResponse = reviewsResponse
 
@@ -97,8 +96,7 @@ module.exports = async () => {
   // information. The Google Books data is really clean and useful. So, I'm currently
   // using Goodreads to get my book review, and then returning the book data from
   // Google Books.
-  const bookPromises = bookReviews
-    .map((book) => fetchBookFromGoogle(book))
+  const bookPromises = bookReviews.map((book) => fetchBookFromGoogle(book))
   const bookResults = await Promise.all(bookPromises)
   const books = bookResults
     .filter(

--- a/functions/index.js
+++ b/functions/index.js
@@ -83,6 +83,14 @@ app.get(
   }
 )
 
+app.get(
+  '/api/widgets/:provider/sync',
+  async (req, res) => {
+    const result = await syncGoodreadsData()
+    res.status(200).send(result)
+  }
+)
+
 app.get('*', (req, res) => {
   res.sendStatus(404)
 })

--- a/functions/index.js
+++ b/functions/index.js
@@ -91,7 +91,7 @@ app.get(
   }
 )
 
-// TODO: enble this based on the environment
+// TODO: enable this based on the environment
 // app.get(
 //   '/api/widgets/:provider/sync',
 //   async (req, res) => {

--- a/functions/index.js
+++ b/functions/index.js
@@ -15,6 +15,14 @@ admin.initializeApp({
   databaseURL: 'https://personal-stats-chrisvogt.firebaseio.com',
 })
 
+admin.firestore().settings({
+  // Firestore throws when saving documents containing null values and the
+  // Goodreads response object contains null values for unset fields. The
+  // Firestore `ignoreUndefinedProperties` option enables support for fields
+  // with null values.
+  ignoreUndefinedProperties: true,
+})
+
 exports.syncGoodreadsData = functions.pubsub
   .schedule('every day 02:00')
   .onRun(() => syncGoodreadsData())
@@ -83,13 +91,14 @@ app.get(
   }
 )
 
-app.get(
-  '/api/widgets/:provider/sync',
-  async (req, res) => {
-    const result = await syncGoodreadsData()
-    res.status(200).send(result)
-  }
-)
+// TODO: enble this based on the environment
+// app.get(
+//   '/api/widgets/:provider/sync',
+//   async (req, res) => {
+//     const result = await syncGoodreadsData()
+//     res.status(200).send(result)
+//   }
+// )
 
 app.get('*', (req, res) => {
   res.sendStatus(404)

--- a/functions/jobs/sync-goodreads-data.js
+++ b/functions/jobs/sync-goodreads-data.js
@@ -14,8 +14,6 @@ const syncGoodreadsData = async () => {
   let reviewsResponse
   let updates
 
-  console.log('SYNCING GOODREADS DATA')
-
   try {
     const [user, recentlyRead] = await Promise.all([
       fetchUser(),
@@ -57,19 +55,17 @@ const syncGoodreadsData = async () => {
     profile,
   }
 
-  console.log(widgetContent)
-
   try {
     await Promise.all([
-      // await db.collection('goodreads').doc('last-response_user-show').set({
-      //   response: jsonResponse,
-      //   fetchedAt: admin.firestore.FieldValue.serverTimestamp(),
-      // }),
-      // await db.collection('goodreads').doc('last-response_book-reviews').set({
-      //   response: reviewsResponse,
-      //   fetchedAt: admin.firestore.FieldValue.serverTimestamp(),
-      // }),
-      // await db.collection('goodreads').doc('widget-content').set(widgetContent),
+      await db.collection('goodreads').doc('last-response_user-show').set({
+        response: jsonResponse,
+        fetchedAt: admin.firestore.FieldValue.serverTimestamp(),
+      }),
+      await db.collection('goodreads').doc('last-response_book-reviews').set({
+        response: reviewsResponse,
+        fetchedAt: admin.firestore.FieldValue.serverTimestamp(),
+      }),
+      await db.collection('goodreads').doc('widget-content').set(widgetContent),
     ])
   } catch (err) {
     logger.error('Failed to save Goodreads data to database.', err)
@@ -81,13 +77,7 @@ const syncGoodreadsData = async () => {
 
   return {
     result: 'SUCCESS',
-    data: {
-      collections: {
-        recentlyReadBooks,
-        updates,
-      },
-      profile,
-    },
+    data: widgetContent
   }
 }
 

--- a/functions/jobs/sync-goodreads-data.js
+++ b/functions/jobs/sync-goodreads-data.js
@@ -36,13 +36,6 @@ const syncGoodreadsData = async () => {
 
   const db = admin
     .firestore()
-    .settings({
-    // Firestore throws when saving documents containing null values and the
-    // Goodreads response object contains null values for unset fields. The
-    // Firestore `ignoreUndefinedProperties` option enables support for fields
-    // with null values.
-    ignoreUndefinedProperties: true,
-  })
 
   const widgetContent = {
     collections: {

--- a/functions/selectors/config.js
+++ b/functions/selectors/config.js
@@ -1,0 +1,12 @@
+const get = require('lodash/get')
+
+/**
+ * Select Google Books API Key
+ *
+ * Selects the Google Books API key from the config.
+ */
+const selectGoogleBooksAPIKey = config => get(config, 'google.books_api_key')
+
+module.exports = {
+  selectGoogleBooksAPIKey
+}


### PR DESCRIPTION
This function tidies up the sync function for the latest books, and also updates the endpoint to explicitly request 12+ books. It seems the API recently changed to return only 10 books.