### PR TITLE
fix: use correct auth header for GitHub API request

### DIFF
--- a/functions/lib/get-github-widget-content.js
+++ b/functions/lib/get-github-widget-content.js
@@ -19,7 +19,9 @@ const getGitHubWidgetContent = async () => {
 
   const { body } = await graphqlGot('https://api.github.com/graphql', {
     query,
-    token: accessToken,
+    headers: {
+      Authorization: `token ${accessToken}`
+    },
     variables: {
       username,
     },

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "personal-metrics",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "description": "Personal metrics. A hobby life-tracking project.",
   "scripts": {
     "deploy": "firebase deploy --only functions",


### PR DESCRIPTION
The GraphQL library I'm using has a helper option for sending auth headers in requests; however, I discovered that the header value doesn't match what GitHub expects when using that option. Here I switch to manually set the Authorization header, which resolves the issue and is verified in prod.