### PR TITLE
feat: break apart Steam images in response

### DIFF
--- a/functions/jobs/sync-steam-data.js
+++ b/functions/jobs/sync-steam-data.js
@@ -10,11 +10,6 @@ const { selectSteamAPIKey, selectSteamUserId } = require('../selectors/config')
 
 const { DATABASE_COLLECTION_STEAM } = require('../constants')
 
-const buildIconImageUrl = (appId, hashId) =>
-  `http://media.steampowered.com/steamcommunity/public/images/apps/${appId}/${hashId}.jpg`
-
-const buildLogoImageUrl = appId => `https://cdn.cloudflare.steamstatic.com/steam/apps/${appId}/capsule_231x87.jpg`
-
 const transformSteamGame = (game) => {
   const {
     appid: id,
@@ -24,14 +19,16 @@ const transformSteamGame = (game) => {
     playtime_forever: playTimeForever,
   } = game
 
-  const iconURL = buildIconImageUrl(id, iconHash)
-  const logoURL = buildLogoImageUrl(id)
-
   return {
     displayName,
-    iconURL,
     id,
-    logoURL,
+    images: {
+      capsuleLarge: `https://cdn.cloudflare.steamstatic.com/steam/apps/${id}/capsule_616x353.jpg`,
+      capsuleSmall: `https://cdn.cloudflare.steamstatic.com/steam/apps/${id}/capsule_231x87.jpg`,
+      icon: iconHash ? `http://media.steampowered.com/steamcommunity/public/images/apps/${id}/${iconHash}.jpg` : '',
+      header: `https://cdn.cloudflare.steamstatic.com/steam/apps/${id}/header.jpg`,
+      heroCapsule: `https://cdn.cloudflare.steamstatic.com/steam/apps/${id}/hero_capsule.jpg`
+    },
     playTime2Weeks,
     playTimeForever,
   }


### PR DESCRIPTION
This pull request refactors the way Steam game image URLs are handled in the `functions/jobs/sync-steam-data.js` file. The changes consolidate image URL generation into a nested `images` object within the `transformSteamGame` function, improving code readability and maintainability.

### Refactoring of Steam game image URLs:

* Removed two helper functions, `buildIconImageUrl` and `buildLogoImageUrl`, which were previously used to construct image URLs.
* Updated the `transformSteamGame` function to include a new `images` object that encapsulates all relevant image URLs (`capsuleLarge`, `capsuleSmall`, `icon`, `header`, and `heroCapsule`) directly within the returned object. This replaces individual `iconURL` and `logoURL` fields.

<img width="1713" alt="Screenshot 2025-06-01 at 10 39 19 PM" src="https://github.com/user-attachments/assets/a5d842b2-635d-4cf2-86eb-fdfe987aaccf" />
