### PR TITLE
feat: add biography and followersCount to IG request

### DIFF
--- a/functions/CHANGELOG.md
+++ b/functions/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 1.7.0
+
+- Fetches additional fields from the Instagram API: biography, followersCount.
+- Adds additional response information to the Instagram sync API response when no images were uploaded.
+- Adds this changelog.
+
+----
+
+This changelog was started with v1.7.0.

--- a/functions/api/instagram/fetch-instagram-data.js
+++ b/functions/api/instagram/fetch-instagram-data.js
@@ -3,10 +3,12 @@ const got = require('got')
 
 const defaultFields = [
   'account_type',
+  'biography',
+  'followers_count',
   'id',
-  'username',
   'media_count',
-  'media{caption,children{id,media_url,thumbnail_url},id,ig_id,media_type,media_url,permalink,thumbnail_url,timestamp,username}'
+  'media{caption,children{id,media_url,thumbnail_url},id,ig_id,media_type,media_url,permalink,thumbnail_url,timestamp,username}',
+  'username',
 ]
 
 const INSTAGRAM_BASE_URL = 'https://graph.instagram.com'

--- a/functions/jobs/sync-instagram-data.js
+++ b/functions/jobs/sync-instagram-data.js
@@ -103,24 +103,30 @@ const syncInstagramData = async () => {
     validMediaTypes.includes(mediaType)
   )
 
+  const updatedWidgetContent = {
+    media: filteredMedia.map(transformInstagramMedia),
+    meta: {
+      synced: Timestamp.now(),
+    },
+    profile: {
+      biography: instagramResponse.biography,
+      followersCount: instagramResponse.followers_count,
+      mediaCount: instagramResponse.media_count,
+      username: instagramResponse.username,
+    },
+  }
+
   // Save the widget content
   await db
     .collection('instagram')
     .doc('widget-content')
-    .set({
-      media: filteredMedia.map(transformInstagramMedia),
-      meta: {
-        synced: Timestamp.now(),
-      },
-      profile: {
-        username: instagramResponse.username,
-        mediaCount: instagramResponse.media_count,
-      },
-    })
+    .set(updatedWidgetContent)
 
   if (!mediaToDownload.length) {
     return {
+      data: updatedWidgetContent,
       ok: true,
+      result: 'SUCCESS',
       totalUploadedCount: 0,
     }
   }
@@ -146,6 +152,7 @@ const syncInstagramData = async () => {
     result: 'SUCCESS',
     totalUploadedCount: result.length,
     uploadedFiles: result.map(({ fileName }) => fileName),
+    data: updatedWidgetContent,
   }
 }
 

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "personal-metrics",
-  "version": "0.7.1",
+  "version": "0.7.0",
   "description": "Personal metrics API. A hobby project tracking my online metrics.",
   "scripts": {
     "deploy": "firebase deploy --only functions",


### PR DESCRIPTION
This PR adds additional fields to the data fetched from Instagram, which I'll use on the Instagram widget I render on www.chrisvogt.me. It also adds a changelog.