### PR TITLE
feat: add owned games to Steam widget API response

### DIFF
--- a/functions/CHANGELOG.md
+++ b/functions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.0
+
+- Adds "ownedGame" to the Steam widget API response.
+
 ## 0.8.0
 
 - Fetches additional fields from the Instagram API: biography, followersCount.

--- a/functions/api/steam/get-owned-games.js
+++ b/functions/api/steam/get-owned-games.js
@@ -11,6 +11,7 @@ const getOwnedGames = async (apiKey, userId) => {
     searchParams: {
       key: apiKey,
       steamid: userId,
+      include_appinfo: true
     },
   })
 

--- a/functions/jobs/sync-steam-data.js
+++ b/functions/jobs/sync-steam-data.js
@@ -33,6 +33,7 @@ const transformSteamGame = (game) => {
     playTimeForever,
   }
 }
+
 /**
  * Sync Steam Data
  * 
@@ -87,7 +88,6 @@ const syncSteamData = async () => {
       fetchedAt: Timestamp.now(),
     })
 
-
   const { game_count: ownedGameCount = 0 } = ownedGames
   const {
     avatarfull: avatarURL,
@@ -97,9 +97,11 @@ const syncSteamData = async () => {
 
   const widgetContent = {
     collections: {
-      recentlyPlayedGames: recentlyPlayedGames.map((game) =>
-        transformSteamGame(game)
-      ),
+      ownedGames: ownedGames.games
+        .map(game => transformSteamGame(game))
+        .filter(game => game.playTimeForever >= 100)
+        .sort((a, b) => b.playTimeForever - a.playTimeForever),
+      recentlyPlayedGames: recentlyPlayedGames.map(game => transformSteamGame(game))
     },
     meta: {
       synced: Timestamp.now(),

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "personal-metrics",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Personal metrics API. A hobby project tracking my online metrics.",
   "scripts": {
     "deploy": "firebase deploy --only functions",


### PR DESCRIPTION
This PR adds a new collection of **ownedGames** to the Steam widget API response. These games are sorted by the time spent playing them, and games with <100 minutes are filtered from the results.

<img width="1386" alt="Screenshot 2025-06-18 at 8 42 41 PM" src="https://github.com/user-attachments/assets/ffb18351-cb27-4f49-a687-c234633fc140" />

## AI summary

This pull request introduces enhancements to the Steam widget API, including the addition of owned games data and improvements to how Steam game data is processed and displayed. The changes also update the package version to `0.9.0` to reflect these updates.

### Steam widget API enhancements:
* [`functions/api/steam/get-owned-games.js`](diffhunk://#diff-f4340477ef4e41957ac8b5aacb9b3a9dc434b8060da8b7ab37ba9fe8f457c02aR14): Added the `include_appinfo` parameter to the Steam API request to include additional app information in the response.
* [`functions/jobs/sync-steam-data.js`](diffhunk://#diff-dd635346210f7cb6f7a3cde36d7d4be1afc9f1d2a544cad90d9a8d0a10439198L100-R104): Updated the `syncSteamData` function to include owned games in the widget content. Owned games are filtered to only include games with at least 100 minutes of playtime and are sorted by playtime in descending order.

### Documentation updates:
* [`functions/CHANGELOG.md`](diffhunk://#diff-ebcbc84a33495f87d3a6f7f7555cecceec6e7d61c003c9e31b8c46151783b72cR3-R6): Added a new entry for version `0.9.0`, documenting the addition of "ownedGame" to the Steam widget API response.

### Versioning:
* [`functions/package.json`](diffhunk://#diff-47a4c468f7490979e1df8b5577fd4433613c9c50f054fc38426a0dcddb214436L3-R3): Updated the package version from `0.8.0` to `0.9.0`.