### PR TITLE
feat: moves widget reads onto DocumentStore

### DIFF
--- a/functions/CHANGELOG.md
+++ b/functions/CHANGELOG.md
@@ -24,6 +24,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Auth routes** – `POST /api/auth/session` and `POST /api/auth/logout` now use the rate limiter (20 and 30 requests per 15 minutes respectively) so every route that performs authorization is rate-limited (CodeQL compliance).
 
+## [0.22.10] - 2026-03-15
+
+### Changed
+
+- **Widget reads on `DocumentStore`** – Discogs, Instagram, Spotify, and Steam widget readers now load their `widget-content` documents through the shared `DocumentStore` boundary instead of reaching into Firestore directly.
+- **Consistent widget paths** – Provider widget reads now use the shared widget document path helpers so public widget loading follows the same provider-neutral storage contract across all supported providers.
+
+### Developer experience
+
+- **Widget reader coverage** – Replaced Firestore-specific widget reader tests with `DocumentStore`-backed coverage and added a dedicated Steam widget reader test to keep the provider read seam well-covered during the migration.
+
 ## [0.22.9] - 2026-03-15
 
 ### Added

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics-functions",
-  "version": "0.22.9",
+  "version": "0.22.10",
   "description": "Personal metrics API. A hobby project tracking my online metrics.",
   "type": "module",
   "main": "lib/index.js",

--- a/functions/widgets/get-discogs-widget-content.test.ts
+++ b/functions/widgets/get-discogs-widget-content.test.ts
@@ -1,45 +1,25 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import admin from 'firebase-admin'
-import { Timestamp } from 'firebase/firestore'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { DocumentStore } from '../ports/document-store.js'
 import getDiscogsWidgetContent from './get-discogs-widget-content.js'
 
-// Mock firebase-admin
-vi.mock('firebase-admin', () => ({
-  default: {
-    firestore: vi.fn(() => ({
-      collection: vi.fn(() => ({
-        doc: vi.fn(() => ({
-          get: vi.fn()
-        }))
-      }))
-    }))
-  }
-}))
-
 describe('getDiscogsWidgetContent', () => {
-  let mockGet
-  let mockDoc
-  let mockCollection
-  let mockFirestore
+  let documentStore: DocumentStore
 
   beforeEach(() => {
-    vi.clearAllMocks()
-    
-    mockGet = vi.fn()
-    mockDoc = vi.fn(() => ({ get: mockGet }))
-    mockCollection = vi.fn(() => ({ doc: mockDoc }))
-    mockFirestore = vi.fn(() => ({ collection: mockCollection }))
-    
-    admin.firestore = mockFirestore
+    documentStore = {
+      getDocument: vi.fn(),
+      setDocument: vi.fn(),
+    }
   })
 
   it('should return properly formatted widget content', async () => {
-    const mockData = {
+    vi.mocked(documentStore.getDocument).mockResolvedValue({
       meta: {
         synced: {
           _seconds: 1640995200,
-          _nanoseconds: 0
-        }
+          _nanoseconds: 0,
+        },
       },
       collections: {
         releases: [
@@ -47,98 +27,87 @@ describe('getDiscogsWidgetContent', () => {
             id: 28461454,
             title: 'The Rise & Fall Of A Midwest Princess',
             artist: 'Chappell Roan',
-            year: 2023
-          }
-        ]
+            year: 2023,
+          },
+        ],
       },
       metrics: {
-        'LPs Owned': 150
+        'LPs Owned': 150,
       },
       profile: {
-        profileURL: 'https://www.discogs.com/user/chrisvogt/collection'
-      }
-    }
-
-    mockGet.mockResolvedValue({
-      data: () => mockData
+        profileURL: 'https://www.discogs.com/user/chrisvogt/collection',
+      },
     })
 
-    const result = await getDiscogsWidgetContent()
+    const result = await getDiscogsWidgetContent('chrisvogt', documentStore)
 
     expect(result).toEqual({
-      collections: mockData.collections,
-      metrics: mockData.metrics,
-      profile: mockData.profile,
+      collections: {
+        releases: [
+          {
+            id: 28461454,
+            title: 'The Rise & Fall Of A Midwest Princess',
+            artist: 'Chappell Roan',
+            year: 2023,
+          },
+        ],
+      },
+      metrics: {
+        'LPs Owned': 150,
+      },
+      profile: {
+        profileURL: 'https://www.discogs.com/user/chrisvogt/collection',
+      },
       meta: {
-        synced: new Timestamp(1640995200, 0).toDate()
-      }
+        synced: new Date('2022-01-01T00:00:00.000Z'),
+      },
     })
 
-    expect(mockFirestore).toHaveBeenCalled()
-    expect(mockCollection).toHaveBeenCalledWith('users/chrisvogt/discogs')
-    expect(mockDoc).toHaveBeenCalledWith('widget-content')
-    expect(mockGet).toHaveBeenCalled()
+    expect(documentStore.getDocument).toHaveBeenCalledWith('users/chrisvogt/discogs/widget-content')
   })
 
   it('should handle missing data gracefully', async () => {
-    const mockData = {
-      meta: {
-        synced: {
-          _seconds: 1640995200,
-          _nanoseconds: 0
-        }
-      }
-    }
+    vi.mocked(documentStore.getDocument).mockResolvedValue(null)
 
-    mockGet.mockResolvedValue({
-      data: () => mockData
-    })
-
-    const result = await getDiscogsWidgetContent()
+    const result = await getDiscogsWidgetContent('chrisvogt', documentStore)
 
     expect(result).toEqual({
-      meta: {
-        synced: new Timestamp(1640995200, 0).toDate()
-      }
+      meta: {},
     })
   })
 
   it('should handle missing meta data', async () => {
-    const mockData = {
+    vi.mocked(documentStore.getDocument).mockResolvedValue({
       collections: {
-        releases: []
-      }
-    }
-
-    mockGet.mockResolvedValue({
-      data: () => mockData
+        releases: [],
+      },
     })
 
-    const result = await getDiscogsWidgetContent()
+    const result = await getDiscogsWidgetContent('chrisvogt', documentStore)
 
     expect(result).toEqual({
-      collections: mockData.collections,
-      meta: {}
+      collections: {
+        releases: [],
+      },
+      meta: {},
     })
   })
 
   it('should handle missing meta.synced data', async () => {
-    const mockData = {
+    vi.mocked(documentStore.getDocument).mockResolvedValue({
       meta: {},
       collections: {
-        releases: []
-      }
-    }
-
-    mockGet.mockResolvedValue({
-      data: () => mockData
+        releases: [],
+      },
     })
 
-    const result = await getDiscogsWidgetContent()
+    const result = await getDiscogsWidgetContent('chrisvogt', documentStore)
 
     expect(result).toEqual({
-      collections: mockData.collections,
-      meta: {}
+      collections: {
+        releases: [],
+      },
+      meta: {},
     })
   })
-}) 
+})

