### PR TITLE
feat: extract backend path helpers

### DIFF
--- a/functions/CHANGELOG.md
+++ b/functions/CHANGELOG.md
@@ -24,6 +24,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Auth routes** – `POST /api/auth/session` and `POST /api/auth/logout` now use the rate limiter (20 and 30 requests per 15 minutes respectively) so every route that performs authorization is rate-limited (CodeQL compliance).
 
+## [0.22.5] - 2026-03-15
+
+### Added
+
+- **Backend path helpers** – Added explicit user/provider path builders for Firestore collection paths, media prefixes, and widget host-to-user resolution so backend path generation is owned by a dedicated layer instead of scattered string literals.
+
+### Changed
+
+- **Path constants** – Reworked backend collection/media constants to derive from the shared path helpers while preserving the current `chrisvogt` and `chronogrove` behavior.
+- **Widget reads** – Flickr and Goodreads widget readers now respect the passed `userId` when building widget-content document paths instead of implicitly reading from the default hardcoded user path.
+
+### Developer experience
+
+- **Coverage** – Added focused tests for the new backend path helpers and updated widget/helper coverage for user-aware widget document paths.
+
 ## [0.22.4] - 2026-03-14
 
 ### Added

--- a/functions/config/backend-paths.test.ts
+++ b/functions/config/backend-paths.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getDefaultWidgetUserId,
+  getUsersCollectionPath,
+  getWidgetUserIdForHostname,
+  toMediaPrefix,
+  toUserCollectionPath,
+} from './backend-paths.js'
+
+describe('backend paths', () => {
+  it('returns the default widget user id', () => {
+    expect(getDefaultWidgetUserId()).toBe('chrisvogt')
+  })
+
+  it('returns the root users collection path', () => {
+    expect(getUsersCollectionPath()).toBe('users')
+  })
+
+  it('builds user collection paths explicitly', () => {
+    expect(toUserCollectionPath('chrisvogt', 'spotify')).toBe('users/chrisvogt/spotify')
+    expect(toUserCollectionPath('chronogrove', 'instagram')).toBe('users/chronogrove/instagram')
+  })
+
+  it('builds user-scoped media prefixes explicitly', () => {
+    expect(toMediaPrefix('chrisvogt', 'discogs')).toBe('chrisvogt/discogs/')
+    expect(toMediaPrefix('chrisvogt', 'spotify', 'playlists/')).toBe('chrisvogt/spotify/playlists/')
+  })
+
+  it('resolves the widget user from hostname', () => {
+    expect(getWidgetUserIdForHostname('api.chronogrove.com')).toBe('chronogrove')
+    expect(getWidgetUserIdForHostname('api.chrisvogt.me')).toBe('chrisvogt')
+    expect(getWidgetUserIdForHostname(undefined)).toBe('chrisvogt')
+  })
+})

--- a/functions/config/backend-paths.ts
+++ b/functions/config/backend-paths.ts
@@ -1,0 +1,15 @@
+const DEFAULT_WIDGET_USER_ID = 'chrisvogt'
+const USERS_COLLECTION = 'users'
+
+export const getDefaultWidgetUserId = () => DEFAULT_WIDGET_USER_ID
+
+export const getUsersCollectionPath = () => USERS_COLLECTION
+
+export const toUserCollectionPath = (userId: string, provider: string) =>
+  `${USERS_COLLECTION}/${userId}/${provider}`
+
+export const toMediaPrefix = (userId: string, provider: string, suffix = '') =>
+  `${userId}/${provider}/${suffix}`
+
+export const getWidgetUserIdForHostname = (hostname: string | undefined) =>
+  hostname === 'api.chronogrove.com' ? 'chronogrove' : DEFAULT_WIDGET_USER_ID

--- a/functions/config/constants.ts
+++ b/functions/config/constants.ts
@@ -1,4 +1,10 @@
 import { getDiscogsConfig, getStorageConfig } from './backend-config.js'
