### PR TITLE
feat: use Goodreads description when available

### DIFF
--- a/functions/jobs/sync-goodreads-data.js
+++ b/functions/jobs/sync-goodreads-data.js
@@ -57,26 +57,26 @@ const syncGoodreadsData = async () => {
     profile,
   }
 
-  // try {
-  //   const db = admin.firestore()
-  //   await Promise.all([
-  //     await db.collection('goodreads').doc('last-response_user-show').set({
-  //       response: responses.user,
-  //       updated: Timestamp.now(),
-  //     }),
-  //     await db.collection('goodreads').doc('last-response_book-reviews').set({
-  //       response: responses.reviews,
-  //       updated: Timestamp.now(),
-  //     }),
-  //     await db.collection('goodreads').doc('widget-content').set(widgetContent),
-  //   ])
-  // } catch (err) {
-  //   logger.error('Failed to save Goodreads data to database.', err)
-  //   return {
-  //     result: 'FAILURE',
-  //     error: err.message || err,
-  //   }
-  // }
+  try {
+    const db = admin.firestore()
+    await Promise.all([
+      await db.collection('goodreads').doc('last-response_user-show').set({
+        response: responses.user,
+        updated: Timestamp.now(),
+      }),
+      await db.collection('goodreads').doc('last-response_book-reviews').set({
+        response: responses.reviews,
+        updated: Timestamp.now(),
+      }),
+      await db.collection('goodreads').doc('widget-content').set(widgetContent),
+    ])
+  } catch (err) {
+    logger.error('Failed to save Goodreads data to database.', err)
+    return {
+      result: 'FAILURE',
+      error: err.message || err,
+    }
+  }
 
   return {
     result: 'SUCCESS',

--- a/functions/jobs/sync-goodreads-data.js
+++ b/functions/jobs/sync-goodreads-data.js
@@ -57,26 +57,26 @@ const syncGoodreadsData = async () => {
     profile,
   }
 
-  try {
-    const db = admin.firestore()
-    await Promise.all([
-      await db.collection('goodreads').doc('last-response_user-show').set({
-        response: responses.user,
-        updated: Timestamp.now(),
-      }),
-      await db.collection('goodreads').doc('last-response_book-reviews').set({
-        response: responses.reviews,
-        updated: Timestamp.now(),
-      }),
-      await db.collection('goodreads').doc('widget-content').set(widgetContent),
-    ])
-  } catch (err) {
-    logger.error('Failed to save Goodreads data to database.', err)
-    return {
-      result: 'FAILURE',
-      error: err.message || err,
-    }
-  }
+  // try {
+  //   const db = admin.firestore()
+  //   await Promise.all([
+  //     await db.collection('goodreads').doc('last-response_user-show').set({
+  //       response: responses.user,
+  //       updated: Timestamp.now(),
+  //     }),
+  //     await db.collection('goodreads').doc('last-response_book-reviews').set({
+  //       response: responses.reviews,
+  //       updated: Timestamp.now(),
+  //     }),
+  //     await db.collection('goodreads').doc('widget-content').set(widgetContent),
+  //   ])
+  // } catch (err) {
+  //   logger.error('Failed to save Goodreads data to database.', err)
+  //   return {
+  //     result: 'FAILURE',
+  //     error: err.message || err,
+  //   }
+  // }
 
   return {
     result: 'SUCCESS',


### PR DESCRIPTION
This PR corresponds with chrisvogt/gatsby-theme-chrisvogt#359. I'm unhappy with the descriptions coming back from the Google Books API. They do not match what's rendered on Google Books, and in the case of _Flowers for Algernon_, I find the description short, crude, and offensive—not something I want rendered on my personal website.

This PR updates the API to use the Goodreads description when that's available, and preserves using the other data from Google Books.