--- a/functions/widgets/get-discogs-widget-content.ts
+++ b/functions/widgets/get-discogs-widget-content.ts
@@ -1,22 +1,35 @@
-import admin from 'firebase-admin'
-import { Timestamp } from 'firebase/firestore'
-import { toProviderCollectionPath } from '../config/backend-paths.js'
+import { FirestoreDocumentStore } from '../adapters/storage/firestore-document-store.js'
+import type { DocumentStore } from '../ports/document-store.js'
+import { getDefaultWidgetUserId } from '../config/backend-paths.js'
+import { toDateOrDefault, toUserWidgetContentPath } from './widget-document-store.js'
 
-const getDiscogsWidgetContent = async () => {
-  const db = admin.firestore()
-  const doc = await db.collection(toProviderCollectionPath('discogs')).doc('widget-content').get()
-  const { meta, ...responseData } = doc.data()
+const defaultDocumentStore = new FirestoreDocumentStore()
+
+const getDiscogsWidgetContent = async (
+  userId: string = getDefaultWidgetUserId(),
+  documentStore: DocumentStore = defaultDocumentStore
+) => {
+  const discogsWidgetContentPath = toUserWidgetContentPath(userId, 'discogs')
+  const data = await documentStore.getDocument<{
+    meta?: { synced?: unknown }
+  } & Record<string, unknown>>(discogsWidgetContentPath)
+
+  if (!data) {
+    return {
+      meta: {},
+    }
+  }
+
+  const { meta = {}, ...responseData } = data
 
   const transformedMeta = {
     ...meta,
-    ...(meta?.synced && {
-      synced: new Timestamp(meta.synced._seconds, meta.synced._nanoseconds).toDate()
-    })
+    ...(meta.synced ? { synced: toDateOrDefault(meta.synced) } : {}),
   }
 
   return {
     ...responseData,
-    meta: transformedMeta
+    meta: transformedMeta,
   }
 }
 

--- a/functions/widgets/get-instagram-widget-content.test.ts
+++ b/functions/widgets/get-instagram-widget-content.test.ts
@@ -1,340 +1,190 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import admin from 'firebase-admin'
-import { Timestamp } from 'firebase/firestore'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { DocumentStore } from '../ports/document-store.js'
 import getInstagramWidgetContent from './get-instagram-widget-content.js'
 
-// Mock firebase-admin
-vi.mock('firebase-admin', () => ({
-  default: {
-    firestore: vi.fn(() => ({
-      collection: vi.fn(() => ({
-        doc: vi.fn(() => ({
-          get: vi.fn()
-        }))
-      }))
-    }))
-  }
-}))
-
 describe('getInstagramWidgetContent', () => {
-  let mockGet
-  let mockDoc
-  let mockCollection
-  let mockFirestore
+  let documentStore: DocumentStore
 
   beforeEach(() => {
-    vi.clearAllMocks()
-    
-    mockGet = vi.fn()
-    mockDoc = vi.fn(() => ({ get: mockGet }))
-    mockCollection = vi.fn(() => ({ doc: mockDoc }))
-    mockFirestore = vi.fn(() => ({ collection: mockCollection }))
-    
-    admin.firestore = mockFirestore
+    documentStore = {
+      getDocument: vi.fn(),
+      setDocument: vi.fn(),
+    }
   })
 
   it('should return properly formatted widget content for chrisvogt user', async () => {
-    const mockData = {
+    vi.mocked(documentStore.getDocument).mockResolvedValue({
       meta: {
         synced: {
           _seconds: 1640995200,
-          _nanoseconds: 0
-        }
+          _nanoseconds: 0,
+        },
       },
       media: [
         {
           id: '123',
-          images: { thumbnail: { url: 'https://example.com/image.jpg' } }
-        }
+          images: { thumbnail: { url: 'https://example.com/image.jpg' } },
+        },
       ],
       profile: {
         biography: 'Test bio',
         followersCount: 1000,
         mediaCount: 50,
-        username: 'testuser'
-      }
-    }
-
-    mockGet.mockResolvedValue({
-      data: () => mockData
+        username: 'testuser',
+      },
     })
 
-    const result = await getInstagramWidgetContent('chrisvogt')
+    const result = await getInstagramWidgetContent('chrisvogt', documentStore)
 
     expect(result).toEqual({
       collections: {
-        media: mockData.media
+        media: [
+          {
+            id: '123',
+            images: { thumbnail: { url: 'https://example.com/image.jpg' } },
+          },
+        ],
       },
       meta: {
-        synced: new Timestamp(1640995200, 0).toDate()
+        synced: new Date('2022-01-01T00:00:00.000Z'),
       },
       metrics: [
         {
           displayName: 'Followers',
           id: 'followers-count',
-          value: 1000
+          value: 1000,
         },
         {
           displayName: 'Posts',
           id: 'media-count',
-          value: 50
-        }
+          value: 50,
+        },
       ],
       provider: {
         displayName: 'Instagram',
-        id: 'instagram'
+        id: 'instagram',
       },
       profile: {
         biography: 'Test bio',
         displayName: 'testuser',
-        profileURL: 'https://www.instagram.com/testuser'
-      }
+        profileURL: 'https://www.instagram.com/testuser',
+      },
     })
 
-    expect(mockFirestore).toHaveBeenCalled()
-    expect(mockCollection).toHaveBeenCalledWith('users/chrisvogt/instagram')
-    expect(mockDoc).toHaveBeenCalledWith('widget-content')
-    expect(mockGet).toHaveBeenCalled()
+    expect(documentStore.getDocument).toHaveBeenCalledWith('users/chrisvogt/instagram/widget-content')
   })
 
   it('should return properly formatted widget content for chronogrove user', async () => {
-    const mockData = {
+    vi.mocked(documentStore.getDocument).mockResolvedValue({
       meta: {
         synced: {
           _seconds: 1640995200,
-          _nanoseconds: 0
-        }
+          _nanoseconds: 0,
+        },
       },
       media: [
         {
           id: '456',
-          images: { thumbnail: { url: 'https://example.com/chronogrove.jpg' } }
-        }
+          images: { thumbnail: { url: 'https://example.com/chronogrove.jpg' } },
+        },
       ],
       profile: {
         biography: 'Chronogrove bio',
         followersCount: 500,
         mediaCount: 25,
-        username: 'chronogrove'
-      }
-    }
-
-    mockGet.mockResolvedValue({
-      data: () => mockData
+        username: 'chronogrove',
+      },
     })
 
-    const result = await getInstagramWidgetContent('chronogrove')
+    const result = await getInstagramWidgetContent('chronogrove', documentStore)
 
-    expect(result).toEqual({
-      collections: {
-        media: mockData.media
-      },
-      meta: {
-        synced: new Timestamp(1640995200, 0).toDate()
-      },
-      metrics: [
-        {
-          displayName: 'Followers',
-          id: 'followers-count',
-          value: 500
-        },
-        {
-          displayName: 'Posts',
-          id: 'media-count',
-          value: 25
-        }
-      ],
-      provider: {
-        displayName: 'Instagram',
-        id: 'instagram'
-      },
-      profile: {
-        biography: 'Chronogrove bio',
-        displayName: 'chronogrove',
-        profileURL: 'https://www.instagram.com/chronogrove'
-      }
+    expect(result.profile).toEqual({
+      biography: 'Chronogrove bio',
+      displayName: 'chronogrove',
+      profileURL: 'https://www.instagram.com/chronogrove',
     })
 
-    expect(mockFirestore).toHaveBeenCalled()
-    expect(mockCollection).toHaveBeenCalledWith('users/chronogrove/instagram')
-    expect(mockDoc).toHaveBeenCalledWith('widget-content')
-    expect(mockGet).toHaveBeenCalled()
+    expect(documentStore.getDocument).toHaveBeenCalledWith('users/chronogrove/instagram/widget-content')
   })
 
   it('should handle missing profile data with defaults', async () => {
-    const mockData = {
+    vi.mocked(documentStore.getDocument).mockResolvedValue({
       meta: {
         synced: {
           _seconds: 1640995200,
-          _nanoseconds: 0
-        }
+          _nanoseconds: 0,
+        },
       },
-      media: []
-    }
-
-    mockGet.mockResolvedValue({
-      data: () => mockData
+      media: [],
     })
 
-    const result = await getInstagramWidgetContent('chrisvogt')
+    const result = await getInstagramWidgetContent('chrisvogt', documentStore)
 
     expect(result.profile).toEqual({
       biography: '',
       displayName: '',
-      profileURL: 'https://www.instagram.com/'
+      profileURL: 'https://www.instagram.com/',
     })
 
     expect(result.metrics).toEqual([
       {
         displayName: 'Followers',
         id: 'followers-count',
-        value: 0
+        value: 0,
       },
       {
         displayName: 'Posts',
         id: 'media-count',
-        value: 0
-      }
+        value: 0,
+      },
     ])
   })
 
   it('should handle partial profile data with defaults', async () => {
-    const mockData = {
+    vi.mocked(documentStore.getDocument).mockResolvedValue({
       meta: {
         synced: {
           _seconds: 1640995200,
-          _nanoseconds: 0
-        }
+          _nanoseconds: 0,
+        },
       },
       media: [],
       profile: {
-        username: 'partialuser'
-        // Missing biography, followersCount, mediaCount
-      }
-    }
-
-    mockGet.mockResolvedValue({
-      data: () => mockData
+        username: 'partialuser',
+      },
     })
 
-    const result = await getInstagramWidgetContent('chrisvogt')
+    const result = await getInstagramWidgetContent('chrisvogt', documentStore)
 
     expect(result.profile).toEqual({
       biography: '',
       displayName: 'partialuser',
-      profileURL: 'https://www.instagram.com/partialuser'
+      profileURL: 'https://www.instagram.com/partialuser',
     })
-
-    expect(result.metrics).toEqual([
-      {
-        displayName: 'Followers',
-        id: 'followers-count',
-        value: 0
-      },
-      {
-        displayName: 'Posts',
-        id: 'media-count',
-        value: 0
-      }
-    ])
   })
 
-  it('should throw error when data retrieval fails', async () => {
-    mockGet.mockResolvedValue({
-      data: () => null
-    })
+  it('should throw error when data retrieval returns nothing', async () => {
+    vi.mocked(documentStore.getDocument).mockResolvedValue(null)
 
-    await expect(getInstagramWidgetContent('chrisvogt')).rejects.toThrow('Failed to get a response.')
+    await expect(getInstagramWidgetContent('chrisvogt', documentStore)).rejects.toThrow(
+      'Failed to get a response.'
+    )
   })
 
-  it('should throw error when get() throws', async () => {
-    mockGet.mockRejectedValue(new Error('Database error'))
+  it('should throw error when document store rejects', async () => {
+    vi.mocked(documentStore.getDocument).mockRejectedValue(new Error('Database error'))
 
-    await expect(getInstagramWidgetContent('chrisvogt')).rejects.toThrow('Database error')
+    await expect(getInstagramWidgetContent('chrisvogt', documentStore)).rejects.toThrow(
+      'Database error'
+    )
   })
 
-  it('should throw error when data() throws', async () => {
-    mockGet.mockResolvedValue({
-      data: () => {
-        throw new Error('Data parsing error')
-      }
-    })
+  it('should rethrow non-Error failures from the document store', async () => {
+    vi.mocked(documentStore.getDocument).mockRejectedValue('Database error')
 
-    await expect(getInstagramWidgetContent('chrisvogt')).rejects.toThrow('Failed to get a response.')
+    await expect(getInstagramWidgetContent('chrisvogt', documentStore)).rejects.toBe(
+      'Database error'
+    )
   })
-
-  it('should handle empty media array', async () => {
-    const mockData = {
-      meta: {
-        synced: {
-          _seconds: 1640995200,
-          _nanoseconds: 0
-        }
-      },
-      media: [],
-      profile: {
-        biography: 'Empty media user',
-        followersCount: 100,
-        mediaCount: 0,
-        username: 'emptymedia'
-      }
-    }
-
-    mockGet.mockResolvedValue({
-      data: () => mockData
-    })
-
-    const result = await getInstagramWidgetContent('chrisvogt')
-
-    expect(result.collections.media).toEqual([])
-    expect(result.metrics).toEqual([
-      {
-        displayName: 'Followers',
-        id: 'followers-count',
-        value: 100
-      },
-      {
-        displayName: 'Posts',
-        id: 'media-count',
-        value: 0
-      }
-    ])
-  })
-
-  it('should handle large follower and media counts', async () => {
-    const mockData = {
-      meta: {
-        synced: {
-          _seconds: 1640995200,
-          _nanoseconds: 0
-        }
-      },
-      media: [],
-      profile: {
-        biography: 'Popular user',
-        followersCount: 1000000,
-        mediaCount: 5000,
-        username: 'popularuser'
-      }
-    }
-
-    mockGet.mockResolvedValue({
-      data: () => mockData
-    })
-
-    const result = await getInstagramWidgetContent('chrisvogt')
-
-    expect(result.metrics).toEqual([
-      {
-        displayName: 'Followers',
-        id: 'followers-count',
-        value: 1000000
-      },
-      {
-        displayName: 'Posts',
-        id: 'media-count',
-        value: 5000
-      }
-    ])
-  })
-}) 
+})

--- a/functions/widgets/get-instagram-widget-content.ts
+++ b/functions/widgets/get-instagram-widget-content.ts
@@ -1,56 +1,69 @@
-import admin from 'firebase-admin'
-import { Timestamp } from 'firebase/firestore'
+import { FirestoreDocumentStore } from '../adapters/storage/firestore-document-store.js'
+import type { DocumentStore } from '../ports/document-store.js'
+import { getDefaultWidgetUserId } from '../config/backend-paths.js'
+import { toDateOrDefault, toUserWidgetContentPath } from './widget-document-store.js'
 
-const getInstagramWidgetContent = async userId => {
-  const db = admin.firestore()
-  const collectionName = `users/${userId}/instagram`
-  const doc = await db.collection(collectionName).doc('widget-content').get()
+const defaultDocumentStore = new FirestoreDocumentStore()
 
-  try {
-    const data = doc.data()
-
-    const {
-      meta,
-      media,
-      profile: {
-        biography = '',
-        followersCount = 0,
-        mediaCount = 0,
-        username = '',
-      } = {}
-    } = data
-
-    return {
-      collections: {
-        media,
-      },
-      meta: {
-        synced: new Timestamp(meta.synced._seconds, meta.synced._nanoseconds).toDate()
-      },
-      metrics: [
-        {
-          displayName: 'Followers',
-          id: 'followers-count',
-          value: followersCount,
-        },
-        {
-          displayName: 'Posts',
-          id: 'media-count',
-          value: mediaCount,
-        },
-      ],
-      provider: {
-        displayName: 'Instagram',
-        id: 'instagram',
-      },
-      profile: {
-        biography,
-        displayName: username,
-        profileURL: `https://www.instagram.com/${username}`,
-      },
+const getInstagramWidgetContent = async (
+  userId: string = getDefaultWidgetUserId(),
+  documentStore: DocumentStore = defaultDocumentStore
+) => {
+  const instagramWidgetContentPath = toUserWidgetContentPath(userId, 'instagram')
+  const data = await documentStore.getDocument<{
+    media?: unknown[]
+    meta?: { synced?: unknown }
+    profile?: {
+      biography?: string
+      followersCount?: number
+      mediaCount?: number
+      username?: string
     }
-  } catch {
+  }>(instagramWidgetContentPath)
+
+  if (!data) {
     throw new Error('Failed to get a response.')
+  }
+
+  const {
+    meta = {},
+    media,
+    profile: {
+      biography = '',
+      followersCount = 0,
+      mediaCount = 0,
+      username = '',
+    } = {},
+  } = data
+
+  return {
+    collections: {
+      media,
+    },
+    meta: {
+      synced: toDateOrDefault(meta.synced),
+    },
+    metrics: [
+      {
+        displayName: 'Followers',
+        id: 'followers-count',
+        value: followersCount,
+      },
+      {
+        displayName: 'Posts',
+        id: 'media-count',
+        value: mediaCount,
+      },
+    ],
+    provider: {
+      displayName: 'Instagram',
+      id: 'instagram',
+    },
+    profile: {
+      biography,
+      displayName: username,
+      profileURL: `https://www.instagram.com/${username}`,
+    },
   }
 }
 

--- a/functions/widgets/get-spotify-widget-content.test.ts
+++ b/functions/widgets/get-spotify-widget-content.test.ts
@@ -1,131 +1,127 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import admin from 'firebase-admin'
-import { Timestamp } from 'firebase/firestore'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { DocumentStore } from '../ports/document-store.js'
 import getSpotifyWidgetContent from './get-spotify-widget-content.js'
 
-// Mock firebase-admin
-vi.mock('firebase-admin', () => ({
-  default: {
-    firestore: vi.fn(() => ({
-      collection: vi.fn(() => ({
-        doc: vi.fn(() => ({
-          get: vi.fn()
-        }))
-      }))
-    }))
-  }
-}))
-
 describe('getSpotifyWidgetContent', () => {
-  let mockGet
-  let mockDoc
-  let mockCollection
-  let mockFirestore
+  let documentStore: DocumentStore
 
   beforeEach(() => {
-    vi.clearAllMocks()
-    
-    mockGet = vi.fn()
-    mockDoc = vi.fn(() => ({ get: mockGet }))
-    mockCollection = vi.fn(() => ({ doc: mockDoc }))
-    mockFirestore = vi.fn(() => ({ collection: mockCollection }))
-    
-    admin.firestore = mockFirestore
+    documentStore = {
+      getDocument: vi.fn(),
+      setDocument: vi.fn(),
+    }
   })
 
   it('should return properly formatted widget content', async () => {
-    const mockData = {
+    vi.mocked(documentStore.getDocument).mockResolvedValue({
       meta: {
         synced: {
           _seconds: 1640995200,
-          _nanoseconds: 0
-        }
+          _nanoseconds: 0,
+        },
       },
       collections: {
         playlists: [
           {
             id: 'playlist1',
             name: 'Test Playlist',
-            images: [{ url: 'https://example.com/image.jpg' }]
-          }
+            images: [{ url: 'https://example.com/image.jpg' }],
+          },
         ],
         topTracks: [
           {
             id: 'track1',
             name: 'Test Track',
-            artists: [{ name: 'Test Artist' }]
-          }
-        ]
+            artists: [{ name: 'Test Artist' }],
+          },
+        ],
       },
       metrics: [
         {
           displayName: 'Followers',
           id: 'followers-count',
-          value: 1000
-        }
+          value: 1000,
+        },
       ],
       profile: {
         displayName: 'Test User',
         id: 'user123',
-        profileURL: 'https://open.spotify.com/user/user123'
-      }
-    }
-
-    mockGet.mockResolvedValue({
-      data: () => mockData
+        profileURL: 'https://open.spotify.com/user/user123',
+      },
     })
 
-    const result = await getSpotifyWidgetContent()
+    const result = await getSpotifyWidgetContent('chrisvogt', documentStore)
 
     expect(result).toEqual({
-      collections: mockData.collections,
-      metrics: mockData.metrics,
-      profile: mockData.profile,
+      collections: {
+        playlists: [
+          {
+            id: 'playlist1',
+            name: 'Test Playlist',
+            images: [{ url: 'https://example.com/image.jpg' }],
+          },
+        ],
+        topTracks: [
+          {
+            id: 'track1',
+            name: 'Test Track',
+            artists: [{ name: 'Test Artist' }],
+          },
+        ],
+      },
+      metrics: [
+        {
+          displayName: 'Followers',
+          id: 'followers-count',
+          value: 1000,
+        },
+      ],
+      profile: {
+        displayName: 'Test User',
+        id: 'user123',
+        profileURL: 'https://open.spotify.com/user/user123',
+      },
       meta: {
-        synced: new Timestamp(1640995200, 0).toDate()
-      }
+        synced: new Date('2022-01-01T00:00:00.000Z'),
+      },
     })
 
-    expect(mockFirestore).toHaveBeenCalled()
-    expect(mockCollection).toHaveBeenCalledWith('users/chrisvogt/spotify')
-    expect(mockDoc).toHaveBeenCalledWith('widget-content')
-    expect(mockGet).toHaveBeenCalled()
+    expect(documentStore.getDocument).toHaveBeenCalledWith('users/chrisvogt/spotify/widget-content')
   })
 
   it('should handle missing data gracefully', async () => {
-    const mockData = {
+    vi.mocked(documentStore.getDocument).mockResolvedValue({
       meta: {
         synced: {
           _seconds: 1640995200,
-          _nanoseconds: 0
-        }
-      }
-    }
-
-    mockGet.mockResolvedValue({
-      data: () => mockData
+          _nanoseconds: 0,
+        },
+      },
     })
 
-    const result = await getSpotifyWidgetContent()
+    const result = await getSpotifyWidgetContent('chrisvogt', documentStore)
 
     expect(result).toEqual({
       meta: {
-        synced: new Timestamp(1640995200, 0).toDate()
-      }
+        synced: new Date('2022-01-01T00:00:00.000Z'),
+      },
     })
   })
 
   it('should throw error when data retrieval fails', async () => {
-    mockGet.mockResolvedValue({
-      data: () => null
-    })
+    vi.mocked(documentStore.getDocument).mockResolvedValue(null)
 
-    await expect(getSpotifyWidgetContent()).rejects.toThrow()
+    await expect(getSpotifyWidgetContent('chrisvogt', documentStore)).rejects.toThrow(
+      'No Spotify data found in DocumentStore'
+    )
   })
 
-  it('should throw error when get() throws', async () => {
-    mockGet.mockRejectedValue(new Error('Database error'))
+  it('should throw error when document store rejects', async () => {
+    vi.mocked(documentStore.getDocument).mockRejectedValue(new Error('Database error'))
 
-    await expect(getSpotifyWidgetContent()).rejects.toThrow('Database error')
+    await expect(getSpotifyWidgetContent('chrisvogt', documentStore)).rejects.toThrow(
+      'Database error'
+    )
   })
-}) 
+})

