### PR TITLE
bug(firebase): fixes a missing api token client config error

### DIFF
--- a/functions/.env.template
+++ b/functions/.env.template
@@ -6,6 +6,7 @@
 # Firebase Configuration (Client-Side)
 # These are used by the /api/firebase-config endpoint to serve config to the client
 # Set these to match your Firebase project configuration
+# (If left as placeholder, public/firebase-config.js will refuse to init Firebase.)
 CLIENT_API_KEY=your_api_key_here
 CLIENT_AUTH_DOMAIN=your_project_id.firebaseapp.com
 CLIENT_PROJECT_ID=your_project_id

--- a/public/firebase-config.js
+++ b/public/firebase-config.js
@@ -1,27 +1,51 @@
-// Firebase configuration
-// Configuration is loaded dynamically from the backend
-// This prevents hardcoding sensitive values in the client
+/**
+ * Firebase client config loader
+ *
+ * The app needs apiKey, authDomain, and projectId to talk to Firebase Auth.
+ * Instead of hardcoding them here, we fetch them from the backend at runtime.
+ *
+ * The API key in this config is safe to expose to the client: it is a Firebase
+ * Web API key, designed for browser use. Security is enforced by referrer and
+ * API restrictions on the key, not by keeping the key secret.
+ *
+ * Flow:
+ * 1. Call loadFirebaseConfig() (e.g. before initializeApp()).
+ * 2. It requests GET /api/firebase-config, which returns the values from the
+ *    server’s env (CLIENT_API_KEY etc. / auth.client_api_key in production).
+ * 3. If the response looks like a placeholder or is missing, we throw and do
+ *    not init Firebase — so we never send a fake key to Google.
+ *
+ * Placeholder check: We treat the same strings as functions/.env.template
+ * (CLIENT_API_KEY=your_api_key_here) as invalid so that misconfigured or
+ * unset env is caught in the client instead of failing later with auth errors.
+ */
 
 let firebaseConfig = null;
+
+const PLACEHOLDER_API_KEYS = ['your_api_key_here', 'YOUR_API_KEY_HERE'];
+
+function isPlaceholderConfig(config) {
+  return !config?.apiKey || PLACEHOLDER_API_KEYS.includes(config.apiKey);
+}
 
 // Fetch configuration from backend
 async function loadFirebaseConfig() {
   try {
     const response = await fetch('/api/firebase-config');
     if (!response.ok) {
-      throw new Error('Failed to load Firebase config');
+      throw new Error(`Failed to load Firebase config (${response.status})`);
     }
     firebaseConfig = await response.json();
+    if (isPlaceholderConfig(firebaseConfig)) {
+      throw new Error(
+        'Firebase config not configured: API key missing or still set to placeholder. ' +
+        'Check that the backend serves /api/firebase-config and that auth.client_api_key is set in production.'
+      );
+    }
     return firebaseConfig;
   } catch (error) {
     console.error('Error loading Firebase config:', error);
-    // Fallback to placeholder config
-    firebaseConfig = {
-      apiKey: "YOUR_API_KEY_HERE",
-      authDomain: "YOUR_AUTH_DOMAIN_HERE",
-      projectId: "YOUR_PROJECT_ID_HERE"
-    };
-    return firebaseConfig;
+    throw error;
   }
 }
 


### PR DESCRIPTION
## Summary

Harden Firebase client config loading and document auth key behavior so the app never initializes with a placeholder API key and the client key’s exposure is clearly explained.

## Changes

- **`public/firebase-config.js`**
  - No longer falls back to a placeholder when `/api/firebase-config` fails or returns an unset value; throws instead so we never call `initializeApp()` with a fake key.
  - Treats the same placeholder as `functions/.env.template` (`your_api_key_here`) as invalid, and still treats `YOUR_API_KEY_HERE` as invalid for backwards compatibility.
  - Doc block at top: purpose, flow, and note that the Firebase Web API key is intended to be sent to the client and is protected by referrer and API restrictions, not by secrecy.

- **`functions/.env.template`**
  - Comment under `CLIENT_API_KEY` noting that if it’s left as the placeholder, the client will refuse to init Firebase.