### PR TITLE
fix: update logo url for steam games

### DIFF
--- a/functions/jobs/sync-steam-data.js
+++ b/functions/jobs/sync-steam-data.js
@@ -10,21 +10,22 @@ const { selectSteamAPIKey, selectSteamUserId } = require('../selectors/config')
 
 const { DATABASE_COLLECTION_STEAM } = require('../constants')
 
-const buildImage = (appId, hashId) =>
+const buildIconImageUrl = (appId, hashId) =>
   `http://media.steampowered.com/steamcommunity/public/images/apps/${appId}/${hashId}.jpg`
+
+const buildLogoImageUrl = appId => `https://cdn.cloudflare.steamstatic.com/steam/apps/${appId}/capsule_231x87.jpg`
 
 const transformSteamGame = (game) => {
   const {
     appid: id,
     img_icon_url: iconHash,
-    img_logo_url: logoHash,
     name: displayName,
     playtime_2weeks: playTime2Weeks,
     playtime_forever: playTimeForever,
   } = game
 
-  const iconURL = buildImage(id, iconHash)
-  const logoURL = buildImage(id, logoHash)
+  const iconURL = buildIconImageUrl(id, iconHash)
+  const logoURL = buildLogoImageUrl(id)
 
   return {
     displayName,


### PR DESCRIPTION
The logo for Steam games is currently broken because Steam stopped returning it in their API response. This PR updates that to use a new method of building the logo URL.

<img width="1713" alt="Screenshot 2025-06-01 at 9 56 52 PM" src="https://github.com/user-attachments/assets/61039b09-e108-4284-9455-fdeb1ca466eb" />