--- a/functions/widgets/get-spotify-widget-content.ts
+++ b/functions/widgets/get-spotify-widget-content.ts
@@ -1,20 +1,31 @@
-import admin from 'firebase-admin'
-import { Timestamp } from 'firebase/firestore'
-import { toProviderCollectionPath } from '../config/backend-paths.js'
+import { FirestoreDocumentStore } from '../adapters/storage/firestore-document-store.js'
+import type { DocumentStore } from '../ports/document-store.js'
+import { getDefaultWidgetUserId } from '../config/backend-paths.js'
+import { toDateOrDefault, toUserWidgetContentPath } from './widget-document-store.js'
 
-const getSpotifyWidgetContent = async () => {
-  const db = admin.firestore()
-  const doc = await db.collection(toProviderCollectionPath('spotify')).doc('widget-content').get()
-  const { meta, ...responseData } = doc.data()
+const defaultDocumentStore = new FirestoreDocumentStore()
 
-  const transformedMeta = {
-    ...meta,
-    synced: new Timestamp(meta.synced._seconds, meta.synced._nanoseconds).toDate()
+const getSpotifyWidgetContent = async (
+  userId: string = getDefaultWidgetUserId(),
+  documentStore: DocumentStore = defaultDocumentStore
+) => {
+  const spotifyWidgetContentPath = toUserWidgetContentPath(userId, 'spotify')
+  const data = await documentStore.getDocument<{
+    meta?: { synced?: unknown }
+  } & Record<string, unknown>>(spotifyWidgetContentPath)
+
+  if (!data) {
+    throw new Error('No Spotify data found in DocumentStore')
   }
+
+  const { meta = {}, ...responseData } = data
 
   return {
     ...responseData,
-    meta: transformedMeta
+    meta: {
+      ...meta,
+      synced: toDateOrDefault(meta.synced),
+    },
   }
 }
 

--- a/functions/widgets/get-steam-widget-content.test.ts
+++ b/functions/widgets/get-steam-widget-content.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { DocumentStore } from '../ports/document-store.js'
+import getSteamWidgetContent from './get-steam-widget-content.js'
+
+describe('getSteamWidgetContent', () => {
+  let documentStore: DocumentStore
+
+  beforeEach(() => {
+    documentStore = {
+      getDocument: vi.fn(),
+      setDocument: vi.fn(),
+    }
+  })
+
+  it('should return properly formatted widget content', async () => {
+    vi.mocked(documentStore.getDocument).mockResolvedValue({
+      meta: {
+        synced: {
+          _seconds: 1640995200,
+          _nanoseconds: 0,
+        },
+      },
+      collections: {
+        recentlyPlayedGames: [{ id: 1, name: 'Half-Life' }],
+      },
+      metrics: [{ displayName: 'Games', id: 'owned-games', value: 42 }],
+    })
+
+    const result = await getSteamWidgetContent('chrisvogt', documentStore)
+
+    expect(result).toEqual({
+      collections: {
+        recentlyPlayedGames: [{ id: 1, name: 'Half-Life' }],
+      },
+      metrics: [{ displayName: 'Games', id: 'owned-games', value: 42 }],
+      meta: {
+        synced: new Date('2022-01-01T00:00:00.000Z'),
+      },
+    })
+
+    expect(documentStore.getDocument).toHaveBeenCalledWith('users/chrisvogt/steam/widget-content')
+  })
+
+  it('should return the default synced date when no document exists', async () => {
+    vi.mocked(documentStore.getDocument).mockResolvedValue(null)
+
+    const result = await getSteamWidgetContent('chrisvogt', documentStore)
+
+    expect(result).toEqual({
+      meta: { synced: new Date(0) },
+    })
+  })
+
+  it('should default the synced date when metadata is missing', async () => {
+    vi.mocked(documentStore.getDocument).mockResolvedValue({
+      collections: {
+        recentlyPlayedGames: [],
+      },
+    })
+
+    const result = await getSteamWidgetContent('chrisvogt', documentStore)
+
+    expect(result).toEqual({
+      collections: {
+        recentlyPlayedGames: [],
+      },
+      meta: {
+        synced: new Date(0),
+      },
+    })
+  })
+})

--- a/functions/widgets/get-steam-widget-content.ts
+++ b/functions/widgets/get-steam-widget-content.ts
@@ -1,32 +1,31 @@
-import admin from 'firebase-admin'
-import { Timestamp } from 'firebase/firestore'
-import { toProviderCollectionPath } from '../config/backend-paths.js'
+import { FirestoreDocumentStore } from '../adapters/storage/firestore-document-store.js'
+import type { DocumentStore } from '../ports/document-store.js'
+import { getDefaultWidgetUserId } from '../config/backend-paths.js'
+import { toDateOrDefault, toUserWidgetContentPath } from './widget-document-store.js'
 
-const getSteamWidgetContent = async () => {
-  const db = admin.firestore()
-  const doc = await db
-    .collection(toProviderCollectionPath('steam'))
-    .doc('widget-content')
-    .get()
+const defaultDocumentStore = new FirestoreDocumentStore()
 
-  const data = doc.data()
+const getSteamWidgetContent = async (
+  userId: string = getDefaultWidgetUserId(),
+  documentStore: DocumentStore = defaultDocumentStore
+) => {
+  const steamWidgetContentPath = toUserWidgetContentPath(userId, 'steam')
+  const data = await documentStore.getDocument<{
+    meta?: { synced?: unknown }
+  } & Record<string, unknown>>(steamWidgetContentPath)
+
   if (!data) {
     return { meta: { synced: new Date(0) } }
   }
 
   const { meta = {}, ...responseData } = data
 
-  const transformedMeta = {
-    ...meta,
-    synced: new Timestamp(
-      meta.synced._seconds,
-      meta.synced._nanoseconds
-    ).toDate(),
-  }
-
   return {
     ...responseData,
-    meta: transformedMeta,
+    meta: {
+      ...meta,
+      synced: toDateOrDefault(meta.synced),
+    },
   }
 }
 

--- a/functions/widgets/get-widget-content.test.ts
+++ b/functions/widgets/get-widget-content.test.ts
@@ -142,6 +142,46 @@ describe('getWidgetContent', () => {
     expect(result).toEqual(mockContent)
   })
 
+  it('should pass the document store to discogs widget content when provided', async () => {
+    const mockContent = { collections: { releases: [] } }
+    getDiscogsWidgetContent.mockResolvedValue(mockContent)
+
+    const result = await getWidgetContent('discogs', 'user123', documentStore)
+
+    expect(getDiscogsWidgetContent).toHaveBeenCalledWith('user123', documentStore)
+    expect(result).toEqual(mockContent)
+  })
+
+  it('should pass the document store to instagram widget content when provided', async () => {
+    const mockContent = { collections: { media: [] } }
+    getInstagramWidgetContent.mockResolvedValue(mockContent)
+
+    const result = await getWidgetContent('instagram', 'user123', documentStore)
+
+    expect(getInstagramWidgetContent).toHaveBeenCalledWith('user123', documentStore)
+    expect(result).toEqual(mockContent)
+  })
+
+  it('should pass the document store to spotify widget content when provided', async () => {
+    const mockContent = { collections: { topTracks: [] } }
+    getSpotifyWidgetContent.mockResolvedValue(mockContent)
+
+    const result = await getWidgetContent('spotify', 'user123', documentStore)
+
+    expect(getSpotifyWidgetContent).toHaveBeenCalledWith('user123', documentStore)
+    expect(result).toEqual(mockContent)
+  })
+
+  it('should pass the document store to steam widget content when provided', async () => {
+    const mockContent = { collections: { recentlyPlayedGames: [] } }
+    getSteamWidgetContent.mockResolvedValue(mockContent)
+
+    const result = await getWidgetContent('steam', 'user123', documentStore)
+
+    expect(getSteamWidgetContent).toHaveBeenCalledWith('user123', documentStore)
+    expect(result).toEqual(mockContent)
+  })
+
   it('should throw error for unrecognized widget type', async () => {
     await expect(getWidgetContent('invalid', 'user123')).rejects.toThrow(
       'Unrecognized widget type: invalid'


### PR DESCRIPTION
## Summary

This PR addresses `#125` by moving the remaining Firestore-backed widget read paths onto the shared `DocumentStore` boundary.

Discogs, Instagram, Spotify, and Steam widget readers now resolve their `widget-content` documents through the same storage seam already used by Goodreads and Flickr. This keeps public widget reads provider-neutral, reduces Firebase-specific data access in request-time code, and bumps the functions package to `0.22.10`.

Closes #125
Related to #114
Related to #115

## What Changed

- updated `functions/widgets/get-discogs-widget-content.ts`
  - now reads from `DocumentStore`
  - uses shared widget document path helpers
  - preserves existing response shape and meta date handling
- updated `functions/widgets/get-instagram-widget-content.ts`
  - now reads from `DocumentStore`
  - uses shared widget document path helpers
  - preserves existing response shape and fallback behavior
- updated `functions/widgets/get-spotify-widget-content.ts`
  - now reads from `DocumentStore`
  - uses shared widget document path helpers
  - preserves existing response shape and meta date handling
- updated `functions/widgets/get-steam-widget-content.ts`
  - now reads from `DocumentStore`
  - uses shared widget document path helpers
  - preserves the existing empty-state fallback
- added `functions/widgets/get-steam-widget-content.test.ts`
- replaced Firestore-mocked widget reader tests with `DocumentStore`-backed tests for:
  - `functions/widgets/get-discogs-widget-content.test.ts`
  - `functions/widgets/get-instagram-widget-content.test.ts`
  - `functions/widgets/get-spotify-widget-content.test.ts`
- expanded `functions/widgets/get-widget-content.test.ts`
  - verifies `DocumentStore` is passed through the widget dispatcher for the migrated providers
- bumped `functions/package.json` to `0.22.10`
- added a `0.22.10` changelog entry

## Why

We’ve already isolated runtime config and Firebase bootstrap. The next portability win is to get request-time widget reads off direct Firestore access and onto the shared storage abstraction.

This PR makes the widget API route depend on a consistent storage contract rather than provider-specific Firestore calls, which moves the backend closer to a provider-neutral core and sets up the broader remaining document migration work in `#115`.

## Issues Impacted

- `#125` solved directly
- `#114` advanced as part of the backend portability/decoupling track
- `#115` positively impacted because the public widget read path now demonstrates the `DocumentStore` migration pattern for additional backend reads and writes

## Testing

- `cd functions && /Users/chrisvogt/.nvm/versions/node/v24.13.0/bin/node node_modules/typescript/bin/tsc --noEmit`
- `cd functions && /Users/chrisvogt/.nvm/versions/node/v24.13.0/bin/node node_modules/vitest/vitest.mjs run widgets/get-discogs-widget-content.test.ts widgets/get-instagram-widget-content.test.ts widgets/get-spotify-widget-content.test.ts widgets/get-steam-widget-content.test.ts widgets/get-goodreads-widget-content.test.ts widgets/get-flickr-widget-content.test.ts widgets/get-widget-content.test.ts`
- `cd functions && /Users/chrisvogt/.nvm/versions/node/v24.13.0/bin/node node_modules/vitest/vitest.mjs run widgets/get-discogs-widget-content.test.ts widgets/get-instagram-widget-content.test.ts widgets/get-spotify-widget-content.test.ts widgets/get-steam-widget-content.test.ts widgets/get-goodreads-widget-content.test.ts widgets/get-flickr-widget-content.test.ts widgets/get-widget-content.test.ts --coverage --coverage.reporter=text`

## Verification

- manually tested widget reads for Flickr, Steam, and Spotify after the refactor
- focused widget suite passes: `46` tests across `7` files
- touched widget reader files reach full line coverage in the focused coverage run

## Notes

- The broad `functions` suite still hits the existing sandbox-only Supertest `listen EPERM 0.0.0.0` issue for `index.test.ts` and `app/create-express-app.test.ts` in this environment, so this PR uses targeted verification around the migrated widget read seam.
- This PR intentionally does not migrate the remaining non-widget backend Firestore reads/writes; that follow-on work remains in `#115`.
