### PR TITLE
chore: updates pnpm and GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: "pnpm"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,16 +35,18 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Install dependencies for both functions and hosting so CodeQL can resolve imports.
       - name: Install pnpm
         if: matrix.language == 'javascript-typescript'
         uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.1
 
       - name: Setup Node.js
         if: matrix.language == 'javascript-typescript'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: "pnpm"

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -16,13 +16,15 @@ jobs:
     if: ${{ false }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: "pnpm"

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -13,13 +13,15 @@ jobs:
     if: ${{ false && github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
+        with:
+          version: 10.32.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: "pnpm"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This repository contains a Firebase-backed service I use to fetch and sync data 
 ### Prerequisites
 
 - **Node.js** (version in [.nvmrc](./.nvmrc), e.g. 24)
-- **pnpm** (e.g. `corepack enable && corepack prepare pnpm@9.15.0 --activate`, or see [pnpm.io](https://pnpm.io/installation))
+- **pnpm** (e.g. `corepack enable && corepack prepare pnpm@10.32.1 --activate`, or see [pnpm.io](https://pnpm.io/installation))
 - **Firebase CLI** (`pnpm add -g firebase-tools` or `npm install -g firebase-tools`)
 - **Firebase project** and `firebase login`
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "metrics",
   "private": true,
   "description": "Personal metrics – Firebase Hosting + Cloud Functions",
-  "packageManager": "pnpm@10.30.3+sha512.c961d1e0a2d8e354ecaa5166b822516668b7f44cb5bd95122d590dd81922f606f5473b6d23ec4a5be05e7fcd18e8488d47d978bbe981872f1145d06e9a740017",
+  "packageManager": "pnpm@10.32.1",
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev",


### PR DESCRIPTION
## Summary

Updates the repo pnpm pin and refreshes GitHub Actions workflow dependencies to remove the old runtime warning from CI.

This keeps local tooling, package manager expectations, and workflow setup aligned around the current Node 24 / pnpm 10 toolchain.

## What changed

- bumped the root `packageManager` pin to `pnpm@10.32.1`
- updated the README pnpm install example to match the new pin
- upgraded workflow actions from:
  - `actions/checkout@v4` -> `actions/checkout@v5`
  - `actions/setup-node@v4` -> `actions/setup-node@v5`
- added an explicit `version: 10.32.1` to `pnpm/action-setup@v4` in all active workflows

## Why

The workflows were still producing warnings from older GitHub Action runtime dependencies even though the project itself already targets Node 24.

Pinning pnpm more explicitly and updating the workflow action versions should make CI quieter and keep the automation environment closer to local development.

## Files changed

- `package.json`
- `README.md`
- `.github/workflows/ci.yml`
- `.github/workflows/codeql.yml`
- `.github/workflows/deploy-preview.yml`
- `.github/workflows/firebase-hosting-pull-request.yml`

## Notes

Local developers may want to sync their pnpm version with the new repo pin:

```bash
corepack enable
corepack prepare pnpm@10.32.1 --activate
pnpm --version
