### PR TITLE
fix(functions): avoid eager media bootstrap startup

### DIFF
--- a/functions/app/create-express-app.route-coverage.test.ts
+++ b/functions/app/create-express-app.route-coverage.test.ts
@@ -106,7 +106,7 @@ describe('createExpressApp route coverage', () => {
       ensureRuntimeConfigApplied,
       getClientAuthConfig,
       logger,
-      mediaStore: new LocalDiskMediaStore('/tmp/metrics-unused-route-coverage'),
+      resolveMediaStore: () => new LocalDiskMediaStore('/tmp/metrics-unused-route-coverage'),
     })
 
     const clientAuthHandler = findRouteHandler(app, 'get', '/api/client-auth-config')
@@ -145,7 +145,7 @@ describe('createExpressApp route coverage', () => {
       ensureRuntimeConfigApplied,
       getClientAuthConfig,
       logger,
-      mediaStore: new LocalDiskMediaStore('/tmp/metrics-unused-route-coverage'),
+      resolveMediaStore: () => new LocalDiskMediaStore('/tmp/metrics-unused-route-coverage'),
     })
     const syncRouteHandler = findRouteHandler(app, 'get', '/api/widgets/sync/:provider')
     const response = createResponse()

--- a/functions/app/create-express-app.test.ts
+++ b/functions/app/create-express-app.test.ts
@@ -74,7 +74,8 @@ describe('createExpressApp media route', () => {
       ensureRuntimeConfigApplied: vi.fn().mockResolvedValue(undefined),
       getClientAuthConfig: vi.fn(() => ({})),
       logger,
-      mediaStore: new LocalDiskMediaStore(path.join(os.tmpdir(), 'metrics-unused-media-root')),
+      resolveMediaStore: () =>
+        new LocalDiskMediaStore(path.join(os.tmpdir(), 'metrics-unused-media-root')),
     })
   }
 
@@ -94,11 +95,11 @@ describe('createExpressApp media route', () => {
       ensureRuntimeConfigApplied: vi.fn().mockResolvedValue(undefined),
       getClientAuthConfig: vi.fn(() => ({})),
       logger,
-      mediaStore: {
+      resolveMediaStore: () => ({
         describe: () => ({ backend: 'gcs', target: 'bucket' }),
         fetchAndStore: vi.fn(),
         listFiles: vi.fn(),
-      },
+      }),
     })
 
     await request(app)
@@ -122,11 +123,11 @@ describe('createExpressApp media route', () => {
       ensureRuntimeConfigApplied: vi.fn().mockResolvedValue(undefined),
       getClientAuthConfig: vi.fn(() => ({})),
       logger,
-      mediaStore: {
+      resolveMediaStore: () => ({
         describe: () => ({ backend: 'gcs', target: '/tmp/not-local' }),
         fetchAndStore: vi.fn(),
         listFiles: vi.fn(),
-      },
+      }),
     })
 
     await request(app)
@@ -148,7 +149,7 @@ describe('createExpressApp media route', () => {
       ensureRuntimeConfigApplied: vi.fn().mockResolvedValue(undefined),
       getClientAuthConfig: vi.fn(() => ({})),
       logger,
-      mediaStore,
+      resolveMediaStore: () => mediaStore,
     })
 
     await request(routeApp)
@@ -166,7 +167,7 @@ describe('createExpressApp media route', () => {
       ensureRuntimeConfigApplied: vi.fn().mockResolvedValue(undefined),
       getClientAuthConfig: vi.fn(() => ({})),
       logger,
-      mediaStore,
+      resolveMediaStore: () => mediaStore,
     })
 
     const existingPath = path.join(rootDir, 'cover.jpg')
@@ -191,7 +192,7 @@ describe('createExpressApp media route', () => {
       ensureRuntimeConfigApplied: vi.fn().mockResolvedValue(undefined),
       getClientAuthConfig: vi.fn(() => ({})),
       logger,
-      mediaStore,
+      resolveMediaStore: () => mediaStore,
     })
 
     fs.mkdirSync(path.join(rootDir, 'folder'))
@@ -211,7 +212,7 @@ describe('createExpressApp media route', () => {
       ensureRuntimeConfigApplied: vi.fn().mockResolvedValue(undefined),
       getClientAuthConfig: vi.fn(() => ({})),
       logger,
-      mediaStore,
+      resolveMediaStore: () => mediaStore,
     })
 
     fs.writeFileSync(path.join(rootDir, 'cover.jpg'), 'file-bytes')
@@ -270,7 +271,8 @@ describe('createExpressApp auth and session branches', () => {
       ensureRuntimeConfigApplied,
       getClientAuthConfig,
       logger,
-      mediaStore: new LocalDiskMediaStore(path.join(os.tmpdir(), 'metrics-unused-auth-media')),
+      resolveMediaStore: () =>
+        new LocalDiskMediaStore(path.join(os.tmpdir(), 'metrics-unused-auth-media')),
     })
   }
 

