### PR TITLE
feat: extracts backend config boundary

### DIFF
--- a/functions/api/discogs/fetch-release-details.ts
+++ b/functions/api/discogs/fetch-release-details.ts
@@ -1,4 +1,5 @@
 import { logger } from 'firebase-functions'
+import { getDiscogsConfig } from '../../config/backend-config.js'
 
 /**
  * Fetches detailed release resource data from Discogs API with retry logic
@@ -8,7 +9,7 @@ import { logger } from 'firebase-functions'
  * @returns {Promise<Object|null>} The detailed release resource data or null if failed
  */
 const fetchReleaseDetails = async (resourceUrl, releaseId, maxRetries = 3) => {
-  const apiKey = process.env.DISCOGS_API_KEY
+  const { apiKey } = getDiscogsConfig()
 
   if (!apiKey) {
     throw new Error('Missing required environment variable: DISCOGS_API_KEY')

--- a/functions/api/discogs/fetch-releases.ts
+++ b/functions/api/discogs/fetch-releases.ts
@@ -1,9 +1,8 @@
 import { logger } from 'firebase-functions'
-// Removed import { DISCOGS_USERNAME } from '../../constants.js'
+import { getDiscogsConfig } from '../../config/backend-config.js'
 
 const fetchDiscogsReleases = async () => {
-  const apiKey = process.env.DISCOGS_API_KEY
-  const username = process.env.DISCOGS_USERNAME // Read directly from env
+  const { apiKey, username } = getDiscogsConfig()
 
   if (!apiKey || !username) {
     throw new Error('Missing required environment variables: DISCOGS_API_KEY or DISCOGS_USERNAME')

--- a/functions/api/flickr/fetch-photos.ts
+++ b/functions/api/flickr/fetch-photos.ts
@@ -1,6 +1,8 @@
 import { logger } from 'firebase-functions'
 import got from 'got'
 
+import { getFlickrConfig } from '../../config/backend-config.js'
+
 const FLICKR_API_BASE_URL = 'https://www.flickr.com/services/rest'
 
 /**
@@ -8,8 +10,7 @@ const FLICKR_API_BASE_URL = 'https://www.flickr.com/services/rest'
  * @see {@link https://www.flickr.com/services/api/flickr.people.getPhotos.html}
  */
 const fetchPhotos = async () => {
-  const apiKey = process.env.FLICKR_API_KEY
-  const userId = process.env.FLICKR_USER_ID
+  const { apiKey, userId } = getFlickrConfig()
 
   if (!apiKey || !userId) {
     throw new Error('Missing required Flickr configuration (FLICKR_API_KEY or FLICKR_USER_ID)')

--- a/functions/api/gemini/generate-steam-summary.ts
+++ b/functions/api/gemini/generate-steam-summary.ts
@@ -1,5 +1,7 @@
 import { GoogleGenerativeAI } from '@google/generative-ai'
 import { logger } from 'firebase-functions'
+
+import { getGeminiApiKey } from '../../config/backend-config.js'
 import extractJsonFromGeminiResponse from '../../utils/extract-json-from-gemini-response.js'
 
 /**
@@ -8,7 +10,7 @@ import extractJsonFromGeminiResponse from '../../utils/extract-json-from-gemini-
  * @returns {Promise<string>} - The AI-generated summary
  */
 const generateSteamSummary = async (steamData) => {
-  const apiKey = process.env.GEMINI_API_KEY
+  const apiKey = getGeminiApiKey()
 
   if (!apiKey) {
     throw new Error('GEMINI_API_KEY environment variable is required')

--- a/functions/api/goodreads/fetch-recently-read-books.ts
+++ b/functions/api/goodreads/fetch-recently-read-books.ts
@@ -8,6 +8,10 @@ import fetchAndUploadFile from '../cloud-storage/fetch-and-upload-file.js'
 import fetchBookFromGoogle from '../google-books/fetch-book.js'
 import listStoredMedia from '../cloud-storage/list-stored-media.js'
 import { getMediaStore } from '../../selectors/media-store.js'
+import {
+  getGoodreadsConfig,
+  getGoogleBooksApiKey,
+} from '../../config/backend-config.js'
 
 import {
   IMAGE_CDN_BASE_URL
@@ -59,8 +63,7 @@ const transformBookData = (book) => {
 
 export default async () => {
   const mediaStore = getMediaStore()
-  const key = process.env.GOODREADS_API_KEY
-  const userID = process.env.GOODREADS_USER_ID
+  const { apiKey: key, userId: userID } = getGoodreadsConfig()
 
   const { body } = await got(
     `https://www.goodreads.com/review/list/${userID}.xml?key=${key}&v=2&shelf=read&sort=date_read&per_page=100`
@@ -142,7 +145,7 @@ export default async () => {
         const maxRetries = 3
         for (let attempt = 1; attempt <= maxRetries; attempt++) {
           try {
-            const googleBooksAPIKey = process.env.GOOGLE_BOOKS_API_KEY
+            const googleBooksAPIKey = getGoogleBooksApiKey()
             const { body } = await got('https://www.googleapis.com/books/v1/volumes', {
               searchParams: {
                 q: searchQuery,

--- a/functions/api/goodreads/fetch-user.ts
+++ b/functions/api/goodreads/fetch-user.ts
@@ -4,6 +4,7 @@ import xml2js from 'xml2js'
 
 import getReview from '../../helpers/get-review.js'
 import getUserStatus from '../../helpers/get-user-status.js'
+import { getGoodreadsConfig } from '../../config/backend-config.js'
 
 const transformUpdate = (update) => {
   if (update.type === 'userstatus') {
@@ -82,8 +83,7 @@ const getUpdatesFromResponse = (result) => {
 }
 
 const fetchUser = async () => {
-  const key = process.env.GOODREADS_API_KEY
-  const userID = process.env.GOODREADS_USER_ID
+  const { apiKey: key, userId: userID } = getGoodreadsConfig()
   const goodreadsURL = `https://www.goodreads.com/user/show/${userID}?format=xml&key=${key}`
 
   const response = await got(goodreadsURL)

--- a/functions/api/goodreads/generate-goodreads-summary.ts
+++ b/functions/api/goodreads/generate-goodreads-summary.ts
@@ -1,5 +1,7 @@
 import { GoogleGenerativeAI } from '@google/generative-ai'
 import { logger } from 'firebase-functions'
+
+import { getGeminiApiKey } from '../../config/backend-config.js'
 import extractJsonFromGeminiResponse from '../../utils/extract-json-from-gemini-response.js'
 
 /**
@@ -8,7 +10,7 @@ import extractJsonFromGeminiResponse from '../../utils/extract-json-from-gemini-
  * @returns {Promise<string>} - The AI-generated summary
  */
 const generateGoodreadsSummary = async (goodreadsData) => {
-  const apiKey = process.env.GEMINI_API_KEY
+  const apiKey = getGeminiApiKey()
 
   if (!apiKey) {
     throw new Error('GEMINI_API_KEY environment variable is required')

--- a/functions/api/google-books/fetch-book.ts
+++ b/functions/api/google-books/fetch-book.ts
@@ -1,10 +1,11 @@
 import { logger } from 'firebase-functions'
 import got from 'got'
 
-const googleBooksAPIKey = process.env.GOOGLE_BOOKS_API_KEY
+import { getGoogleBooksApiKey } from '../../config/backend-config.js'
 
 const fetchBook = async (book, maxRetries = 3) => {
   const { isbn, rating } = book
+  const googleBooksAPIKey = getGoogleBooksApiKey()
 
   if (!isbn) {
     throw new Error(`ISBN number required to search Google Books. You passed: ${isbn}`)

--- a/functions/api/instagram/fetch-instagram-data.ts
+++ b/functions/api/instagram/fetch-instagram-data.ts
@@ -1,5 +1,7 @@
 import got from 'got'
 
+import { getInstagramAccessToken } from '../../config/backend-config.js'
+
 const defaultFields = [
   'account_type',
   'biography',
@@ -13,7 +15,7 @@ const defaultFields = [
 const INSTAGRAM_BASE_URL = 'https://graph.instagram.com'
 
 const fetchInstagramMedia = async () => {
-  const accessToken = process.env.INSTAGRAM_ACCESS_TOKEN
+  const accessToken = getInstagramAccessToken()
 
   const { body } = await got('me', {
     responseType: 'json',

--- a/functions/config/backend-config.test.ts
+++ b/functions/config/backend-config.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('backend config', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    delete process.env.NODE_ENV
+    delete process.env.__FUNCTIONS_CONFIG_APPLIED__
+    delete process.env.CLIENT_API_KEY
+    delete process.env.CLIENT_AUTH_DOMAIN
+    delete process.env.CLIENT_PROJECT_ID
+    delete process.env.CLOUD_STORAGE_IMAGES_BUCKET
+    delete process.env.MEDIA_STORE_BACKEND
+    delete process.env.LOCAL_MEDIA_ROOT
+    delete process.env.IMAGE_CDN_BASE_URL
+    delete process.env.DISCOGS_API_KEY
+    delete process.env.DISCOGS_USERNAME
+    delete process.env.FLICKR_API_KEY
+    delete process.env.FLICKR_USER_ID
+    delete process.env.GITHUB_ACCESS_TOKEN
+    delete process.env.GITHUB_USERNAME
+    delete process.env.GOODREADS_API_KEY
+    delete process.env.GOODREADS_USER_ID
+    delete process.env.GOOGLE_BOOKS_API_KEY
+    delete process.env.GEMINI_API_KEY
+    delete process.env.INSTAGRAM_ACCESS_TOKEN
+    delete process.env.SPOTIFY_CLIENT_ID
+    delete process.env.SPOTIFY_CLIENT_SECRET
+    delete process.env.SPOTIFY_REDIRECT_URI
+    delete process.env.SPOTIFY_REFRESH_TOKEN
+    delete process.env.STEAM_API_KEY
+    delete process.env.STEAM_USER_ID
+  })
+
+  it('detects production mode from NODE_ENV', async () => {
+    process.env.NODE_ENV = 'production'
+    const { isProductionEnvironment } = await import('./backend-config.js')
+
+    expect(isProductionEnvironment()).toBe(true)
+  })
+
+  it('loads local dotenv only outside production', async () => {
+    const dotenvConfig = vi.fn()
+    vi.doMock('dotenv', () => ({ config: dotenvConfig }))
+
+    const { loadLocalDevelopmentEnv } = await import('./backend-config.js')
+    loadLocalDevelopmentEnv('/tmp/test.env')
+
+    expect(dotenvConfig).toHaveBeenCalledWith({ path: '/tmp/test.env' })
+  })
+
+  it('skips local dotenv loading in production', async () => {
+    process.env.NODE_ENV = 'production'
+    const dotenvConfig = vi.fn()
+    vi.doMock('dotenv', () => ({ config: dotenvConfig }))
+
+    const { loadLocalDevelopmentEnv } = await import('./backend-config.js')
+    loadLocalDevelopmentEnv('/tmp/test.env')
+
+    expect(dotenvConfig).not.toHaveBeenCalled()
+  })
+
+  it('tracks whether runtime config was already applied', async () => {
+    const {
+      hasAppliedRuntimeConfig,
+      markRuntimeConfigApplied,
+    } = await import('./backend-config.js')
+
+    expect(hasAppliedRuntimeConfig()).toBe(false)
+    markRuntimeConfigApplied()
+    expect(hasAppliedRuntimeConfig()).toBe(true)
+  })
+
+  it('returns normalized firebase client config values', async () => {
+    process.env.CLIENT_API_KEY = 'api-key'
+    process.env.CLIENT_AUTH_DOMAIN = 'project.firebaseapp.com'
+    process.env.CLIENT_PROJECT_ID = 'project-id'
+
+    const { getFirebaseClientConfig } = await import('./backend-config.js')
+
+    expect(getFirebaseClientConfig()).toEqual({
+      apiKey: 'api-key',
+      authDomain: 'project.firebaseapp.com',
+      projectId: 'project-id',
+    })
+  })
+
+  it('returns normalized provider config values from env', async () => {
+    process.env.DISCOGS_API_KEY = 'discogs-key'
+    process.env.DISCOGS_USERNAME = 'discogs-user'
+    process.env.FLICKR_API_KEY = 'flickr-key'
+    process.env.FLICKR_USER_ID = 'flickr-user'
+    process.env.GITHUB_ACCESS_TOKEN = 'github-token'
+    process.env.GITHUB_USERNAME = 'github-user'
+    process.env.GOODREADS_API_KEY = 'goodreads-key'
+    process.env.GOODREADS_USER_ID = 'goodreads-user'
+    process.env.GOOGLE_BOOKS_API_KEY = 'google-key'
+    process.env.GEMINI_API_KEY = 'gemini-key'
+    process.env.INSTAGRAM_ACCESS_TOKEN = 'ig-token'
+    process.env.SPOTIFY_CLIENT_ID = 'spotify-id'
+    process.env.SPOTIFY_CLIENT_SECRET = 'spotify-secret'
+    process.env.SPOTIFY_REDIRECT_URI = 'https://example.com/callback'
+    process.env.SPOTIFY_REFRESH_TOKEN = 'spotify-refresh'
+    process.env.STEAM_API_KEY = 'steam-key'
+    process.env.STEAM_USER_ID = 'steam-user'
+
+    const {
+      getDiscogsConfig,
+      getFlickrConfig,
+      getGeminiApiKey,
+      getGitHubConfig,
+      getGoodreadsConfig,
+      getGoogleBooksApiKey,
+      getInstagramAccessToken,
+      getSpotifyConfig,
+      getSteamConfig,
+    } = await import('./backend-config.js')
+
+    expect(getDiscogsConfig()).toEqual({ apiKey: 'discogs-key', username: 'discogs-user' })
+    expect(getFlickrConfig()).toEqual({ apiKey: 'flickr-key', userId: 'flickr-user' })
+    expect(getGitHubConfig()).toEqual({ accessToken: 'github-token', username: 'github-user' })
+    expect(getGoodreadsConfig()).toEqual({ apiKey: 'goodreads-key', userId: 'goodreads-user' })
+    expect(getGoogleBooksApiKey()).toBe('google-key')
+    expect(getGeminiApiKey()).toBe('gemini-key')
+    expect(getInstagramAccessToken()).toBe('ig-token')
+    expect(getSpotifyConfig()).toEqual({
+      clientId: 'spotify-id',
+      clientSecret: 'spotify-secret',
+      redirectUri: 'https://example.com/callback',
+      refreshToken: 'spotify-refresh',
+    })
+    expect(getSteamConfig()).toEqual({ apiKey: 'steam-key', userId: 'steam-user' })
+  })
+
+  it('returns normalized storage config with development defaults', async () => {
+    process.env.NODE_ENV = 'development'
+    process.env.IMAGE_CDN_BASE_URL = '/api/media/'
+
+    const { getStorageConfig } = await import('./backend-config.js')
+    const storageConfig = getStorageConfig()
+
+    expect(storageConfig.mediaStoreBackend).toBe('disk')
+    expect(storageConfig.imageCdnBaseUrl).toBe('/api/media/')
+    expect(storageConfig.localMediaRoot.endsWith('tmp/media')).toBe(true)
+  })
+
+  it('returns normalized storage config with explicit overrides', async () => {
+    process.env.NODE_ENV = 'production'
+    process.env.CLOUD_STORAGE_IMAGES_BUCKET = 'bucket-name'
+    process.env.MEDIA_STORE_BACKEND = 'disk'
+    process.env.LOCAL_MEDIA_ROOT = '/tmp/media-root'
+
+    const { getStorageConfig } = await import('./backend-config.js')
+
+    expect(getStorageConfig()).toEqual({
+      cloudStorageImagesBucket: 'bucket-name',
+      imageCdnBaseUrl: undefined,
+      localMediaRoot: '/tmp/media-root',
+      mediaStoreBackend: 'disk',
+    })
+  })
+})

--- a/functions/config/backend-config.ts
+++ b/functions/config/backend-config.ts
@@ -1,0 +1,73 @@
+import * as dotenv from 'dotenv'
+import path from 'path'
+
+const FUNCTIONS_CONFIG_APPLIED_ENV = '__FUNCTIONS_CONFIG_APPLIED__'
+
+export const isProductionEnvironment = () => process.env.NODE_ENV === 'production'
+
+export const loadLocalDevelopmentEnv = (envPath: string): void => {
+  if (isProductionEnvironment()) {
+    return
+  }
+
+  dotenv.config({ path: envPath })
+}
+
+export const hasAppliedRuntimeConfig = (): boolean =>
+  Boolean(process.env[FUNCTIONS_CONFIG_APPLIED_ENV])
+
+export const markRuntimeConfigApplied = (): void => {
+  process.env[FUNCTIONS_CONFIG_APPLIED_ENV] = '1'
+}
+
+export const getFirebaseClientConfig = () => ({
+  apiKey: process.env.CLIENT_API_KEY,
+  authDomain: process.env.CLIENT_AUTH_DOMAIN,
+  projectId: process.env.CLIENT_PROJECT_ID,
+})
+
+export const getStorageConfig = () => ({
+  cloudStorageImagesBucket: process.env.CLOUD_STORAGE_IMAGES_BUCKET,
+  imageCdnBaseUrl: process.env.IMAGE_CDN_BASE_URL,
+  localMediaRoot: process.env.LOCAL_MEDIA_ROOT ?? path.resolve(process.cwd(), 'tmp/media'),
+  mediaStoreBackend: process.env.MEDIA_STORE_BACKEND ?? (isProductionEnvironment() ? 'gcs' : 'disk'),
+})
+
+export const getDiscogsConfig = () => ({
+  apiKey: process.env.DISCOGS_API_KEY,
+  username: process.env.DISCOGS_USERNAME,
+})
+
+export const getFlickrConfig = () => ({
+  apiKey: process.env.FLICKR_API_KEY,
+  userId: process.env.FLICKR_USER_ID,
+})
+
+export const getGitHubConfig = () => ({
+  accessToken: process.env.GITHUB_ACCESS_TOKEN,
+  username: process.env.GITHUB_USERNAME,
+})
+
+export const getGoodreadsConfig = () => ({
+  apiKey: process.env.GOODREADS_API_KEY,
+  userId: process.env.GOODREADS_USER_ID,
+})
+
+export const getGoogleBooksApiKey = (): string | undefined => process.env.GOOGLE_BOOKS_API_KEY
+
+export const getGeminiApiKey = (): string | undefined => process.env.GEMINI_API_KEY
+
+export const getInstagramAccessToken = (): string | undefined =>
+  process.env.INSTAGRAM_ACCESS_TOKEN
+
+export const getSpotifyConfig = () => ({
+  clientId: process.env.SPOTIFY_CLIENT_ID,
+  clientSecret: process.env.SPOTIFY_CLIENT_SECRET,
+  redirectUri: process.env.SPOTIFY_REDIRECT_URI,
+  refreshToken: process.env.SPOTIFY_REFRESH_TOKEN,
+})
+
+export const getSteamConfig = () => ({
+  apiKey: process.env.STEAM_API_KEY,
+  userId: process.env.STEAM_USER_ID,
+})

--- a/functions/config/constants.ts
+++ b/functions/config/constants.ts
@@ -1,6 +1,11 @@
-const CLOUD_STORAGE_IMAGES_BUCKET = process.env.CLOUD_STORAGE_IMAGES_BUCKET
-const MEDIA_STORE_BACKEND = process.env.MEDIA_STORE_BACKEND
-const LOCAL_MEDIA_ROOT = process.env.LOCAL_MEDIA_ROOT
+import { getDiscogsConfig, getStorageConfig } from './backend-config.js'
+
+const {
+  cloudStorageImagesBucket: CLOUD_STORAGE_IMAGES_BUCKET,
+  imageCdnBaseUrl: IMAGE_CDN_BASE_URL,
+  localMediaRoot: LOCAL_MEDIA_ROOT,
+  mediaStoreBackend: MEDIA_STORE_BACKEND,
+} = getStorageConfig()
 
 const CURRENT_USERNAME = 'chrisvogt'
 
@@ -26,9 +31,7 @@ const DATABASE_COLLECTION_GITHUB = `users/${CURRENT_USERNAME}/github`
 
 const DATABASE_COLLECTION_USERS = 'users'
 
-const IMAGE_CDN_BASE_URL = process.env.IMAGE_CDN_BASE_URL
-
-const DISCOGS_USERNAME = process.env.DISCOGS_USERNAME
+const { username: DISCOGS_USERNAME } = getDiscogsConfig()
 
 export {
   CLOUD_STORAGE_IMAGES_BUCKET,

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -3,7 +3,6 @@ import { logger } from 'firebase-functions'
 import admin from 'firebase-admin'
 import compression from 'compression'
 import cors from 'cors'
-import * as dotenv from 'dotenv'
 import express from 'express'
 import cookieParser from 'cookie-parser'
 import { onRequest } from 'firebase-functions/v2/https'
@@ -15,6 +14,13 @@ import path from 'path'
 import { fileURLToPath } from 'url'
 
 import { applyExportedConfigToEnv } from './config/exported-config.js'
+import {
+  getFirebaseClientConfig,
+  hasAppliedRuntimeConfig,
+  isProductionEnvironment,
+  loadLocalDevelopmentEnv,
+  markRuntimeConfigApplied,
+} from './config/backend-config.js'
 import { FirestoreDocumentStore } from './adapters/storage/firestore-document-store.js'
 import { LocalDiskMediaStore } from './adapters/storage/local-disk-media-store.js'
 import { getRateLimitKey } from './middleware/rate-limit-key.js'
@@ -34,9 +40,7 @@ const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
 // Load environment variables from functions/.env synchronously in development.
-if (process.env.NODE_ENV !== 'production') {
-  dotenv.config({ path: path.resolve(__dirname, '../.env') })
-}
+loadLocalDevelopmentEnv(path.resolve(__dirname, '../.env'))
 
 const rateLimitMessage = { ok: false, error: 'Too many requests. Please try again later.' }
 
@@ -60,7 +64,7 @@ const storageFirestoreDatabaseUrl = defineString(
 const functionsConfigExport = defineJsonSecret('FUNCTIONS_CONFIG_EXPORT')
 
 function getAdminCredential(): admin.credential.Credential {
-  if (process.env.NODE_ENV === 'production') {
+  if (isProductionEnvironment()) {
     return admin.credential.applicationDefault()
   }
   const tokenPath = './token.json'
@@ -71,11 +75,11 @@ function getAdminCredential(): admin.credential.Credential {
 }
 
 async function ensureExportedConfigApplied(): Promise<void> {
-  if (process.env.__FUNCTIONS_CONFIG_APPLIED__) return
+  if (hasAppliedRuntimeConfig()) return
   try {
     const data = functionsConfigExport.value()
     applyExportedConfigToEnv(data as Record<string, string>)
-    process.env.__FUNCTIONS_CONFIG_APPLIED__ = '1'
+    markRuntimeConfigApplied()
   } catch (err) {
     logger.warn('Could not load FUNCTIONS_CONFIG_EXPORT (e.g. local dev with .env)', {
       message: err instanceof Error ? err.message : String(err),
@@ -93,7 +97,7 @@ const adminConfig: admin.AppOptions = {
 admin.initializeApp(adminConfig)
 
 // Connect to emulators in development mode
-if (process.env.NODE_ENV !== 'production') {
+if (!isProductionEnvironment()) {
   try {
     (admin.auth() as unknown as { useEmulator(url: string): void }).useEmulator('http://127.0.0.1:9099')
     console.log('Connected to Firebase Auth emulator')
@@ -180,7 +184,7 @@ const buildFailureResponse = (err: unknown = {}): { ok: false; error: string } =
 const ALLOWED_EMAIL_DOMAINS = ['@chrisvogt.me', '@chronogrove.com']
 function isAllowedEmail(email: string | undefined | null): boolean {
   if (!email) return false
-  if (process.env.NODE_ENV !== 'production') return true
+  if (!isProductionEnvironment()) return true
   return ALLOWED_EMAIL_DOMAINS.some((domain) => email.endsWith(domain))
 }
 
@@ -321,7 +325,7 @@ const corsAllowList: RegExp[] = [
   /https?:\/\/([a-z0-9]+[.])*dev-chronogrove[.]com$/,
 ]
 
-if (process.env.NODE_ENV !== 'production') {
+if (!isProductionEnvironment()) {
   corsAllowList.push(/localhost:?(\d+)?$/)
 }
 
@@ -538,8 +542,8 @@ expressApp.post(
       const options = {
         maxAge: expiresIn,
         httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
-        sameSite: (process.env.NODE_ENV === 'production' ? 'strict' : 'lax') as 'strict' | 'lax',
+        secure: isProductionEnvironment(),
+        sameSite: (isProductionEnvironment() ? 'strict' : 'lax') as 'strict' | 'lax',
         path: '/',
       }
 
@@ -561,11 +565,7 @@ expressApp.post(
 
 expressApp.get('/api/firebase-config', cors(corsOptions), async (_req, res) => {
   await ensureExportedConfigApplied()
-  const config = {
-    apiKey: process.env.CLIENT_API_KEY,
-    authDomain: process.env.CLIENT_AUTH_DOMAIN,
-    projectId: process.env.CLIENT_PROJECT_ID,
-  }
+  const config = getFirebaseClientConfig()
   res.json(config)
 })
 
@@ -580,8 +580,8 @@ expressApp.post(
       await admin.auth().revokeRefreshTokens(req.user.uid)
       res.clearCookie('session', {
         httpOnly: true,
-        secure: process.env.NODE_ENV === 'production',
-        sameSite: process.env.NODE_ENV === 'production' ? 'strict' : 'lax',
+        secure: isProductionEnvironment(),
+        sameSite: isProductionEnvironment() ? 'strict' : 'lax',
         path: '/',
       })
       res.status(200).send({

--- a/functions/jobs/sync-goodreads-data.ts
+++ b/functions/jobs/sync-goodreads-data.ts
@@ -11,6 +11,7 @@ import generateGoodreadsSummary from '../api/goodreads/generate-goodreads-summar
 import fetchBookFromGoogle from '../api/google-books/fetch-book.js'
 import fetchAndUploadFile from '../api/cloud-storage/fetch-and-upload-file.js'
 import listStoredMedia from '../api/cloud-storage/list-stored-media.js'
+import { getGoogleBooksApiKey } from '../config/backend-config.js'
 import { getMediaStore } from '../selectors/media-store.js'
 import { DATABASE_COLLECTION_GOODREADS, IMAGE_CDN_BASE_URL } from '../config/constants.js'
 
@@ -208,7 +209,7 @@ const processUpdatesWithMedia = async (updates = [], books = []) => {
             }
             
             try {
-              const googleBooksAPIKey = process.env.GOOGLE_BOOKS_API_KEY
+              const googleBooksAPIKey = getGoogleBooksApiKey()
               result = await fetchWithRetry(async () => {
                 const { body } = await got('https://www.googleapis.com/books/v1/volumes', {
                   searchParams: {

--- a/functions/jobs/sync-spotify-data.ts
+++ b/functions/jobs/sync-spotify-data.ts
@@ -9,6 +9,7 @@ import getSpotifyPlaylists from '../api/spotify/get-playlists.js'
 import getSpotifyTopTracks from '../api/spotify/get-top-tracks.js'
 import getSpotifyUserProfile from '../api/spotify/get-user-profile.js'
 import listStoredMedia from '../api/cloud-storage/list-stored-media.js'
+import { getSpotifyConfig } from '../config/backend-config.js'
 import { getMediaStore } from '../selectors/media-store.js'
 import transformTrackToCollectionItem from '../transformers/track-to-collection-item.js'
 
@@ -58,11 +59,7 @@ const transformPlaylists = (playlists) => playlists.map(playlist => {
 
 const syncSpotifyTopTracks = async () => {
   const mediaStore = getMediaStore()
-  // In v2, we'll use environment variables directly instead of config()
-  const clientId = process.env.SPOTIFY_CLIENT_ID
-  const clientSecret = process.env.SPOTIFY_CLIENT_SECRET
-  const redirectURI = process.env.SPOTIFY_REDIRECT_URI
-  const refreshToken = process.env.SPOTIFY_REFRESH_TOKEN
+  const { clientId, clientSecret, redirectUri: redirectURI, refreshToken } = getSpotifyConfig()
 
   const { accessToken } = await getSpotifyAccessToken({
     clientId,

--- a/functions/jobs/sync-steam-data.ts
+++ b/functions/jobs/sync-steam-data.ts
@@ -7,6 +7,7 @@ import getPlayerSummary from '../api/steam/get-player-summary.js'
 import getRecentlyPlayedGames from '../api/steam/get-recently-played-games.js'
 import generateSteamSummary from '../api/gemini/generate-steam-summary.js'
 
+import { getSteamConfig } from '../config/backend-config.js'
 import { DATABASE_COLLECTION_STEAM } from '../config/constants.js'
 
 const transformSteamGame = (game) => {
@@ -51,8 +52,7 @@ const transformSteamGame = (game) => {
  *  - capsule_231x87.jpg
  */
 const syncSteamData = async () => {
-  const apiKey = process.env.STEAM_API_KEY
-  const userId = process.env.STEAM_USER_ID
+  const { apiKey, userId } = getSteamConfig()
 
   const [recentlyPlayedGames, ownedGames, playerSummary] = await Promise.all([
     getRecentlyPlayedGames(apiKey, userId),

--- a/functions/selectors/media-store.ts
+++ b/functions/selectors/media-store.ts
@@ -1,16 +1,15 @@
-import path from 'path'
-
 import { GcsMediaStore } from '../adapters/storage/gcs-media-store.js'
 import { LocalDiskMediaStore } from '../adapters/storage/local-disk-media-store.js'
+import { getStorageConfig } from '../config/backend-config.js'
 import type { MediaStore } from '../ports/media-store.js'
 
 let defaultMediaStore: MediaStore | undefined
 
 export const resolveMediaStoreBackend = () =>
-  process.env.MEDIA_STORE_BACKEND ?? (process.env.NODE_ENV === 'production' ? 'gcs' : 'disk')
+  getStorageConfig().mediaStoreBackend
 
 export const resolveLocalMediaRoot = () =>
-  process.env.LOCAL_MEDIA_ROOT ?? path.resolve(process.cwd(), 'tmp/media')
+  getStorageConfig().localMediaRoot
 
 export const isDiskMediaStoreSelected = () => resolveMediaStoreBackend() === 'disk'
 

--- a/functions/services/sync/sync-flickr-data.ts
+++ b/functions/services/sync/sync-flickr-data.ts
@@ -3,13 +3,14 @@ import { logger } from 'firebase-functions'
 
 import type { DocumentStore } from '../../ports/document-store.js'
 import { DATABASE_COLLECTION_FLICKR } from '../../config/constants.js'
+import { getFlickrConfig } from '../../config/backend-config.js'
 import fetchPhotos from '../../api/flickr/fetch-photos.js'
 
 export const FLICKR_LAST_RESPONSE_PATH = `${DATABASE_COLLECTION_FLICKR}/last-response`
 export const FLICKR_WIDGET_CONTENT_PATH = `${DATABASE_COLLECTION_FLICKR}/widget-content`
 
 const syncFlickrData = async (documentStore: DocumentStore) => {
-  const flickrUsername = process.env.FLICKR_USER_ID
+  const { userId: flickrUsername } = getFlickrConfig()
 
   try {
     const photosResponse = await fetchPhotos()

--- a/functions/widgets/get-github-widget-content.ts
+++ b/functions/widgets/get-github-widget-content.ts
@@ -3,6 +3,8 @@ import graphqlGot from 'graphql-got'
 import path from 'path'
 import { fileURLToPath } from 'url'
 
+import { getGitHubConfig } from '../config/backend-config.js'
+
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 
@@ -12,8 +14,7 @@ const query = fs.readFileSync(
 )
 
 const getGitHubWidgetContent = async () => {
-  const accessToken = process.env.GITHUB_ACCESS_TOKEN
-  const username = process.env.GITHUB_USERNAME
+  const { accessToken, username } = getGitHubConfig()
 
   if (!accessToken || !username) {
     throw new Error('Missing required environment variables for GitHub widget (GITHUB_ACCESS_TOKEN or GITHUB_USERNAME).')


### PR DESCRIPTION
## Summary

Introduces the first provider-neutral backend config boundary in `functions/` and moves service/runtime callers away from scattered direct `process.env` reads.

## What Changed

- added a new normalized backend config module in `functions/config/backend-config.ts`
- added focused tests for the new config boundary in `functions/config/backend-config.test.ts`
- moved local development env loading behind the config boundary
- moved runtime config application state (`__FUNCTIONS_CONFIG_APPLIED__`) behind the config boundary
- updated the Firebase Functions entrypoint to use config helpers instead of inline env access
- updated storage/config constants and media-store selection to read from normalized config helpers
- migrated direct env reads in provider/service modules to config helpers, including Discogs, Flickr, Goodreads, GitHub, Instagram, Spotify, Steam, Gemini, and Google Books callers

## Why

This advances #129 by separating backend services from raw runtime configuration sources. The goal is to make services depend on normalized config values while keeping Firebase Secret Manager, exported config, and local `.env` concerns isolated closer to runtime/bootstrap code.

## Scope Notes

Included in this PR:
- normalized config getters for current backend services
- local dotenv loading wrapped in a dedicated config module
- runtime-config application state wrapped in a dedicated config module
- service-layer migration away from scattered direct env access
- duplicate issue cleanup for the older backend portability issue set

Not included in this PR:
- full Firebase runtime/bootstrap extraction
- hardcoded user/path cleanup
- auth/session boundary extraction
- deployment/runtime provider changes

## Testing

Validated in `functions/` with:

    pnpm test
    pnpm lint

Results:
- 53 test files passed
- 510 tests passed
- 1 test skipped
- lint passed cleanly

## Issues

Advances #129  
Helps prepare #128  
Touches #131  
Supports #132  
Closes duplicate issues #116, #117, #118, #119, #120, #121, #122, #123, and #124