### PR TITLE
chore: appease linter and setup linting workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           node-version: 20
           cache: npm
+          cache-dependency-path: functions/package-lock.json
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Lint Firebase Functions
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: |
+          cd functions
+          npm ci
+
+      - name: Run ESLint
+        run: |
+          cd functions
+          npm run lint

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,9 +1,0 @@
-.cache/
-.DS_Store
-.env
-.gatsby-context.js
-*.log
-coverage
-logs
-node_modules
-public

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,0 @@
-{
-  "jsxSingleQuote": true,
-  "printWidth": 80,
-  "semi": false,
-  "singleQuote": true
-}

--- a/functions/jobs/sync-spotify-data.js
+++ b/functions/jobs/sync-spotify-data.js
@@ -55,7 +55,7 @@ const getMediaToDownloadReducer = (storedMediaFileNames = []) => (acc, playlist)
 }
 
 const transformPlaylists = (playlists) => playlists.map(playlist => {
-  const id = getMediaURLFromPlaylist(playlist)?.replace(SPOTIFY_MOSAIC_BASE_URL, '');
+  const id = getMediaURLFromPlaylist(playlist)?.replace(SPOTIFY_MOSAIC_BASE_URL, '')
   const cdnImageURL = `${IMAGE_CDN_BASE_URL}${CLOUD_STORAGE_SPOTIFY_PLAYLISTS_PATH}${id}.jpg`
   return {
     ...playlist,


### PR DESCRIPTION
This pull request introduces several changes to streamline the CI/CD pipeline, remove outdated configuration files, and refine code formatting and logic. The most notable updates include the addition of a GitHub Actions workflow for linting Firebase Functions, the removal of Prettier configuration files, and a minor adjustment to the `transformPlaylists` function to solve a linter error.

### CI/CD Enhancements:
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR1-R32): Added a GitHub Actions workflow named "CI" to lint Firebase Functions. It runs on `ubuntu-latest`, checks out the code, sets up Node.js (version 20), installs dependencies, and runs ESLint.

### Code Formatting Cleanup:
* [`.prettierignore`](diffhunk://#diff-b640b344ee7f3f03d2a443795a5d0708ef50e2e6e34214109ab2aad13ad6ba98L1-L9): Removed the Prettier ignore file, which previously excluded certain directories and files from formatting checks.
* [`.prettierrc`](diffhunk://#diff-663ade211b3a1552162de21c4031fcd16be99407aae5ceecbb491a2efc43d5d2L1-L6): Deleted the Prettier configuration file, which defined formatting rules such as single quotes and no semicolons.

### Code Logic Adjustment:
* [`functions/jobs/sync-spotify-data.js`](diffhunk://#diff-3ee99a39bbd59809a26861a3d0b3099af5d0b598ba310185b33bd9345e1fd770L58-R58): Updated the `transformPlaylists` function to remove an unnecessary semicolon from the `id` assignment, ensuring consistent formatting.