### PR TITLE
feat: refactors provider path configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -55,8 +56,11 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: functions/coverage/lcov.info
+          disable_search: true
+          name: functions-unit-coverage
           flags: unittests
           fail_ci_if_error: true
+          verbose: true
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() && steps.junit.outputs.file != '' }}
@@ -65,7 +69,10 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           files: ${{ steps.junit.outputs.file }}
+          disable_search: true
+          name: functions-unit-test-results
           report_type: test_results
+          verbose: true
 
       - name: Fail if tests failed
         if: ${{ steps.tests.outcome == 'failure' }}

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ hosting/dist
 
 # Functions TypeScript build output (tsc → lib/); source lives in config/, widgets/, utils/, helpers/
 functions/lib/
+local-media/
 
 # Optional npm cache directory
 .npm

--- a/functions/CHANGELOG.md
+++ b/functions/CHANGELOG.md
@@ -24,6 +24,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Auth routes** – `POST /api/auth/session` and `POST /api/auth/logout` now use the rate limiter (20 and 30 requests per 15 minutes respectively) so every route that performs authorization is rate-limited (CodeQL compliance).
 
+## [0.22.6] - 2026-03-15
+
+### Added
+
+- **Backend path config overrides** – Added `DEFAULT_WIDGET_USER_ID` and `WIDGET_USER_ID_BY_HOSTNAME` support so the default widget user and hostname-to-user routing can be configured without code changes.
+
+### Changed
+
+- **Provider path resolution** – Replaced precomputed per-user collection and media path constants with runtime path builders so sync jobs, widget reads, and media destination helpers no longer treat one hardcoded username as a structural constant.
+- **Provider sync persistence** – Discogs, Goodreads, Instagram, Spotify, Steam, and Flickr persistence paths now resolve through the shared backend path layer, preserving existing document layouts while making alternate deployments easier to configure.
+
+### Developer experience
+
+- **Coverage** – Added focused config/path override tests and updated transformer/widget coverage around the new runtime path resolution.
+
 ## [0.22.5] - 2026-03-15
 
 ### Added

--- a/functions/config/backend-config.test.ts
+++ b/functions/config/backend-config.test.ts
@@ -29,6 +29,8 @@ describe('backend config', () => {
     delete process.env.SPOTIFY_REFRESH_TOKEN
     delete process.env.STEAM_API_KEY
     delete process.env.STEAM_USER_ID
+    delete process.env.DEFAULT_WIDGET_USER_ID
+    delete process.env.WIDGET_USER_ID_BY_HOSTNAME
   })
 
   it('detects production mode from NODE_ENV', async () => {
@@ -143,6 +145,14 @@ describe('backend config', () => {
     expect(storageConfig.localMediaRoot.endsWith('tmp/media')).toBe(true)
   })
 
+  it('defaults storage backend to gcs in production when unset', async () => {
+    process.env.NODE_ENV = 'production'
+
+    const { getStorageConfig } = await import('./backend-config.js')
+
+    expect(getStorageConfig().mediaStoreBackend).toBe('gcs')
+  })
+
   it('returns normalized storage config with explicit overrides', async () => {
     process.env.NODE_ENV = 'production'
     process.env.CLOUD_STORAGE_IMAGES_BUCKET = 'bucket-name'
@@ -156,6 +166,62 @@ describe('backend config', () => {
       imageCdnBaseUrl: undefined,
       localMediaRoot: '/tmp/media-root',
       mediaStoreBackend: 'disk',
+    })
+  })
+
+  it('returns normalized backend path config with env overrides', async () => {
+    process.env.DEFAULT_WIDGET_USER_ID = 'custom-user'
+    process.env.WIDGET_USER_ID_BY_HOSTNAME = JSON.stringify({
+      'api.custom.example': 'custom-user',
+      'api.secondary.example': 'secondary-user',
+    })
+
+    const { getBackendPathConfig } = await import('./backend-config.js')
+
+    expect(getBackendPathConfig()).toEqual({
+      defaultWidgetUserId: 'custom-user',
+      widgetUserIdByHostname: {
+        'api.custom.example': 'custom-user',
+        'api.secondary.example': 'secondary-user',
+      },
+    })
+  })
+
+  it('parses hostname mapping config from comma-separated env values', async () => {
+    process.env.WIDGET_USER_ID_BY_HOSTNAME =
+      'api.custom.example=custom-user, api.secondary.example=secondary-user'
+
+    const { getBackendPathConfig } = await import('./backend-config.js')
+
+    expect(getBackendPathConfig().widgetUserIdByHostname).toEqual({
+      'api.custom.example': 'custom-user',
+      'api.secondary.example': 'secondary-user',
+    })
+  })
+
+  it('filters invalid entries from JSON hostname mapping config', async () => {
+    process.env.WIDGET_USER_ID_BY_HOSTNAME = JSON.stringify({
+      'api.custom.example': 'custom-user',
+      '': 'missing-hostname',
+      'api.empty-user.example': '',
+      'api.invalid-user.example': 123,
+    })
+
+    const { getBackendPathConfig } = await import('./backend-config.js')
+
+    expect(getBackendPathConfig().widgetUserIdByHostname).toEqual({
+      'api.custom.example': 'custom-user',
+    })
+  })
+
+  it('ignores malformed entries in comma-separated hostname mapping config', async () => {
+    process.env.WIDGET_USER_ID_BY_HOSTNAME =
+      'api.custom.example=custom-user, invalid-entry, api.empty-user.example=, =missing-hostname'
+
+    const { getBackendPathConfig } = await import('./backend-config.js')
+
+    expect(getBackendPathConfig().widgetUserIdByHostname).toEqual({
+      'api.custom.example': 'custom-user',
     })
   })
 })

--- a/functions/config/backend-config.ts
+++ b/functions/config/backend-config.ts
@@ -2,6 +2,10 @@ import * as dotenv from 'dotenv'
 import path from 'path'
 
 const FUNCTIONS_CONFIG_APPLIED_ENV = '__FUNCTIONS_CONFIG_APPLIED__'
