### PR TITLE
feat: enable text compression for API responses

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -4,6 +4,7 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 const admin = require('firebase-admin')
+const compression = require('compression')
 const cors = require('cors')
 const express = require('express')
 const { logger } = require('firebase-functions')
@@ -75,6 +76,9 @@ const buildFailureResponse = (err = {}) => ({
 })
 
 const app = express()
+
+// Enable compression middleware
+app.use(compression())
 
 const corsAllowList = [
   /https?:\/\/([a-z0-9]+[.])*chrisvogt[.]me$/,

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@google-cloud/firestore": "^6.8.0",
         "axios": "^0.21.4",
+        "compression": "^1.8.0",
         "cors": "^2.8.5",
         "express": "^4.18.1",
         "firebase": "^11.0.2",
@@ -1672,6 +1673,60 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.0.tgz",
+      "integrity": "sha512-k6WLKfunuqCYD3t6AsuPGvQWaKwuLLh2/xHNcX4qE+vIfDNXpSqnrhwA7O53R7WVQUnt8dVAIW+YHr7xTgOgGA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.0.2",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/compression/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/concat-map": {
@@ -4211,6 +4266,15 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }

--- a/functions/package.json
+++ b/functions/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@google-cloud/firestore": "^6.8.0",
     "axios": "^0.21.4",
+    "compression": "^1.8.0",
     "cors": "^2.8.5",
     "express": "^4.18.1",
     "firebase": "^11.0.2",


### PR DESCRIPTION
This PR enables [text compression](https://web.dev/articles/optimizing-content-efficiency-optimize-encoding-and-transfer) for my responses from metrics.chrisvogt.me. Google Lighthouse pointed out that I don't currently have that enabled.

<img width="1729" alt="Screenshot 2025-06-19 at 2 42 51 PM" src="https://github.com/user-attachments/assets/bff757ec-c2a2-423f-a876-9fb1a0e5e69e" />

After running this change locally, I can see Brotli being applied in my response headers. ✅ 