+import {
+  getDefaultWidgetUserId,
+  getUsersCollectionPath,
+  toMediaPrefix,
+  toUserCollectionPath,
+} from './backend-paths.js'
 
 const {
   cloudStorageImagesBucket: CLOUD_STORAGE_IMAGES_BUCKET,
@@ -7,29 +13,29 @@ const {
   mediaStoreBackend: MEDIA_STORE_BACKEND,
 } = getStorageConfig()
 
-const CURRENT_USERNAME = 'chrisvogt'
+const CURRENT_USERNAME = getDefaultWidgetUserId()
 
-const CLOUD_STORAGE_DISCOGS_PATH = `${CURRENT_USERNAME}/discogs/`
+const CLOUD_STORAGE_DISCOGS_PATH = toMediaPrefix(CURRENT_USERNAME, 'discogs')
 
-const CLOUD_STORAGE_INSTAGRAM_PATH = `${CURRENT_USERNAME}/instagram/`
+const CLOUD_STORAGE_INSTAGRAM_PATH = toMediaPrefix(CURRENT_USERNAME, 'instagram')
 
-const CLOUD_STORAGE_SPOTIFY_PLAYLISTS_PATH = `${CURRENT_USERNAME}/spotify/playlists/`
+const CLOUD_STORAGE_SPOTIFY_PLAYLISTS_PATH = toMediaPrefix(CURRENT_USERNAME, 'spotify', 'playlists/')
 
-const DATABASE_COLLECTION_DISCOGS = `users/${CURRENT_USERNAME}/discogs`
+const DATABASE_COLLECTION_DISCOGS = toUserCollectionPath(CURRENT_USERNAME, 'discogs')
 
-const DATABASE_COLLECTION_FLICKR = `users/${CURRENT_USERNAME}/flickr`
+const DATABASE_COLLECTION_FLICKR = toUserCollectionPath(CURRENT_USERNAME, 'flickr')
 
-const DATABASE_COLLECTION_SPOTIFY = `users/${CURRENT_USERNAME}/spotify`
+const DATABASE_COLLECTION_SPOTIFY = toUserCollectionPath(CURRENT_USERNAME, 'spotify')
 
-const DATABASE_COLLECTION_STEAM = `users/${CURRENT_USERNAME}/steam`
+const DATABASE_COLLECTION_STEAM = toUserCollectionPath(CURRENT_USERNAME, 'steam')
 
-const DATABASE_COLLECTION_INSTAGRAM = `users/${CURRENT_USERNAME}/instagram`
+const DATABASE_COLLECTION_INSTAGRAM = toUserCollectionPath(CURRENT_USERNAME, 'instagram')
 
-const DATABASE_COLLECTION_GOODREADS = `users/${CURRENT_USERNAME}/goodreads`
+const DATABASE_COLLECTION_GOODREADS = toUserCollectionPath(CURRENT_USERNAME, 'goodreads')
 
-const DATABASE_COLLECTION_GITHUB = `users/${CURRENT_USERNAME}/github`
+const DATABASE_COLLECTION_GITHUB = toUserCollectionPath(CURRENT_USERNAME, 'github')
 
-const DATABASE_COLLECTION_USERS = 'users'
+const DATABASE_COLLECTION_USERS = getUsersCollectionPath()
 
 const { username: DISCOGS_USERNAME } = getDiscogsConfig()
 

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -21,6 +21,7 @@ import {
   loadLocalDevelopmentEnv,
   markRuntimeConfigApplied,
 } from './config/backend-config.js'
+import { getWidgetUserIdForHostname } from './config/backend-paths.js'
 import { FirestoreDocumentStore } from './adapters/storage/firestore-document-store.js'
 import { LocalDiskMediaStore } from './adapters/storage/local-disk-media-store.js'
 import { getRateLimitKey } from './middleware/rate-limit-key.js'
@@ -425,7 +426,7 @@ expressApp.get('/api/widgets/:provider', cors(corsOptions), async (req, res) => 
   }
 
   const originalHostname = (req.headers['x-forwarded-host'] as string) || req.hostname
-  const userId = originalHostname === 'api.chronogrove.com' ? 'chronogrove' : 'chrisvogt'
+  const userId = getWidgetUserIdForHostname(originalHostname)
 
   try {
     const widgetContent = await getWidgetContent(provider, userId, documentStore)

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics-functions",
-  "version": "0.22.4",
+  "version": "0.22.5",
   "description": "Personal metrics API. A hobby project tracking my online metrics.",
   "type": "module",
   "main": "lib/index.js",

--- a/functions/widgets/get-flickr-widget-content.test.ts
+++ b/functions/widgets/get-flickr-widget-content.test.ts
@@ -46,7 +46,7 @@ describe('getFlickrWidgetContent', () => {
 
     const result = await getFlickrWidgetContent('user123', documentStore)
 
-    expect(documentStore.getDocument).toHaveBeenCalledWith('users/chrisvogt/flickr/widget-content')
+    expect(documentStore.getDocument).toHaveBeenCalledWith('users/user123/flickr/widget-content')
     expect(result).toEqual(mockData)
   })
 

--- a/functions/widgets/get-flickr-widget-content.ts
+++ b/functions/widgets/get-flickr-widget-content.ts
@@ -1,17 +1,17 @@
 import { logger } from 'firebase-functions'
 import { FirestoreDocumentStore } from '../adapters/storage/firestore-document-store.js'
-import { DATABASE_COLLECTION_FLICKR } from '../config/constants.js'
 import type { DocumentStore } from '../ports/document-store.js'
-import { toWidgetContentPath } from './widget-document-store.js'
+import { getDefaultWidgetUserId } from '../config/backend-paths.js'
+import { toUserWidgetContentPath } from './widget-document-store.js'
 
 const defaultDocumentStore = new FirestoreDocumentStore()
-const flickrWidgetContentPath = toWidgetContentPath(DATABASE_COLLECTION_FLICKR)
 
 const getFlickrWidgetContent = async (
-  _userId?: string,
+  userId: string = getDefaultWidgetUserId(),
   documentStore: DocumentStore = defaultDocumentStore
 ) => {
   try {
+    const flickrWidgetContentPath = toUserWidgetContentPath(userId, 'flickr')
     const widgetContent = await documentStore.getDocument(flickrWidgetContentPath)
 
     if (!widgetContent) {

--- a/functions/widgets/get-goodreads-widget-content.test.ts
+++ b/functions/widgets/get-goodreads-widget-content.test.ts
@@ -58,7 +58,7 @@ describe('getGoodreadsWidgetContent', () => {
       }
     })
 
-    expect(documentStore.getDocument).toHaveBeenCalledWith('users/chrisvogt/goodreads/widget-content')
+    expect(documentStore.getDocument).toHaveBeenCalledWith('users/user123/goodreads/widget-content')
   })
 
   it('should handle missing data gracefully', async () => {

--- a/functions/widgets/get-goodreads-widget-content.ts
+++ b/functions/widgets/get-goodreads-widget-content.ts
@@ -1,15 +1,15 @@
 import { FirestoreDocumentStore } from '../adapters/storage/firestore-document-store.js'
-import { DATABASE_COLLECTION_GOODREADS } from '../config/constants.js'
 import type { DocumentStore } from '../ports/document-store.js'
-import { toDateOrDefault, toWidgetContentPath } from './widget-document-store.js'
+import { getDefaultWidgetUserId } from '../config/backend-paths.js'
+import { toDateOrDefault, toUserWidgetContentPath } from './widget-document-store.js'
 
 const defaultDocumentStore = new FirestoreDocumentStore()
-const goodreadsWidgetContentPath = toWidgetContentPath(DATABASE_COLLECTION_GOODREADS)
 
 const getGoodreadsWidgetContent = async (
-  _userId?: string,
+  userId: string = getDefaultWidgetUserId(),
   documentStore: DocumentStore = defaultDocumentStore
 ) => {
+  const goodreadsWidgetContentPath = toUserWidgetContentPath(userId, 'goodreads')
   const data = await documentStore.getDocument<{
     meta?: { synced?: unknown }
   } & Record<string, unknown>>(goodreadsWidgetContentPath)

--- a/functions/widgets/widget-document-store.test.ts
+++ b/functions/widgets/widget-document-store.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, it } from 'vitest'
 
-import { toDateOrDefault, toWidgetContentPath } from './widget-document-store.js'
+import { toDateOrDefault, toUserWidgetContentPath, toWidgetContentPath } from './widget-document-store.js'
 
 describe('widget-document-store helpers', () => {
   it('builds widget-content document paths', () => {
     expect(toWidgetContentPath('users/chrisvogt/flickr')).toBe(
       'users/chrisvogt/flickr/widget-content'
+    )
+  })
+
+  it('builds widget-content paths from user and provider', () => {
+    expect(toUserWidgetContentPath('chronogrove', 'instagram')).toBe(
+      'users/chronogrove/instagram/widget-content'
     )
   })
 

--- a/functions/widgets/widget-document-store.ts
+++ b/functions/widgets/widget-document-store.ts
@@ -1,6 +1,10 @@
 import { Timestamp } from 'firebase/firestore'
 
+import { toUserCollectionPath } from '../config/backend-paths.js'
+
 export const toWidgetContentPath = (collectionPath: string) => `${collectionPath}/widget-content`
+export const toUserWidgetContentPath = (userId: string, provider: string) =>
+  toWidgetContentPath(toUserCollectionPath(userId, provider))
 
 export const toDateOrDefault = (value: unknown, fallback: Date = new Date(0)) => {
   if (value instanceof Date) {


### PR DESCRIPTION
## Summary

Introduces an explicit backend path helper layer in `functions/` so user/provider document paths and media prefixes are generated by a dedicated module instead of hardcoded string constants.

## What Changed

- added shared backend path helpers in `functions/config/backend-paths.ts`
- added focused tests for path generation and hostname-to-user resolution in `functions/config/backend-paths.test.ts`
- updated `functions/config/constants.ts` to derive collection paths and media prefixes from the new helpers
- moved widget hostname-to-user resolution in `functions/index.ts` onto the shared helper
- updated widget document-store helpers to support user/provider-based widget-content paths
- updated Flickr and Goodreads widget readers to honor the passed `userId`
- bumped `functions/package.json` to `0.22.5`
- added a `0.22.5` changelog entry in `functions/CHANGELOG.md`

## Why

This advances #131 by removing hardcoded path construction assumptions from the backend and making user/provider path generation explicit. It also prepares follow-up work in #128 and #129 by moving one more Firebase-specific structural concern behind a small dedicated boundary.

## Scope Notes

Included in this PR:
- explicit user/provider path builders
- hostname-to-widget-user resolution helper
- widget reader updates for user-aware document paths
- release metadata update

Not included in this PR:
- auth/session boundary refactor
- runtime/bootstrap extraction
- broader multi-tenant behavior changes beyond preserving current `chrisvogt` / `chronogrove` behavior

## Testing

Validated in `functions/` with:

    pnpm test
    pnpm lint

Results:
- 54 test files passed
- 516 tests passed
- 1 test skipped
- lint passed cleanly

Manual smoke test:
- verified Flickr sync/read path still worked locally
- verified Discogs sync/read path still worked locally

## Issues

Advances #131  
Helps prepare #128  
Builds on #129  
Supports #132