+const DEFAULT_WIDGET_USER_ID = 'chrisvogt'
+const DEFAULT_WIDGET_HOSTNAME_USER_MAP = {
+  'api.chronogrove.com': 'chronogrove',
+} as const
 
 export const isProductionEnvironment = () => process.env.NODE_ENV === 'production'
 
@@ -70,4 +74,39 @@ export const getSpotifyConfig = () => ({
 export const getSteamConfig = () => ({
   apiKey: process.env.STEAM_API_KEY,
   userId: process.env.STEAM_USER_ID,
+})
+
+const parseWidgetUserMap = (
+  rawValue: string | undefined
+): Record<string, string> => {
+  if (!rawValue) {
+    return { ...DEFAULT_WIDGET_HOSTNAME_USER_MAP }
+  }
+
+  try {
+    const parsed = JSON.parse(rawValue) as Record<string, unknown>
+    return Object.entries(parsed).reduce<Record<string, string>>((acc, [hostname, userId]) => {
+      if (hostname.length > 0 && typeof userId === 'string' && userId.length > 0) {
+        acc[hostname] = userId
+      }
+      return acc
+    }, {})
+  } catch {
+    return rawValue
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+      .reduce<Record<string, string>>((acc, entry) => {
+        const [hostname, userId] = entry.split('=').map((part) => part?.trim())
+        if (hostname && userId) {
+          acc[hostname] = userId
+        }
+        return acc
+      }, {})
+  }
+}
+
+export const getBackendPathConfig = () => ({
+  defaultWidgetUserId: process.env.DEFAULT_WIDGET_USER_ID ?? DEFAULT_WIDGET_USER_ID,
+  widgetUserIdByHostname: parseWidgetUserMap(process.env.WIDGET_USER_ID_BY_HOSTNAME),
 })

--- a/functions/config/backend-paths.test.ts
+++ b/functions/config/backend-paths.test.ts
@@ -1,35 +1,71 @@
-import { describe, expect, it } from 'vitest'
-
-import {
-  getDefaultWidgetUserId,
-  getUsersCollectionPath,
-  getWidgetUserIdForHostname,
-  toMediaPrefix,
-  toUserCollectionPath,
-} from './backend-paths.js'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 describe('backend paths', () => {
-  it('returns the default widget user id', () => {
+  const originalEnv = { ...process.env }
+
+  beforeEach(() => {
+    vi.resetModules()
+    process.env = { ...originalEnv }
+    delete process.env.DEFAULT_WIDGET_USER_ID
+    delete process.env.WIDGET_USER_ID_BY_HOSTNAME
+  })
+
+  afterEach(() => {
+    process.env = originalEnv
+  })
+
+  it('returns the default widget user id', async () => {
+    const { getDefaultWidgetUserId } = await importBackendPaths()
     expect(getDefaultWidgetUserId()).toBe('chrisvogt')
   })
 
-  it('returns the root users collection path', () => {
+  it('returns the root users collection path', async () => {
+    const { getUsersCollectionPath } = await importBackendPaths()
     expect(getUsersCollectionPath()).toBe('users')
   })
 
-  it('builds user collection paths explicitly', () => {
+  it('builds user collection paths explicitly', async () => {
+    const { toUserCollectionPath, toProviderCollectionPath } = await importBackendPaths()
     expect(toUserCollectionPath('chrisvogt', 'spotify')).toBe('users/chrisvogt/spotify')
     expect(toUserCollectionPath('chronogrove', 'instagram')).toBe('users/chronogrove/instagram')
+    expect(toProviderCollectionPath('spotify')).toBe('users/chrisvogt/spotify')
   })
 
-  it('builds user-scoped media prefixes explicitly', () => {
+  it('builds user-scoped media prefixes explicitly', async () => {
+    const { toMediaPrefix, toProviderMediaPrefix } = await importBackendPaths()
     expect(toMediaPrefix('chrisvogt', 'discogs')).toBe('chrisvogt/discogs/')
     expect(toMediaPrefix('chrisvogt', 'spotify', 'playlists/')).toBe('chrisvogt/spotify/playlists/')
+    expect(toProviderMediaPrefix('instagram')).toBe('chrisvogt/instagram/')
   })
 
-  it('resolves the widget user from hostname', () => {
+  it('resolves the widget user from hostname', async () => {
+    const { getWidgetUserIdForHostname } = await importBackendPaths()
     expect(getWidgetUserIdForHostname('api.chronogrove.com')).toBe('chronogrove')
     expect(getWidgetUserIdForHostname('api.chrisvogt.me')).toBe('chrisvogt')
     expect(getWidgetUserIdForHostname(undefined)).toBe('chrisvogt')
   })
+
+  it('allows the default widget user and hostname mapping to be overridden by env', async () => {
+    process.env.DEFAULT_WIDGET_USER_ID = 'custom-user'
+    process.env.WIDGET_USER_ID_BY_HOSTNAME =
+      'api.custom.example=custom-user,api.secondary.example=secondary-user'
+
+    const {
+      getDefaultWidgetUserId,
+      getWidgetUserIdForHostname,
+      toProviderCollectionPath,
+      toProviderMediaPrefix,
+    } = await importBackendPaths()
+
+    expect(getDefaultWidgetUserId()).toBe('custom-user')
+    expect(getWidgetUserIdForHostname('api.custom.example')).toBe('custom-user')
+    expect(getWidgetUserIdForHostname('api.secondary.example')).toBe('secondary-user')
+    expect(toProviderCollectionPath('goodreads')).toBe('users/custom-user/goodreads')
+    expect(toProviderMediaPrefix('discogs')).toBe('custom-user/discogs/')
+  })
 })
+
+const importBackendPaths = () => {
+  // Dynamic import keeps env-sensitive path config fresh per test.
+  return vi.importActual<typeof import('./backend-paths.js')>('./backend-paths.js')
+}

--- a/functions/config/backend-paths.ts
+++ b/functions/config/backend-paths.ts
@@ -1,15 +1,33 @@
-const DEFAULT_WIDGET_USER_ID = 'chrisvogt'
+import { getBackendPathConfig } from './backend-config.js'
+
 const USERS_COLLECTION = 'users'
 
-export const getDefaultWidgetUserId = () => DEFAULT_WIDGET_USER_ID
+export const getDefaultWidgetUserId = () => getBackendPathConfig().defaultWidgetUserId
 
 export const getUsersCollectionPath = () => USERS_COLLECTION
 
 export const toUserCollectionPath = (userId: string, provider: string) =>
   `${USERS_COLLECTION}/${userId}/${provider}`
 
+export const toProviderCollectionPath = (
+  provider: string,
+  userId: string = getDefaultWidgetUserId()
+) => toUserCollectionPath(userId, provider)
+
 export const toMediaPrefix = (userId: string, provider: string, suffix = '') =>
   `${userId}/${provider}/${suffix}`
 
-export const getWidgetUserIdForHostname = (hostname: string | undefined) =>
-  hostname === 'api.chronogrove.com' ? 'chronogrove' : DEFAULT_WIDGET_USER_ID
+export const toProviderMediaPrefix = (
+  provider: string,
+  userId: string = getDefaultWidgetUserId(),
+  suffix = ''
+) => toMediaPrefix(userId, provider, suffix)
+
+export const getWidgetUserIdForHostname = (hostname: string | undefined) => {
+  const { defaultWidgetUserId, widgetUserIdByHostname } = getBackendPathConfig()
+  if (!hostname) {
+    return defaultWidgetUserId
+  }
+
+  return widgetUserIdByHostname[hostname] ?? defaultWidgetUserId
+}

--- a/functions/config/constants.test.ts
+++ b/functions/config/constants.test.ts
@@ -1,158 +1,24 @@
-import { describe, it, expect } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import {
   CLOUD_STORAGE_IMAGES_BUCKET,
-  LOCAL_MEDIA_ROOT,
-  MEDIA_STORE_BACKEND,
-  CLOUD_STORAGE_DISCOGS_PATH,
-  CLOUD_STORAGE_INSTAGRAM_PATH,
-  CLOUD_STORAGE_SPOTIFY_PLAYLISTS_PATH,
-  CURRENT_USERNAME,
-  DATABASE_COLLECTION_DISCOGS,
-  DATABASE_COLLECTION_FLICKR,
-  DATABASE_COLLECTION_INSTAGRAM,
-  DATABASE_COLLECTION_SPOTIFY,
-  DATABASE_COLLECTION_STEAM,
-  DATABASE_COLLECTION_GOODREADS,
-  DATABASE_COLLECTION_GITHUB,
   DATABASE_COLLECTION_USERS,
   DISCOGS_USERNAME,
-  IMAGE_CDN_BASE_URL
+  IMAGE_CDN_BASE_URL,
+  LOCAL_MEDIA_ROOT,
+  MEDIA_STORE_BACKEND,
 } from './constants.js'
 
 describe('constants', () => {
-  describe('CURRENT_USERNAME', () => {
-    it('should be a string with the correct value', () => {
-      expect(CURRENT_USERNAME).toBe('chrisvogt')
-      expect(typeof CURRENT_USERNAME).toBe('string')
-    })
+  it('exports the shared users collection path', () => {
+    expect(DATABASE_COLLECTION_USERS).toBe('users')
   })
 
-  describe('CLOUD_STORAGE_DISCOGS_PATH', () => {
-    it('should be a string with the correct value', () => {
-      expect(CLOUD_STORAGE_DISCOGS_PATH).toBe(`${CURRENT_USERNAME}/discogs/`)
-      expect(typeof CLOUD_STORAGE_DISCOGS_PATH).toBe('string')
-    })
-  })
-
-  describe('CLOUD_STORAGE_INSTAGRAM_PATH', () => {
-    it('should be a string with the correct value', () => {
-      expect(CLOUD_STORAGE_INSTAGRAM_PATH).toBe(`${CURRENT_USERNAME}/instagram/`)
-      expect(typeof CLOUD_STORAGE_INSTAGRAM_PATH).toBe('string')
-    })
-  })
-
-  describe('CLOUD_STORAGE_SPOTIFY_PLAYLISTS_PATH', () => {
-    it('should be a string with the correct value', () => {
-      expect(CLOUD_STORAGE_SPOTIFY_PLAYLISTS_PATH).toBe(`${CURRENT_USERNAME}/spotify/playlists/`)
-      expect(typeof CLOUD_STORAGE_SPOTIFY_PLAYLISTS_PATH).toBe('string')
-    })
-  })
-
-  describe('DATABASE_COLLECTION_DISCOGS', () => {
-    it('should be a string with the correct value', () => {
-      expect(DATABASE_COLLECTION_DISCOGS).toBe(`users/${CURRENT_USERNAME}/discogs`)
-      expect(typeof DATABASE_COLLECTION_DISCOGS).toBe('string')
-    })
-  })
-
-  describe('DATABASE_COLLECTION_FLICKR', () => {
-    it('should be a string with the correct value', () => {
-      expect(DATABASE_COLLECTION_FLICKR).toBe(`users/${CURRENT_USERNAME}/flickr`)
-      expect(typeof DATABASE_COLLECTION_FLICKR).toBe('string')
-    })
-  })
-
-  describe('DATABASE_COLLECTION_INSTAGRAM', () => {
-    it('should be a string with the correct value', () => {
-      expect(DATABASE_COLLECTION_INSTAGRAM).toBe(`users/${CURRENT_USERNAME}/instagram`)
-      expect(typeof DATABASE_COLLECTION_INSTAGRAM).toBe('string')
-    })
-  })
-
-  describe('DATABASE_COLLECTION_SPOTIFY', () => {
-    it('should be a string with the correct value', () => {
-      expect(DATABASE_COLLECTION_SPOTIFY).toBe(`users/${CURRENT_USERNAME}/spotify`)
-      expect(typeof DATABASE_COLLECTION_SPOTIFY).toBe('string')
-    })
-  })
-
-  describe('DATABASE_COLLECTION_STEAM', () => {
-    it('should be a string with the correct value', () => {
-      expect(DATABASE_COLLECTION_STEAM).toBe(`users/${CURRENT_USERNAME}/steam`)
-      expect(typeof DATABASE_COLLECTION_STEAM).toBe('string')
-    })
-  })
-
-  describe('DATABASE_COLLECTION_USERS', () => {
-    it('should be a string with the correct value', () => {
-      expect(DATABASE_COLLECTION_USERS).toBe('users')
-      expect(typeof DATABASE_COLLECTION_USERS).toBe('string')
-    })
-  })
-
-  describe('environment-dependent constants', () => {
-    it('should have CLOUD_STORAGE_IMAGES_BUCKET as string or undefined', () => {
-      expect(typeof CLOUD_STORAGE_IMAGES_BUCKET === 'string' || CLOUD_STORAGE_IMAGES_BUCKET === undefined).toBe(true)
-    })
-
-    it('should have MEDIA_STORE_BACKEND as string or undefined', () => {
-      expect(typeof MEDIA_STORE_BACKEND === 'string' || MEDIA_STORE_BACKEND === undefined).toBe(true)
-    })
-
-    it('should have LOCAL_MEDIA_ROOT as string or undefined', () => {
-      expect(typeof LOCAL_MEDIA_ROOT === 'string' || LOCAL_MEDIA_ROOT === undefined).toBe(true)
-    })
-
-    it('should have DISCOGS_USERNAME as string or undefined', () => {
-      expect(typeof DISCOGS_USERNAME === 'string' || DISCOGS_USERNAME === undefined).toBe(true)
-    })
-
-    it('should have IMAGE_CDN_BASE_URL as string or undefined', () => {
-      expect(typeof IMAGE_CDN_BASE_URL === 'string' || IMAGE_CDN_BASE_URL === undefined).toBe(true)
-    })
-  })
-
-  describe('all constants', () => {
-    it('should export all expected constants', () => {
-      const constants = {
-        CLOUD_STORAGE_IMAGES_BUCKET,
-        LOCAL_MEDIA_ROOT,
-        MEDIA_STORE_BACKEND,
-        CLOUD_STORAGE_DISCOGS_PATH,
-        CLOUD_STORAGE_INSTAGRAM_PATH,
-        CLOUD_STORAGE_SPOTIFY_PLAYLISTS_PATH,
-        CURRENT_USERNAME,
-        DATABASE_COLLECTION_DISCOGS,
-        DATABASE_COLLECTION_FLICKR,
-        DATABASE_COLLECTION_INSTAGRAM,
-        DATABASE_COLLECTION_SPOTIFY,
-        DATABASE_COLLECTION_STEAM,
-        DATABASE_COLLECTION_GOODREADS,
-        DATABASE_COLLECTION_GITHUB,
-        DATABASE_COLLECTION_USERS,
-        DISCOGS_USERNAME,
-        IMAGE_CDN_BASE_URL
-      }
-
-      expect(Object.keys(constants)).toHaveLength(17)
-      expect(constants).toHaveProperty('CLOUD_STORAGE_IMAGES_BUCKET')
-      expect(constants).toHaveProperty('LOCAL_MEDIA_ROOT')
-      expect(constants).toHaveProperty('MEDIA_STORE_BACKEND')
-      expect(constants).toHaveProperty('CLOUD_STORAGE_DISCOGS_PATH')
-      expect(constants).toHaveProperty('CLOUD_STORAGE_INSTAGRAM_PATH')
-      expect(constants).toHaveProperty('CLOUD_STORAGE_SPOTIFY_PLAYLISTS_PATH')
-      expect(constants).toHaveProperty('CURRENT_USERNAME')
-      expect(constants).toHaveProperty('DATABASE_COLLECTION_DISCOGS')
-      expect(constants).toHaveProperty('DATABASE_COLLECTION_FLICKR')
-      expect(constants).toHaveProperty('DATABASE_COLLECTION_INSTAGRAM')
-      expect(constants).toHaveProperty('DATABASE_COLLECTION_SPOTIFY')
-      expect(constants).toHaveProperty('DATABASE_COLLECTION_STEAM')
-      expect(constants).toHaveProperty('DATABASE_COLLECTION_GOODREADS')
-      expect(constants).toHaveProperty('DATABASE_COLLECTION_GITHUB')
-      expect(constants).toHaveProperty('DATABASE_COLLECTION_USERS')
-      expect(constants).toHaveProperty('DISCOGS_USERNAME')
-      expect(constants).toHaveProperty('IMAGE_CDN_BASE_URL')
-    })
+  it('exports environment-backed values without throwing', () => {
+    expect(typeof CLOUD_STORAGE_IMAGES_BUCKET === 'string' || CLOUD_STORAGE_IMAGES_BUCKET === undefined).toBe(true)
+    expect(typeof MEDIA_STORE_BACKEND === 'string' || MEDIA_STORE_BACKEND === undefined).toBe(true)
+    expect(typeof LOCAL_MEDIA_ROOT === 'string' || LOCAL_MEDIA_ROOT === undefined).toBe(true)
+    expect(typeof DISCOGS_USERNAME === 'string' || DISCOGS_USERNAME === undefined).toBe(true)
+    expect(typeof IMAGE_CDN_BASE_URL === 'string' || IMAGE_CDN_BASE_URL === undefined).toBe(true)
   })
 })

--- a/functions/config/constants.ts
+++ b/functions/config/constants.ts
@@ -1,10 +1,5 @@
 import { getDiscogsConfig, getStorageConfig } from './backend-config.js'
-import {
-  getDefaultWidgetUserId,
-  getUsersCollectionPath,
-  toMediaPrefix,
-  toUserCollectionPath,
-} from './backend-paths.js'
+import { getUsersCollectionPath } from './backend-paths.js'
 
 const {
   cloudStorageImagesBucket: CLOUD_STORAGE_IMAGES_BUCKET,
@@ -12,28 +7,6 @@ const {
   localMediaRoot: LOCAL_MEDIA_ROOT,
   mediaStoreBackend: MEDIA_STORE_BACKEND,
 } = getStorageConfig()
-
-const CURRENT_USERNAME = getDefaultWidgetUserId()
-
-const CLOUD_STORAGE_DISCOGS_PATH = toMediaPrefix(CURRENT_USERNAME, 'discogs')
-
-const CLOUD_STORAGE_INSTAGRAM_PATH = toMediaPrefix(CURRENT_USERNAME, 'instagram')
-
-const CLOUD_STORAGE_SPOTIFY_PLAYLISTS_PATH = toMediaPrefix(CURRENT_USERNAME, 'spotify', 'playlists/')
-
-const DATABASE_COLLECTION_DISCOGS = toUserCollectionPath(CURRENT_USERNAME, 'discogs')
-
-const DATABASE_COLLECTION_FLICKR = toUserCollectionPath(CURRENT_USERNAME, 'flickr')
-
-const DATABASE_COLLECTION_SPOTIFY = toUserCollectionPath(CURRENT_USERNAME, 'spotify')
-
-const DATABASE_COLLECTION_STEAM = toUserCollectionPath(CURRENT_USERNAME, 'steam')
-
-const DATABASE_COLLECTION_INSTAGRAM = toUserCollectionPath(CURRENT_USERNAME, 'instagram')
-
-const DATABASE_COLLECTION_GOODREADS = toUserCollectionPath(CURRENT_USERNAME, 'goodreads')
-
-const DATABASE_COLLECTION_GITHUB = toUserCollectionPath(CURRENT_USERNAME, 'github')
 
 const DATABASE_COLLECTION_USERS = getUsersCollectionPath()
 
@@ -43,17 +16,6 @@ export {
   CLOUD_STORAGE_IMAGES_BUCKET,
   LOCAL_MEDIA_ROOT,
   MEDIA_STORE_BACKEND,
-  CLOUD_STORAGE_DISCOGS_PATH,
-  CLOUD_STORAGE_INSTAGRAM_PATH,
-  CLOUD_STORAGE_SPOTIFY_PLAYLISTS_PATH,
-  CURRENT_USERNAME,
-  DATABASE_COLLECTION_DISCOGS,
-  DATABASE_COLLECTION_FLICKR,
-  DATABASE_COLLECTION_INSTAGRAM,
-  DATABASE_COLLECTION_SPOTIFY,
-  DATABASE_COLLECTION_STEAM,
-  DATABASE_COLLECTION_GOODREADS,
-  DATABASE_COLLECTION_GITHUB,
   DATABASE_COLLECTION_USERS,
   DISCOGS_USERNAME,
   IMAGE_CDN_BASE_URL,

--- a/functions/jobs/sync-discogs-data.ts
+++ b/functions/jobs/sync-discogs-data.ts
@@ -10,9 +10,9 @@ import listStoredMedia from '../api/cloud-storage/list-stored-media.js'
 import { getMediaStore } from '../selectors/media-store.js'
 import toDiscogsDestinationPath from '../transformers/to-discogs-destination-path.js'
 import transformDiscogsRelease from '../transformers/transform-discogs-release.js'
+import { toProviderCollectionPath } from '../config/backend-paths.js'
 
 import { 
-  DATABASE_COLLECTION_DISCOGS,
   DISCOGS_USERNAME
 } from '../config/constants.js'
 
@@ -76,6 +76,7 @@ const getMediaReducer = (storedMediaFileNames = []) => (acc, release) => {
 
 const syncDiscogsData = async () => {
   try {
+    const discogsCollectionPath = toProviderCollectionPath('discogs')
     const mediaStore = getMediaStore()
     const discogsResponse = await fetchDiscogsReleases()
 
@@ -124,7 +125,7 @@ const syncDiscogsData = async () => {
 
     // Save the raw Discogs response data (with enhanced releases)
     await db
-      .collection(DATABASE_COLLECTION_DISCOGS)
+      .collection(discogsCollectionPath)
       .doc('last-response')
       .set(documentToSave)
 
@@ -147,7 +148,7 @@ const syncDiscogsData = async () => {
 
     // Save the widget content
     await db
-      .collection(DATABASE_COLLECTION_DISCOGS)
+      .collection(discogsCollectionPath)
       .doc('widget-content')
       .set(updatedWidgetContent)
 

--- a/functions/jobs/sync-goodreads-data.ts
+++ b/functions/jobs/sync-goodreads-data.ts
@@ -12,8 +12,9 @@ import fetchBookFromGoogle from '../api/google-books/fetch-book.js'
 import fetchAndUploadFile from '../api/cloud-storage/fetch-and-upload-file.js'
 import listStoredMedia from '../api/cloud-storage/list-stored-media.js'
 import { getGoogleBooksApiKey } from '../config/backend-config.js'
+import { toProviderCollectionPath } from '../config/backend-paths.js'
 import { getMediaStore } from '../selectors/media-store.js'
-import { DATABASE_COLLECTION_GOODREADS, IMAGE_CDN_BASE_URL } from '../config/constants.js'
+import { IMAGE_CDN_BASE_URL } from '../config/constants.js'
 
 const toBookMediaDestinationPath = id => `books/${id}-thumbnail.jpg`
 
@@ -449,6 +450,7 @@ const fetchAllGoodreadsPromises = async (): Promise<{
  * Sync Goodreads Data
  */
 const syncGoodreadsData = async () => {
+  const goodreadsCollectionPath = toProviderCollectionPath('goodreads')
   const {
     collections = {},
     error,
@@ -486,7 +488,7 @@ const syncGoodreadsData = async () => {
 
   const res = responses as { user?: unknown; reviews?: unknown }
   const saveUserResponse = async () => await db
-    .collection(DATABASE_COLLECTION_GOODREADS)
+    .collection(goodreadsCollectionPath)
     .doc('last-response_user-show')
     .set({
       response: res.user,
@@ -494,7 +496,7 @@ const syncGoodreadsData = async () => {
     })
 
   const saveBookReviews = async () => await db
-    .collection(DATABASE_COLLECTION_GOODREADS)
+    .collection(goodreadsCollectionPath)
     .doc('last-response_book-reviews')
     .set({
       response: res.reviews,
@@ -502,14 +504,14 @@ const syncGoodreadsData = async () => {
     })
 
   const saveWidgetContent = async () => await db
-    .collection(DATABASE_COLLECTION_GOODREADS)
+    .collection(goodreadsCollectionPath)
     .doc('widget-content')
     .set(widgetContent)
 
   const saveAISummary = async () => {
     if (aiSummary) {
       await db
-        .collection(DATABASE_COLLECTION_GOODREADS)
+        .collection(goodreadsCollectionPath)
         .doc('last-response_ai-summary')
         .set({
           summary: aiSummary,

--- a/functions/jobs/sync-instagram-data.ts
+++ b/functions/jobs/sync-instagram-data.ts
@@ -9,8 +9,7 @@ import listStoredMedia from '../api/cloud-storage/list-stored-media.js'
 import { getMediaStore } from '../selectors/media-store.js'
 import toIGDestinationPath from '../transformers/to-ig-destination-path.js'
 import transformInstagramMedia from '../transformers/transform-instagram-media.js'
-
-import { DATABASE_COLLECTION_INSTAGRAM } from '../config/constants.js'
+import { toProviderCollectionPath } from '../config/backend-paths.js'
 
 /*
 
@@ -79,6 +78,7 @@ const getMediaReducer = (storedMediaFileNames = []) => (acc, mediaItem) => {
 
 const syncInstagramData = async () => {
   try {
+    const instagramCollectionPath = toProviderCollectionPath('instagram')
     const mediaStore = getMediaStore()
     const instagramResponse = (await fetchInstagramData()) as {
       media?: { data?: unknown[] }
@@ -102,7 +102,7 @@ const syncInstagramData = async () => {
 
     // Save the raw Instagram response data
     await db
-      .collection(DATABASE_COLLECTION_INSTAGRAM)
+      .collection(instagramCollectionPath)
       .doc('last-response')
       .set({
         ...instagramResponse,
@@ -128,7 +128,7 @@ const syncInstagramData = async () => {
 
     // Save the widget content
     await db
-      .collection(DATABASE_COLLECTION_INSTAGRAM)
+      .collection(instagramCollectionPath)
       .doc('widget-content')
       .set(updatedWidgetContent)
 

--- a/functions/jobs/sync-spotify-data.ts
+++ b/functions/jobs/sync-spotify-data.ts
@@ -9,13 +9,12 @@ import getSpotifyPlaylists from '../api/spotify/get-playlists.js'
 import getSpotifyTopTracks from '../api/spotify/get-top-tracks.js'
 import getSpotifyUserProfile from '../api/spotify/get-user-profile.js'
 import listStoredMedia from '../api/cloud-storage/list-stored-media.js'
+import { toProviderCollectionPath, toProviderMediaPrefix } from '../config/backend-paths.js'
 import { getSpotifyConfig } from '../config/backend-config.js'
 import { getMediaStore } from '../selectors/media-store.js'
 import transformTrackToCollectionItem from '../transformers/track-to-collection-item.js'
 
 import {
-  CLOUD_STORAGE_SPOTIFY_PLAYLISTS_PATH,
-  DATABASE_COLLECTION_SPOTIFY,
   IMAGE_CDN_BASE_URL
 } from '../config/constants.js'
 
@@ -34,7 +33,7 @@ const getMediaToDownloadReducer = (storedMediaFileNames = []) => (acc, playlist)
   // I'm using the media filename — a hash — to identify the media file in GCP Storage because I assume the
   // images on mosaic.scdn.co rotate and change over time based on the playlist.
   const id = mediaURL.replace(SPOTIFY_MOSAIC_BASE_URL, '')
-  const destinationPath = `${CLOUD_STORAGE_SPOTIFY_PLAYLISTS_PATH}${id}.jpg`
+  const destinationPath = `${toProviderMediaPrefix('spotify', undefined, 'playlists/')}${id}.jpg`
   const isAlreadyDownloaded = storedMediaFileNames.includes(destinationPath)
 
   if (!isAlreadyDownloaded) {
@@ -50,7 +49,7 @@ const getMediaToDownloadReducer = (storedMediaFileNames = []) => (acc, playlist)
 
 const transformPlaylists = (playlists) => playlists.map(playlist => {
   const id = getMediaURLFromPlaylist(playlist)?.replace(SPOTIFY_MOSAIC_BASE_URL, '')
-  const cdnImageURL = `${IMAGE_CDN_BASE_URL}${CLOUD_STORAGE_SPOTIFY_PLAYLISTS_PATH}${id}.jpg`
+  const cdnImageURL = `${IMAGE_CDN_BASE_URL}${toProviderMediaPrefix('spotify', undefined, 'playlists/')}${id}.jpg`
   return {
     ...playlist,
     cdnImageURL
@@ -58,6 +57,7 @@ const transformPlaylists = (playlists) => playlists.map(playlist => {
 })
 
 const syncSpotifyTopTracks = async () => {
+  const spotifyCollectionPath = toProviderCollectionPath('spotify')
   const mediaStore = getMediaStore()
   const { clientId, clientSecret, redirectUri: redirectURI, refreshToken } = getSpotifyConfig()
 
@@ -179,7 +179,7 @@ const syncSpotifyTopTracks = async () => {
   const db = admin.firestore()
 
   const savePlaylists = async () => await db
-    .collection(DATABASE_COLLECTION_SPOTIFY)
+    .collection(spotifyCollectionPath)
     .doc('last-response_playlists')
     .set({
       response: playlistsResponse,
@@ -187,7 +187,7 @@ const syncSpotifyTopTracks = async () => {
     })
 
   const saveTopTracksResponse = async () => await db
-    .collection(DATABASE_COLLECTION_SPOTIFY)
+    .collection(spotifyCollectionPath)
     .doc('last-response_top-tracks')
     .set({
       response: topTracks,
@@ -195,7 +195,7 @@ const syncSpotifyTopTracks = async () => {
     })
 
   const saveUserProfileResponse = async () => await db
-    .collection(DATABASE_COLLECTION_SPOTIFY)
+    .collection(spotifyCollectionPath)
     .doc('last-response_user-profile')
     .set({
       response: userProfile,
@@ -204,7 +204,7 @@ const syncSpotifyTopTracks = async () => {
 
   const saveWidgetContent = async () => {
     return await db
-      .collection(DATABASE_COLLECTION_SPOTIFY)
+      .collection(spotifyCollectionPath)
       .doc('widget-content')
       .set(widgetContent)
   }

--- a/functions/jobs/sync-steam-data.ts
+++ b/functions/jobs/sync-steam-data.ts
@@ -7,8 +7,8 @@ import getPlayerSummary from '../api/steam/get-player-summary.js'
 import getRecentlyPlayedGames from '../api/steam/get-recently-played-games.js'
 import generateSteamSummary from '../api/gemini/generate-steam-summary.js'
 
+import { toProviderCollectionPath } from '../config/backend-paths.js'
 import { getSteamConfig } from '../config/backend-config.js'
-import { DATABASE_COLLECTION_STEAM } from '../config/constants.js'
 
 const transformSteamGame = (game) => {
   const {
@@ -53,6 +53,7 @@ const transformSteamGame = (game) => {
  */
 const syncSteamData = async () => {
   const { apiKey, userId } = getSteamConfig()
+  const steamCollectionPath = toProviderCollectionPath('steam')
 
   const [recentlyPlayedGames, ownedGames, playerSummary] = await Promise.all([
     getRecentlyPlayedGames(apiKey, userId),
@@ -63,7 +64,7 @@ const syncSteamData = async () => {
   const db = admin.firestore()
 
   const saveOwnedGames = async () => await db
-    .collection(DATABASE_COLLECTION_STEAM)
+    .collection(steamCollectionPath)
     .doc('last-response_owned-games')
     .set({
       response: ownedGames,
@@ -71,7 +72,7 @@ const syncSteamData = async () => {
     })
 
   const savePlayerSummary = async () => await db
-    .collection(DATABASE_COLLECTION_STEAM)
+    .collection(steamCollectionPath)
     .doc('last-response_player-summary')
     .set({
       response: playerSummary,
@@ -79,7 +80,7 @@ const syncSteamData = async () => {
     })
 
   const saveRecentlyPlayedGames = async () => await db
-    .collection(DATABASE_COLLECTION_STEAM)
+    .collection(steamCollectionPath)
     .doc('last-response_recently-played-games')
     .set({
       response: recentlyPlayedGames,
@@ -135,14 +136,14 @@ const syncSteamData = async () => {
   }
 
   const saveWidgetContent = async () => await db
-    .collection(DATABASE_COLLECTION_STEAM)
+    .collection(steamCollectionPath)
     .doc('widget-content')
     .set(widgetContent)
 
   const saveAISummary = async () => {
     if (aiSummary) {
       await db
-        .collection(DATABASE_COLLECTION_STEAM)
+        .collection(steamCollectionPath)
         .doc('last-response_ai-summary')
         .set({
           summary: aiSummary,

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics-functions",
-  "version": "0.22.5",
+  "version": "0.22.6",
   "description": "Personal metrics API. A hobby project tracking my online metrics.",
   "type": "module",
   "main": "lib/index.js",

--- a/functions/services/sync/sync-flickr-data.ts
+++ b/functions/services/sync/sync-flickr-data.ts
@@ -2,12 +2,12 @@ import { Timestamp } from 'firebase-admin/firestore'
 import { logger } from 'firebase-functions'
 
 import type { DocumentStore } from '../../ports/document-store.js'
-import { DATABASE_COLLECTION_FLICKR } from '../../config/constants.js'
 import { getFlickrConfig } from '../../config/backend-config.js'
+import { toProviderCollectionPath } from '../../config/backend-paths.js'
 import fetchPhotos from '../../api/flickr/fetch-photos.js'
 
-export const FLICKR_LAST_RESPONSE_PATH = `${DATABASE_COLLECTION_FLICKR}/last-response`
-export const FLICKR_WIDGET_CONTENT_PATH = `${DATABASE_COLLECTION_FLICKR}/widget-content`
+export const toFlickrLastResponsePath = () => `${toProviderCollectionPath('flickr')}/last-response`
+export const toFlickrWidgetContentPath = () => `${toProviderCollectionPath('flickr')}/widget-content`
 
 const syncFlickrData = async (documentStore: DocumentStore) => {
   const { userId: flickrUsername } = getFlickrConfig()
@@ -15,7 +15,7 @@ const syncFlickrData = async (documentStore: DocumentStore) => {
   try {
     const photosResponse = await fetchPhotos()
 
-    await documentStore.setDocument(FLICKR_LAST_RESPONSE_PATH, {
+    await documentStore.setDocument(toFlickrLastResponsePath(), {
       response: photosResponse,
       fetchedAt: Timestamp.now(),
     })
@@ -47,7 +47,7 @@ const syncFlickrData = async (documentStore: DocumentStore) => {
       },
     }
 
-    await documentStore.setDocument(FLICKR_WIDGET_CONTENT_PATH, widgetContent)
+    await documentStore.setDocument(toFlickrWidgetContentPath(), widgetContent)
 
     logger.info('Flickr data sync completed successfully', {
       totalPhotos: photoCount,

--- a/functions/transformers/to-discogs-destination-path.ts
+++ b/functions/transformers/to-discogs-destination-path.ts
@@ -1,10 +1,10 @@
 import path from 'path'
 
-import { CLOUD_STORAGE_DISCOGS_PATH } from '../config/constants.js'
+import { toProviderMediaPrefix } from '../config/backend-paths.js'
 
 const toDiscogsDestinationPath = (imageURL, releaseId, imageType = 'thumb') => {
   const fileExtension = path.extname(new URL(imageURL).pathname)
-  const destinationPath = `${CLOUD_STORAGE_DISCOGS_PATH}${releaseId}_${imageType}${fileExtension}`
+  const destinationPath = `${toProviderMediaPrefix('discogs')}${releaseId}_${imageType}${fileExtension}`
   return destinationPath
 }
 

--- a/functions/transformers/to-ig-destination-path.test.ts
+++ b/functions/transformers/to-ig-destination-path.test.ts
@@ -7,9 +7,9 @@ describe('toIGDestinationPath', () => {
   beforeEach(async () => {
     originalEnv = { ...process.env }
     
-    // Mock the constants module
-    vi.doMock('../config/constants.js', () => ({
-      CLOUD_STORAGE_INSTAGRAM_PATH: 'ig/'
+    // Mock the backend path builder
+    vi.doMock('../config/backend-paths.js', () => ({
+      toProviderMediaPrefix: vi.fn(() => 'ig/'),
     }))
     
     // Clear module cache to ensure fresh import

--- a/functions/transformers/to-ig-destination-path.ts
+++ b/functions/transformers/to-ig-destination-path.ts
@@ -1,10 +1,10 @@
 import path from 'path'
 
-import { CLOUD_STORAGE_INSTAGRAM_PATH } from '../config/constants.js'
+import { toProviderMediaPrefix } from '../config/backend-paths.js'
 
 const toIGDestinationPath = (mediaURL, id) => {
   const fileExtension = path.extname(new URL(mediaURL).pathname)
-  const destinationPath = `${CLOUD_STORAGE_INSTAGRAM_PATH}${id}${fileExtension}`
+  const destinationPath = `${toProviderMediaPrefix('instagram')}${id}${fileExtension}`
   return destinationPath
 }
 

--- a/functions/widgets/get-discogs-widget-content.ts
+++ b/functions/widgets/get-discogs-widget-content.ts
@@ -1,10 +1,10 @@
 import admin from 'firebase-admin'
 import { Timestamp } from 'firebase/firestore'
-import { DATABASE_COLLECTION_DISCOGS } from '../config/constants.js'
+import { toProviderCollectionPath } from '../config/backend-paths.js'
 
 const getDiscogsWidgetContent = async () => {
   const db = admin.firestore()
-  const doc = await db.collection(DATABASE_COLLECTION_DISCOGS).doc('widget-content').get()
+  const doc = await db.collection(toProviderCollectionPath('discogs')).doc('widget-content').get()
   const { meta, ...responseData } = doc.data()
 
   const transformedMeta = {

--- a/functions/widgets/get-spotify-widget-content.ts
+++ b/functions/widgets/get-spotify-widget-content.ts
@@ -1,10 +1,10 @@
 import admin from 'firebase-admin'
 import { Timestamp } from 'firebase/firestore'
-import { DATABASE_COLLECTION_SPOTIFY } from '../config/constants.js'
+import { toProviderCollectionPath } from '../config/backend-paths.js'
 
 const getSpotifyWidgetContent = async () => {
   const db = admin.firestore()
-  const doc = await db.collection(DATABASE_COLLECTION_SPOTIFY).doc('widget-content').get()
+  const doc = await db.collection(toProviderCollectionPath('spotify')).doc('widget-content').get()
   const { meta, ...responseData } = doc.data()
 
   const transformedMeta = {

--- a/functions/widgets/get-steam-widget-content.ts
+++ b/functions/widgets/get-steam-widget-content.ts
@@ -1,11 +1,11 @@
 import admin from 'firebase-admin'
-import { DATABASE_COLLECTION_STEAM } from '../config/constants.js'
 import { Timestamp } from 'firebase/firestore'
+import { toProviderCollectionPath } from '../config/backend-paths.js'
 
 const getSteamWidgetContent = async () => {
   const db = admin.firestore()
   const doc = await db
-    .collection(DATABASE_COLLECTION_STEAM)
+    .collection(toProviderCollectionPath('steam'))
     .doc('widget-content')
     .get()
 


### PR DESCRIPTION
## Summary

This PR continues the backend portability work by removing remaining hardcoded user and path assumptions from the `functions/` service layer.

It replaces precomputed per-user collection/media constants with runtime path builders, adds config-driven overrides for the default widget user and hostname routing, and updates sync jobs plus widget readers to resolve paths through the shared backend path layer. It also bumps the functions package to `0.22.6`, updates the changelog, and ignores local `local-media/` output.

Closes #131

## What Changed

- added `DEFAULT_WIDGET_USER_ID` and `WIDGET_USER_ID_BY_HOSTNAME` support in backend config
- added runtime provider path helpers for collection paths and media prefixes
- removed per-user path constants that treated `chrisvogt` as a structural default
- updated Discogs, Goodreads, Instagram, Spotify, Steam, and Flickr persistence paths to use the shared path layer
- updated Discogs, Spotify, and Steam widget reads to resolve provider collection paths at runtime
- updated media destination helpers to build provider media paths through the shared path helpers
- bumped `functions/package.json` to `0.22.6`
- added a `0.22.6` changelog entry
- added `local-media/` to `.gitignore`

## Why

This unblocks the AWS migration work by making backend path selection configurable instead of implicitly tied to the current Firebase-era single-user layout. Current behavior is preserved by default, but the path ownership is now explicit and easier to override per deployment.

## Testing

- `cd functions && /Users/chrisvogt/.nvm/versions/node/v24.13.0/bin/npx tsc --noEmit`
- `cd functions && /Users/chrisvogt/.nvm/versions/node/v24.13.0/bin/npx vitest run config/backend-config.test.ts config/backend-paths.test.ts config/constants.test.ts transformers/to-discogs-destination-path.test.ts transformers/to-ig-destination-path.test.ts jobs/sync-discogs-data.test.ts jobs/sync-instagram-data.test.ts jobs/sync-goodreads-data.test.ts jobs/sync-steam-data.test.ts widgets/get-discogs-widget-content.test.ts widgets/get-spotify-widget-content.test.ts widgets/get-steam-widget-content.test.ts widgets/get-flickr-widget-content.test.ts widgets/get-goodreads-widget-content.test.ts`

## Notes

- Full `npm test` still hits the existing sandbox-related `index.test.ts` failure where Supertest cannot bind to `0.0.0.0` (`EPERM`). The touched module and service-boundary tests passed.
- `local-media/` is treated as local runtime output and is now ignored.