--- a/functions/app/create-express-app.ts
+++ b/functions/app/create-express-app.ts
@@ -35,7 +35,7 @@ interface CreateExpressAppOptions {
   ensureRuntimeConfigApplied: () => Promise<void>
   getClientAuthConfig: () => Record<string, string | undefined>
   logger: LoggerLike
-  mediaStore: MediaStore
+  resolveMediaStore: () => MediaStore
 }
 
 const rateLimitMessage = { ok: false, error: 'Too many requests. Please try again later.' }
@@ -88,7 +88,7 @@ export function createExpressApp({
   ensureRuntimeConfigApplied,
   getClientAuthConfig,
   logger,
-  mediaStore,
+  resolveMediaStore,
 }: CreateExpressAppOptions): express.Express {
   const expressApp = express()
 
@@ -267,6 +267,7 @@ export function createExpressApp({
     cors(corsOptions),
     createRateLimiter(15 * 60 * 1000, 100),
     async (req, res) => {
+      const mediaStore = resolveMediaStore()
       if (!(mediaStore instanceof LocalDiskMediaStore)) {
         res.sendStatus(404)
         return

--- a/functions/bootstrap/create-backend-bootstrap.test.ts
+++ b/functions/bootstrap/create-backend-bootstrap.test.ts
@@ -22,18 +22,8 @@ const getMediaStoreMock = vi.hoisted(() =>
     listFiles: vi.fn(),
   }))
 )
-const createMediaServiceMock = vi.hoisted(() =>
-  vi.fn(() => ({
-    describe: vi.fn(() => ({ backend: 'gcs', target: 'bucket' })),
-    listStoredMedia: vi.fn(),
-    storeRemoteMedia: vi.fn(),
-    toPublicMediaUrl: vi.fn((mediaPath: string) => mediaPath),
-  }))
-)
-const configureMediaServiceMock = vi.hoisted(() => vi.fn())
 const configureClockMock = vi.hoisted(() => vi.fn())
 const configureLoggerMock = vi.hoisted(() => vi.fn())
-const getStorageConfigMock = vi.hoisted(() => vi.fn(() => ({ mediaPublicBaseUrl: 'https://cdn.test' })))
 const getClientAuthConfigMock = vi.hoisted(() =>
   vi.fn(() => ({ apiKey: 'public-key', authDomain: 'auth.test', projectId: 'project-id' }))
 )
@@ -72,7 +62,6 @@ vi.mock('../config/runtime-config.js', () => ({
 
 vi.mock('../config/backend-config.js', () => ({
   getClientAuthConfig: getClientAuthConfigMock,
-  getStorageConfig: getStorageConfigMock,
   isProductionEnvironment: isProductionEnvironmentMock,
 }))
 
@@ -99,11 +88,6 @@ vi.mock('../runtime/firebase-functions-runtime.js', () => ({
 vi.mock('../selectors/media-store.js', () => ({
   getMediaStore: getMediaStoreMock,
   resetMediaStoreForTests: resetMediaStoreForTestsMock,
-}))
-
-vi.mock('../services/media/media-service.js', () => ({
-  configureMediaService: configureMediaServiceMock,
-  createMediaService: createMediaServiceMock,
 }))
 
 vi.mock('../services/clock.js', () => ({
@@ -146,15 +130,9 @@ describe('createBackendBootstrap', () => {
     expect(process.env.MEDIA_STORE_BACKEND).toBe('gcs')
     expect(firestoreDocumentStoreCtorMock).toHaveBeenCalledTimes(1)
     expect(firebaseAuthServiceCtorMock).toHaveBeenCalledWith(adminModuleMock)
-    expect(getMediaStoreMock).toHaveBeenCalledTimes(1)
-    expect(getStorageConfigMock).toHaveBeenCalledTimes(1)
-    expect(createMediaServiceMock).toHaveBeenCalledWith(
-      getMediaStoreMock.mock.results[0]?.value,
-      'https://cdn.test'
-    )
     expect(configureClockMock).toHaveBeenCalledWith(bootstrap.clock)
     expect(configureLoggerMock).toHaveBeenCalledWith(firebaseLoggerMock)
-    expect(configureMediaServiceMock).toHaveBeenCalledWith(bootstrap.mediaService)
+    expect(bootstrap.resolveMediaStore).toBe(getMediaStoreMock)
     expect(bootstrap.getClientAuthConfig()).toEqual({
       apiKey: 'public-key',
       authDomain: 'auth.test',

--- a/functions/bootstrap/create-backend-bootstrap.ts
+++ b/functions/bootstrap/create-backend-bootstrap.ts
@@ -1,4 +1,5 @@
 import admin from 'firebase-admin'
+import { existsSync } from 'fs'
 import { logger as firebaseLogger } from 'firebase-functions'
 import path from 'path'
 import { fileURLToPath } from 'url'
@@ -7,7 +8,6 @@ import { FirebaseAuthService } from '../adapters/auth/firebase-auth-service.js'
 import { FirestoreDocumentStore } from '../adapters/storage/firestore-document-store.js'
 import {
   getClientAuthConfig,
-  getStorageConfig,
   isProductionEnvironment,
 } from '../config/backend-config.js'
 import {
@@ -16,16 +16,10 @@ import {
 } from '../config/runtime-config.js'
 import type { Clock } from '../ports/clock.js'
 import type { DocumentStore } from '../ports/document-store.js'
-import type { MediaStore } from '../ports/media-store.js'
 import type { RuntimePlatform } from '../ports/runtime-platform.js'
 import { configureClock } from '../services/clock.js'
 import { configureLogger } from '../services/logger.js'
-import {
-  configureMediaService,
-  createMediaService,
-  type MediaService,
-} from '../services/media/media-service.js'
-import { getMediaStore, resetMediaStoreForTests } from '../selectors/media-store.js'
+import { resetMediaStoreForTests, getMediaStore } from '../selectors/media-store.js'
 import { getSelectedProviders } from './provider-selection.js'
 import {
   firebaseRuntimeConfigSource,
@@ -59,14 +53,24 @@ export interface BackendBootstrap {
   ensureRuntimeConfigApplied: () => Promise<void>
   getClientAuthConfig: () => Record<string, string | undefined>
   logger: typeof firebaseLogger
-  mediaService: MediaService
-  mediaStore: MediaStore
+  resolveMediaStore: typeof getMediaStore
   runtimePlatform: RuntimePlatform
   runtimeSecrets: unknown[]
 }
 
+const resolveLocalEnvPath = (): string => {
+  const candidates = [
+    path.resolve(process.cwd(), 'functions/.env'),
+    path.resolve(process.cwd(), '.env'),
+    path.resolve(__dirname, '../.env'),
+    path.resolve(__dirname, '../../functions/.env'),
+  ]
+
+  return candidates.find((candidate) => existsSync(candidate)) ?? candidates[0]
+}
+
 export const createBackendBootstrap = (): BackendBootstrap => {
-  bootstrapLocalRuntimeEnv(path.resolve(__dirname, '../.env'))
+  bootstrapLocalRuntimeEnv(resolveLocalEnvPath())
 
   const selectedProviders = getSelectedProviders()
 
@@ -84,13 +88,10 @@ export const createBackendBootstrap = (): BackendBootstrap => {
   const logger = firebaseLogger
   const documentStore = new FirestoreDocumentStore()
   const authService = new FirebaseAuthService(admin)
-  const mediaStore = getMediaStore()
-  const mediaService = createMediaService(mediaStore, getStorageConfig().mediaPublicBaseUrl)
   const runtimeSecrets = getFirebaseRuntimeSecrets()
 
   configureClock(clock)
   configureLogger(logger)
-  configureMediaService(mediaService)
 
   return {
     authService,
@@ -100,8 +101,7 @@ export const createBackendBootstrap = (): BackendBootstrap => {
       ensureRuntimeConfigApplied(firebaseRuntimeConfigSource, logger.warn),
     getClientAuthConfig,
     logger,
-    mediaService,
-    mediaStore,
+    resolveMediaStore: getMediaStore,
     runtimePlatform: firebaseRuntimePlatform,
     runtimeSecrets,
   }

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -13,7 +13,7 @@ const {
   ensureRuntimeConfigApplied,
   getClientAuthConfig,
   logger,
-  mediaStore,
+  resolveMediaStore,
   runtimePlatform,
   runtimeSecrets,
 } = createBackendBootstrap()
@@ -24,7 +24,7 @@ export const expressApp = createExpressApp({
   ensureRuntimeConfigApplied,
   getClientAuthConfig,
   logger,
-  mediaStore,
+  resolveMediaStore,
 })
 
 export { getSessionAuthError }


### PR DESCRIPTION
## Summary

Fixes a deploy regression introduced by the provider-portability refactor.

The functions entrypoint was eagerly resolving the selected media store during module startup. In Firebase 2nd gen, that shifted provider/storage initialization into cold-start import time, which can take down every exported function if config-dependent wiring is touched too early. This PR restores a safer startup path by resolving the media store lazily at request time and by using a stable `.env` lookup path after build output moves files under `lib/`.

## Changes

- make `createExpressApp` accept `resolveMediaStore()` instead of a prebuilt `mediaStore`
- stop constructing the selected media adapter during backend bootstrap
- keep bootstrap/provider selection intact while avoiding eager media initialization on cold start
- make local `.env` resolution robust across source and built paths
- update focused bootstrap and route coverage tests to match the lazy resolver shape

## Why

Deploys started failing across all functions with Cloud Run healthcheck errors after the portability refactor. The shared failure mode strongly suggested a startup/import-time crash rather than a single handler issue. This change narrows the cold-start path back down and avoids touching media-provider wiring before runtime config has been applied.

## Verification

- `pnpm --filter metrics-functions build`
- `NODE_ENV=production node functions/lib/index.js`
- `pnpm --filter metrics-functions exec vitest run bootstrap/create-backend-bootstrap.test.ts app/create-express-app.route-coverage.test.ts services/clock.test.ts services/logger.test.ts utils/time.test.ts bootstrap/provider-selection.test.ts`

## Notes

- This is intentionally a narrow hotfix PR.
- The larger provider-portability work remains in [#155](https://github.com/chrisvogt/metrics/pull/155).
