### PR TITLE
feat: update Instagram to support VIDEO and CAROUSEL media

### DIFF
--- a/functions/api/instagram/fetch-instagram-data.js
+++ b/functions/api/instagram/fetch-instagram-data.js
@@ -6,7 +6,7 @@ const defaultFields = [
   'id',
   'username',
   'media_count',
-  'media{caption,id,ig_id,media_type,media_url,permalink,thumbnail_url,timestamp,username}'
+  'media{caption,children{id,media_url,thumbnail_url},id,ig_id,media_type,media_url,permalink,thumbnail_url,timestamp,username}'
 ]
 
 const INSTAGRAM_BASE_URL = 'https://graph.instagram.com'

--- a/functions/api/spotify/get-playlists.js
+++ b/functions/api/spotify/get-playlists.js
@@ -8,7 +8,7 @@ const getPlaylists = async accessToken => {
     responseType: 'json',
     prefixUrl: SPOTIFY_BASE_URL,
     searchParams: {
-      limit: 13,
+      limit: 14,
       offset: 0
     }
   })


### PR DESCRIPTION
This change updates the data synced from Instagram to support children[] items when those are provided, and also adds support for video media.