### PR TITLE
chore(deps): factors out lodash and unused dependencies

### DIFF
--- a/functions/api/goodreads/fetch-recently-read-books.js
+++ b/functions/api/goodreads/fetch-recently-read-books.js
@@ -1,8 +1,6 @@
 import { parseString } from 'xml2js'
 import convertToHttps from 'to-https'
-import _ from 'lodash'
 import got from 'got'
-import isString from 'lodash.isstring'
 import { logger } from 'firebase-functions'
 import pMap from 'p-map'
 
@@ -76,13 +74,13 @@ export default async () => {
         reject(error)
       }
 
-      const reviewsResponse = _.get(response, 'GoodreadsResponse.reviews[0].review', [])
+      const reviewsResponse = response?.GoodreadsResponse?.reviews?.[0]?.review ?? []
       const transformedReviews = reviewsResponse.reduce((books, book) => {
         const {
           read_at: [date],
         } = book
       
-        if (!isString(date) && date.length > 3) {
+        if (typeof date !== 'string' && date.length > 3) {
           return books
         }
       
@@ -92,20 +90,20 @@ export default async () => {
         } = book
 
         const [firstBook = {}] = Array.isArray(bookData) ? bookData : [bookData]
-        const [goodreadsDescription] = _.get(firstBook, 'description', [])
-        const [isbn10] = _.get(firstBook, 'isbn', [])
-        const [isbn13] = _.get(firstBook, 'isbn13', [])
+        const [goodreadsDescription] = firstBook?.description ?? []
+        const [isbn10] = firstBook?.isbn ?? []
+        const [isbn13] = firstBook?.isbn13 ?? []
         const isbn = isbn13 || isbn10
-        const title = _.get(firstBook, 'title.0')
-        const authorName = _.get(firstBook, 'authors.0.author.0.name.0')
+        const title = firstBook?.title?.[0]
+        const authorName = firstBook?.authors?.[0]?.author?.[0]?.name?.[0]
       
-        if (Array.isArray(books) && isString(isbn)) {
+        if (Array.isArray(books) && typeof isbn === 'string') {
           books.push({
             isbn,
             rating,
             goodreadsDescription,
-            ...(isString(title) && { title }),
-            ...(isString(authorName) && { authorName }),
+            ...(typeof title === 'string' && { title }),
+            ...(typeof authorName === 'string' && { authorName }),
           })
         }
       

--- a/functions/api/goodreads/fetch-user.js
+++ b/functions/api/goodreads/fetch-user.js
@@ -1,5 +1,4 @@
 import { logger } from 'firebase-functions'
-import _ from 'lodash'
 import got from 'got'
 import xml2js from 'xml2js'
 
@@ -25,11 +24,7 @@ const parser = new xml2js.Parser({
 })
 
 const getProfileFromResponse = (result) => {
-  let userShelves = _.get(
-    result,
-    'GoodreadsResponse.user.user_shelves.user_shelf',
-    []
-  )
+  let userShelves = result?.GoodreadsResponse?.user?.user_shelves?.user_shelf ?? []
   // Ensure userShelves is always an array
   if (!Array.isArray(userShelves)) userShelves = []
   const readShelf = userShelves.filter((shelf) => shelf.name === 'read')[0]
@@ -37,7 +32,7 @@ const getProfileFromResponse = (result) => {
   // Handle case where readShelf is undefined
   const bookCount = readShelf?.book_count?._ || ''
   
-  const rawProfile = _.get(result, 'GoodreadsResponse.user', {}) || {}
+  const rawProfile = result?.GoodreadsResponse?.user ?? {}
 
   const {
     name,
@@ -68,7 +63,7 @@ const getProfileFromResponse = (result) => {
 }
 
 const getUpdatesFromResponse = (result) => {
-  const rawUpdates = _.get(result, 'GoodreadsResponse.user.updates.update', [])
+  const rawUpdates = result?.GoodreadsResponse?.user?.updates?.update ?? []
   const isDefined = (subject) => Boolean(subject)
   const validateUpdate = (update) =>
     update && (update.type === 'userstatus' || update.type === 'review')

--- a/functions/api/goodreads/fetch-user.test.js
+++ b/functions/api/goodreads/fetch-user.test.js
@@ -7,10 +7,6 @@ vi.mock('firebase-functions', () => ({
   }
 }))
 
-vi.mock('lodash', () => ({
-  default: { get: vi.fn() }
-}))
-
 vi.mock('got', () => ({
   default: vi.fn()
 }))
@@ -41,7 +37,7 @@ vi.mock('../../lib/get-user-status.js', () => ({
 let fetchUser
 
 describe('fetchUser', () => {
-  let mockGot, mockGet, mockGetReview, mockGetUserStatus, mockLogger
+  let mockGot, mockGetReview, mockGetUserStatus, mockLogger
 
   beforeEach(async () => {
     // Set up environment variables
@@ -56,7 +52,6 @@ describe('fetchUser', () => {
 
     // Get mock functions
     mockGot = (await import('got')).default
-    mockGet = (await import('lodash')).default.get
     mockGetReview = (await import('../../lib/get-review.js')).default
     mockGetUserStatus = (await import('../../lib/get-user-status.js')).default
     mockLogger = (await import('firebase-functions')).logger
@@ -106,12 +101,6 @@ describe('fetchUser', () => {
     mockParseString.mockImplementation((xml, callback) => {
       callback(null, mockJsonResult)
     })
-
-    // Mock lodash.get responses
-    mockGet
-      .mockReturnValueOnce([{ name: 'read', book_count: { _: '50' } }]) // user_shelves
-      .mockReturnValueOnce(mockJsonResult.GoodreadsResponse.user) // user profile
-      .mockReturnValueOnce(mockJsonResult.GoodreadsResponse.user.updates.update) // updates
 
     // Mock helper functions
     mockGetUserStatus.mockReturnValue({ type: 'userstatus', transformed: true })
@@ -209,12 +198,6 @@ describe('fetchUser', () => {
       callback(null, mockJsonResult)
     })
 
-    // Mock lodash.get to return empty array for shelves, and valid user for profile
-    mockGet
-      .mockReturnValueOnce([]) // user_shelves
-      .mockReturnValueOnce(mockJsonResult.GoodreadsResponse.user) // user profile
-      .mockReturnValueOnce([]) // updates
-
     const result = await fetchUser()
 
     expect(result.profile?.readCount ?? 0).toBe(0)
@@ -240,12 +223,6 @@ describe('fetchUser', () => {
       callback(null, mockJsonResult)
     })
 
-    // Mock lodash.get to return array without 'read' shelf, and valid user for profile
-    mockGet
-      .mockReturnValueOnce([{ name: 'to-read', book_count: { _: '25' } }]) // user_shelves
-      .mockReturnValueOnce(mockJsonResult.GoodreadsResponse.user) // user profile
-      .mockReturnValueOnce([]) // updates
-
     const result = await fetchUser()
 
     expect(result.profile?.readCount ?? 0).toBe(0)
@@ -270,11 +247,6 @@ describe('fetchUser', () => {
     mockParseString.mockImplementation((xml, callback) => {
       callback(null, mockJsonResult)
     })
-
-    mockGet
-      .mockReturnValueOnce([{ name: 'read' }]) // user_shelves
-      .mockReturnValueOnce(mockJsonResult.GoodreadsResponse.user) // user profile
-      .mockReturnValueOnce([]) // updates
 
     const result = await fetchUser()
 
@@ -307,11 +279,6 @@ describe('fetchUser', () => {
     mockParseString.mockImplementation((xml, callback) => {
       callback(null, mockJsonResult)
     })
-
-    mockGet
-      .mockReturnValueOnce([{ name: 'read', book_count: { _: '50' } }]) // user_shelves
-      .mockReturnValueOnce(mockJsonResult.GoodreadsResponse.user) // user profile
-      .mockReturnValueOnce(mockJsonResult.GoodreadsResponse.user.updates.update) // updates
 
     // Mock helper functions - return null for invalid type
     mockGetUserStatus.mockReturnValue({ type: 'userstatus', transformed: true })
@@ -346,11 +313,6 @@ describe('fetchUser', () => {
     mockParseString.mockImplementation((xml, callback) => {
       callback(null, mockJsonResult)
     })
-
-    mockGet
-      .mockReturnValueOnce([{ name: 'read', book_count: { _: '50' } }]) // user_shelves
-      .mockReturnValueOnce(mockJsonResult.GoodreadsResponse.user) // user profile
-      .mockReturnValueOnce([mockJsonResult.GoodreadsResponse.user.updates.update]) // updates as array
 
     mockGetUserStatus.mockReturnValue({ type: 'userstatus', transformed: true })
 

--- a/functions/package.json
+++ b/functions/package.json
@@ -30,12 +30,9 @@
     "firebase-functions": "^7.0.5",
     "got": "^14.6.6",
     "graphql-got": "^0.1.2",
-    "lodash": "^4.17.23",
-    "lodash.isstring": "^4.0.1",
     "moment": "^2.30.1",
     "p-all": "^5.0.1",
     "p-map": "^7.0.4",
-    "q-i": "^2.0.1",
     "requestretry": "^8.0.0",
     "to-https": "^2.0.0",
     "xml2js": "^0.6.2"

--- a/functions/selectors/config.js
+++ b/functions/selectors/config.js
@@ -1,58 +1,56 @@
-import _ from 'lodash'
-
 /**
  * Select the Google Books API Key.
  */
-const selectGoogleBooksAPIKey = config => _.get(config, 'google.books_api_key')
+const selectGoogleBooksAPIKey = config => config?.google?.books_api_key
 
 /**
  * Select the Spotify Client ID.
  * @see {@link https://developer.spotify.com/documentation/general/guides/authorization-guide/}
- * @param {object} config The current app configuration. 
+ * @param {object} config The current app configuration.
  * @returns {string} The Spotify Client ID associated with your application.
  */
-const selectSpotifyClientId = config => _.get(config, 'spotify.client_id')
+const selectSpotifyClientId = config => config?.spotify?.client_id
 
 /**
  * Select the Spotify client secret.
  * @see {@link https://developer.spotify.com/documentation/general/guides/authorization-guide/}
- * @param {object} config The current app configuration. 
+ * @param {object} config The current app configuration.
  * @returns {string} The Spotify Client Secret associated with your application.
  */
-const selectSpotifyClientSecret = config => _.get(config, 'spotify.client_secret')
+const selectSpotifyClientSecret = config => config?.spotify?.client_secret
 
 /**
  * Select the Spotify redirect URI.
  * @see {@link https://developer.spotify.com/documentation/general/guides/authorization-guide/}
- * @param {object} config The current app configuration. 
+ * @param {object} config The current app configuration.
  * @returns {string} Must match value set in your Spotify developer dashboard.
  */
-const selectSpotifyRedirectURI = config => _.get(config, 'spotify.redirect_uri')
+const selectSpotifyRedirectURI = config => config?.spotify?.redirect_uri
 
 /**
  * Select the Spotify refresh token.
  * @see {@link https://developer.spotify.com/documentation/general/guides/authorization-guide/}
- * @param {object} config The current app configuration. 
+ * @param {object} config The current app configuration.
  * @returns {string} The latest Spotify Refresh Token. Used in place of an auth code.
  */
-const selectSpotifyRefreshToken = config => _.get(config, 'spotify.refresh_token')
+const selectSpotifyRefreshToken = config => config?.spotify?.refresh_token
 
 /**
  * Select the Steam API key.
  * @see {@link https://partner.steamgames.com/doc/webapi_overview/auth#user-keys}
  * @see {@link https://steamcommunity.com/dev/apikey}
- * @param {object} config The current app configuration. 
+ * @param {object} config The current app configuration.
  * @returns {string} The Steam API key.
  */
-const selectSteamAPIKey = config => _.get(config, 'steam.api_key')
+const selectSteamAPIKey = config => config?.steam?.api_key
 
 /**
  * Select the Steam user identifier.
  * @see {@link https://developer.valvesoftware.com/wiki/Steam_Web_API}
- * @param {object} config The current app configuration. 
+ * @param {object} config The current app configuration.
  * @returns {string} The Steam user id. This numeric value is not the custom username.
  */
-const selectSteamUserId = config => _.get(config, 'steam.user_id')
+const selectSteamUserId = config => config?.steam?.user_id
 
 export {
   selectGoogleBooksAPIKey,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,12 +50,6 @@ importers:
       graphql-got:
         specifier: ^0.1.2
         version: 0.1.2
-      lodash:
-        specifier: ^4.17.23
-        version: 4.17.23
-      lodash.isstring:
-        specifier: ^4.0.1
-        version: 4.0.1
       moment:
         specifier: ^2.30.1
         version: 2.30.1
@@ -65,9 +59,6 @@ importers:
       p-map:
         specifier: ^7.0.4
         version: 7.0.4
-      q-i:
-        specifier: ^2.0.1
-        version: 2.0.1
       requestretry:
         specifier: ^8.0.0
         version: 8.0.0(postman-request@2.88.1-postman.48)
@@ -1456,10 +1447,6 @@ packages:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
 
-  ansi-styles@3.2.1:
-    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
-    engines: {node: '>=4'}
-
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -1678,15 +1665,9 @@ packages:
   collect-v8-coverage@1.0.3:
     resolution: {integrity: sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==}
 
-  color-convert@1.9.3:
-    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
-
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
-
-  color-name@1.1.3:
-    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
@@ -2197,9 +2178,6 @@ packages:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
 
-  get-own-enumerable-property-symbols@3.0.2:
-    resolution: {integrity: sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==}
-
   get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
     engines: {node: '>=8.0.0'}
@@ -2419,10 +2397,6 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
-  is-obj@1.0.1:
-    resolution: {integrity: sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==}
-    engines: {node: '>=0.10.0'}
-
   is-object@1.0.2:
     resolution: {integrity: sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==}
 
@@ -2430,16 +2404,8 @@ packages:
     resolution: {integrity: sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==}
     engines: {node: '>=0.10.0'}
 
-  is-plain-object@2.0.4:
-    resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
-    engines: {node: '>=0.10.0'}
-
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
-
-  is-regexp@1.0.0:
-    resolution: {integrity: sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==}
-    engines: {node: '>=0.10.0'}
 
   is-retry-allowed@1.2.0:
     resolution: {integrity: sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==}
@@ -2462,10 +2428,6 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
-  isobject@3.0.1:
-    resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
-    engines: {node: '>=0.10.0'}
 
   isstream@0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
@@ -3144,10 +3106,6 @@ packages:
   pure-rand@7.0.1:
     resolution: {integrity: sha512-oTUZM/NAZS8p7ANR3SHh30kXB+zK2r2BPcEn/awJIbOvq82WoMN4p62AWWp3Hhw50G0xMsw1mhIBLqHw64EcNQ==}
 
-  q-i@2.0.1:
-    resolution: {integrity: sha512-tr7CzPNxkBDBuPzqi/HDUS4uBOppb91akNTeh56TYio8TiIeXp2Yp8ea9NmDu2DmGH35ZjJDq6C3E4SepVZ4bQ==}
-    engines: {node: '>=4'}
-
   qs@6.14.2:
     resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
     engines: {node: '>=0.6'}
@@ -3414,10 +3372,6 @@ packages:
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
-
-  stringify-object@3.3.0:
-    resolution: {integrity: sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==}
-    engines: {node: '>=4'}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -5017,7 +4971,7 @@ snapshots:
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 2.1.0
-      '@types/node': 22.19.11
+      '@types/node': 25.2.3
 
   '@types/keyv@3.1.4':
     dependencies:
@@ -5047,7 +5001,7 @@ snapshots:
   '@types/request@2.48.13':
     dependencies:
       '@types/caseless': 0.12.5
-      '@types/node': 22.19.11
+      '@types/node': 25.2.3
       '@types/tough-cookie': 4.0.5
       form-data: 2.5.5
     optional: true
@@ -5256,10 +5210,6 @@ snapshots:
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
-
-  ansi-styles@3.2.1:
-    dependencies:
-      color-convert: 1.9.3
 
   ansi-styles@4.3.0:
     dependencies:
@@ -5513,15 +5463,9 @@ snapshots:
 
   collect-v8-coverage@1.0.3: {}
 
-  color-convert@1.9.3:
-    dependencies:
-      color-name: 1.1.3
-
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
-
-  color-name@1.1.3: {}
 
   color-name@1.1.4: {}
 
@@ -6166,8 +6110,6 @@ snapshots:
       hasown: 2.0.2
       math-intrinsics: 1.1.0
 
-  get-own-enumerable-property-symbols@3.0.2: {}
-
   get-package-type@0.1.0: {}
 
   get-proto@1.0.1:
@@ -6450,19 +6392,11 @@ snapshots:
 
   is-number@7.0.0: {}
 
-  is-obj@1.0.1: {}
-
   is-object@1.0.2: {}
 
   is-plain-obj@1.1.0: {}
 
-  is-plain-object@2.0.4:
-    dependencies:
-      isobject: 3.0.1
-
   is-promise@4.0.0: {}
-
-  is-regexp@1.0.0: {}
 
   is-retry-allowed@1.2.0: {}
 
@@ -6475,8 +6409,6 @@ snapshots:
   is-typedarray@1.0.0: {}
 
   isexe@2.0.0: {}
-
-  isobject@3.0.1: {}
 
   isstream@0.1.2: {}
 
@@ -7290,12 +7222,6 @@ snapshots:
 
   pure-rand@7.0.1: {}
 
-  q-i@2.0.1:
-    dependencies:
-      ansi-styles: 3.2.1
-      is-plain-object: 2.0.4
-      stringify-object: 3.3.0
-
   qs@6.14.2:
     dependencies:
       side-channel: 1.1.0
@@ -7630,12 +7556,6 @@ snapshots:
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
-
-  stringify-object@3.3.0:
-    dependencies:
-      get-own-enumerable-property-symbols: 3.0.2
-      is-obj: 1.0.1
-      is-regexp: 1.0.0
 
   strip-ansi@6.0.1:
     dependencies:


### PR DESCRIPTION
# PR review: Remove lodash / lodash.isstring / q-i, use optional chaining

## Scope of the diff

- **functions/api/goodreads/fetch-recently-read-books.js** – remove lodash + lodash.isstring, use optional chaining + `typeof x === 'string'`
- **functions/api/goodreads/fetch-user.js** – remove lodash, use optional chaining + `??`
- **functions/api/goodreads/fetch-user.test.js** – remove lodash mock and all `mockGet` usage
- **functions/package.json** – remove `lodash`, `lodash.isstring`, `q-i`
- **functions/selectors/config.js** – remove lodash, use optional chaining
- **pnpm-lock.yaml** – q-i and its dependency tree removed (ansi-styles, stringify-object, etc.)

---

## ✅ Correctness audit

### 1. No leftover references

- Grep for `lodash`, `_.get`, `getByPath`, `isString`, `lodash.isstring` in `functions/**/*.js`: **no matches.** All usages were updated.

### 2. Behavior parity: optional chaining vs `_.get`

- **`_.get(obj, 'a.b.c', default)`** returns `default` when any segment is `null` or `undefined`.
- **`obj?.a?.b?.c ?? default`** short-circuits on `null`/`undefined` and returns `default` when the final value is `null`/`undefined`.
- For the paths used (Goodreads XML, config), missing or null intermediates yield `undefined`, and `?? []` / `?? {}` matches the previous default. **No intentional behavior change.**

### 3. Selectors (config.js)

- **Before:** `_.get(config, 'google.books_api_key')` → `undefined` when `config` is null/undefined or path is missing.
- **After:** `config?.google?.books_api_key` → same.
- **Tests:** `selectors/config.test.js` still expects `undefined` for `null`, `undefined`, and missing keys; no test changes were needed and behavior is unchanged.

### 4. fetch-user.js

- **userShelves:** `result?.GoodreadsResponse?.user?.user_shelves?.user_shelf ?? []` – same as `_.get(..., [])` for missing path. Existing `if (!Array.isArray(userShelves)) userShelves = []` still normalizes xml2js single-object case.
- **rawProfile:** `result?.GoodreadsResponse?.user ?? {}` – same as `_.get(..., {}) || {}` for null/undefined user. Edge case: if `user` were `0` or `false`, old code would have used `{}` (because of `|| {}`); new code would keep `0`/`false`. Goodreads never returns that; acceptable.
- **rawUpdates:** `result?.GoodreadsResponse?.user?.updates?.update ?? []` – same as `_.get(..., [])`.

### 5. fetch-recently-read-books.js

- **reviewsResponse:** `response?.GoodreadsResponse?.reviews?.[0]?.review ?? []` – equivalent to `_.get(response, 'GoodreadsResponse.reviews[0].review', [])`.
- **firstBook fields:** `firstBook?.description ?? []`, `firstBook?.title?.[0]`, `firstBook?.authors?.[0]?.author?.[0]?.name?.[0]` – same as previous `_.get(firstBook, …)` usage. Destructuring `const [x] = firstBook?.description ?? []` is safe; if xml2js returns a single string, `?? []` would not run (value exists), and `[x] = "string"` would give first character – same as with `_.get` returning that string.
- **isString:** `typeof date !== 'string'` and `typeof isbn === 'string'` etc. match `lodash.isstring` (which is `typeof x === 'string'`).

### 6. fetch-user tests

- **Before:** Lodash was mocked; `mockGet.mockReturnValueOnce(...)` controlled each path’s return value.
- **After:** No lodash; code uses real optional chaining on `mockJsonResult` from `mockParseString`. Each test’s `mockJsonResult` already has the right shape (`GoodreadsResponse.user.user_shelves.user_shelf`, etc.), so the real code reads the same data. **Tests still pass (46 files, 442 passed).**

---

## Lockfile

- **functions** importer in `pnpm-lock.yaml` no longer lists `lodash` or `lodash.isstring`; it is in sync with `functions/package.json`.
- Any remaining `lodash` in the lockfile is from **transitive** dependencies (e.g. `firebase-functions`), not from the functions package. That is expected.
- If CI uses `pnpm install --frozen-lockfile`, ensure the committed lockfile was generated after removing lodash from package.json (otherwise run `pnpm install` once and commit the updated lockfile).

---

## Summary

| Item | Status |
|------|--------|
| All lodash / lodash.isstring / getByPath usages removed or replaced | ✅ |
| Optional chaining matches previous _.get behavior for these paths | ✅ |
| Selectors tests still pass; no behavior change | ✅ |
| fetch-user tests pass without lodash mock | ✅ |
| Full test suite (46 files, 442 tests) passes | ✅ |
| q-i removed (was unused) | ✅ |
| Lockfile: functions no longer depend on lodash; sync if CI fails | ✅ (verify on your branch) |

**Verdict:** Safe to merge after running `pnpm install` and committing the updated lockfile. No missing call sites and no intentional behavior changes; one optional follow-up is to add a quick test that exercises the Goodreads path with a minimal `mockJsonResult` (e.g. empty user_shelves) to lock in the optional-chaining behavior, but existing tests already cover the real flow.
