### PR TITLE
fix: steam icon protocol — https vs http

### DIFF
--- a/functions/CHANGELOG.md
+++ b/functions/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.1
+
+- Fix Steam icon URL to use https instead of http.
+
 ## 0.9.0
 
 - Adds "ownedGame" to the Steam widget API response.

--- a/functions/jobs/sync-steam-data.js
+++ b/functions/jobs/sync-steam-data.js
@@ -23,7 +23,7 @@ const transformSteamGame = (game) => {
     images: {
       capsuleLarge: `https://cdn.cloudflare.steamstatic.com/steam/apps/${id}/capsule_616x353.jpg`,
       capsuleSmall: `https://cdn.cloudflare.steamstatic.com/steam/apps/${id}/capsule_231x87.jpg`,
-      icon: iconHash ? `http://media.steampowered.com/steamcommunity/public/images/apps/${id}/${iconHash}.jpg` : '',
+      icon: iconHash ? `https://media.steampowered.com/steamcommunity/public/images/apps/${id}/${iconHash}.jpg` : '',
       header: `https://cdn.cloudflare.steamstatic.com/steam/apps/${id}/header.jpg`,
       heroCapsule: `https://cdn.cloudflare.steamstatic.com/steam/apps/${id}/hero_capsule.jpg`
     },

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "personal-metrics",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "personal-metrics",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "dependencies": {
         "@google-cloud/firestore": "^6.8.0",
         "axios": "^0.21.4",

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "personal-metrics",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Personal metrics API. A hobby project tracking my online metrics.",
   "scripts": {
     "deploy": "firebase deploy --only functions",


### PR DESCRIPTION
This PR fixes the Steam icon image URL protocol – using https:// instead of http://.

## AI summary

This pull request updates the project to version `0.9.1` and fixes a bug related to the Steam icon URL. The changes ensure that all Steam icon URLs use `https` instead of `http` and update the version number across relevant files.

Bug fix:

* [`functions/jobs/sync-steam-data.js`](diffhunk://#diff-dd635346210f7cb6f7a3cde36d7d4be1afc9f1d2a544cad90d9a8d0a10439198L26-R26): Updated the Steam icon URL to use `https` for secure connections.

Version update:

* [`functions/CHANGELOG.md`](diffhunk://#diff-ebcbc84a33495f87d3a6f7f7555cecceec6e7d61c003c9e31b8c46151783b72cR3-R6): Added a changelog entry for version `0.9.1`, noting the fix for the Steam icon URL.
* [`functions/package-lock.json`](diffhunk://#diff-4344b694eb816225873849f96a11303de5fb9cf3b95c349bae6f93df89a426bbL3-R9): Updated the project version from `0.9.0` to `0.9.1`.
* [`functions/package.json`](diffhunk://#diff-47a4c468f7490979e1df8b5577fd4433613c9c50f054fc38426a0dcddb214436L3-R3): Updated the project version from `0.9.0` to `0.9.1`.