### PR TITLE
fix(functions): restore CDN cacheability for widget GETs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Package-specific changes:
 
 ### Fixed
 
+- **Widget API (functions)** – Public `GET /api/widgets/:provider` responses no longer emit CSRF cookies, so Firebase Hosting / CDN can cache them per `Cache-Control` again. See [functions/CHANGELOG.md](functions/CHANGELOG.md) **0.22.17**.
 - **Auth routes (functions)** – `POST /api/auth/session` and `POST /api/auth/logout` are now rate-limited so all authorization routes satisfy CodeQL; session allows 20 req/15 min, logout 30 req/15 min.
 
 ## [Hosting 0.3.0] - 2026-03-06

--- a/functions/CHANGELOG.md
+++ b/functions/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.17] - 2026-03-19
+
+### Fixed
+
+- **Widget GET CDN caching** – Global `lusca` CSRF was calling `setToken` on every request, so `GET /api/widgets/:provider` responses included `Set-Cookie` (`_csrfSecret`, `XSRF-TOKEN`). Shared caches then refused to store them (`x-cache: MISS`) despite `Cache-Control: public, s-maxage`. Public widget reads are now on the CSRF `blocklist` (exact `/api/widgets/<id>` for each `widgetId`); `/api/widgets/sync/*` is unchanged. Tests assert no `set-cookie` on successful widget reads.
+
 ## [0.22.16] - 2026-03-18
 
 ### Changed

--- a/functions/app/create-express-app.ts
+++ b/functions/app/create-express-app.ts
@@ -14,7 +14,7 @@ import { isProductionEnvironment } from '../config/backend-config.js'
 import { LocalDiskMediaStore } from '../adapters/storage/local-disk-media-store.js'
 import { getRateLimitKey } from '../middleware/rate-limit-key.js'
 import type { WidgetContentUnion, WidgetId } from '../types/widget-content.js'
-import { isWidgetId } from '../types/widget-content.js'
+import { isWidgetId, widgetIds } from '../types/widget-content.js'
 import deleteUserJob from '../jobs/delete-user.js'
 import syncDiscogsDataJob from '../jobs/sync-discogs-data.js'
 import syncFlickrDataJob from '../jobs/sync-flickr-data.js'
@@ -70,6 +70,12 @@ const buildFailureResponse = (err: unknown = {}): { ok: false; error: string } =
 
 const ALLOWED_EMAIL_DOMAINS = ['@chrisvogt.me', '@chronogrove.com']
 const CSRF_SECRET_COOKIE = '_csrfSecret'
+
+/** Paths where lusca must not run: it sets Set-Cookie on every GET, which prevents CDN caching. */
+const CSRF_BLOCKLIST_WIDGET_READS = widgetIds.map((id) => ({
+  path: `/api/widgets/${id}`,
+  type: 'exact' as const,
+}))
 type ProviderSyncId = Exclude<WidgetId, 'github'>
 type ProviderSyncResult = { result: string } & Record<string, unknown>
 
@@ -236,6 +242,7 @@ export function createExpressApp({
     lusca.csrf({
       angular: true,
       secret: CSRF_SECRET_COOKIE,
+      blocklist: CSRF_BLOCKLIST_WIDGET_READS,
       impl: createCookieBackedCsrfImpl({
         httpOnly: true,
         sameSite: isProductionEnvironment() ? 'strict' : 'lax',

--- a/functions/index.test.ts
+++ b/functions/index.test.ts
@@ -163,6 +163,7 @@ describe('index.js', () => {
           payload: { mock: 'widget-content' }
         })
         expect(response.headers['cache-control']).toBe('public, max-age=3600, s-maxage=7200')
+        expect(response.headers['set-cookie']).toBeUndefined()
       })
 
       it('should return 404 for invalid provider', async () => {

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics-functions",
-  "version": "0.22.16",
+  "version": "0.22.17",
   "description": "Personal metrics API. A hobby project tracking my online metrics.",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
I noticed the widget content endpoints, which were previously resolving in 35-50ms, are now resolving around 200-500ms each. This PR skips lusca CSRF on exact public widget read paths so Set-Cookie is not sent; edge caches can honor Cache-Control again.

- metrics-functions 0.22.17
- Changelog: root + functions

Closes #171

Made-with: Cursor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global CSRF middleware configuration; misconfiguration could unintentionally skip CSRF on additional routes or reintroduce caching/cookie regressions. Scoped to exact `GET /api/widgets/<id>` paths and covered by a new header assertion test, reducing risk.
> 
> **Overview**
> Restores CDN/cacheability for public `GET /api/widgets/:provider` by adding a `lusca` CSRF `blocklist` for exact widget-read paths so responses no longer emit `Set-Cookie` headers.
> 
> Bumps Functions to `0.22.17`, updates changelogs, and extends the widget GET test to assert `set-cookie` is absent while preserving `Cache-Control`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df980abc9e3e9123c51ae3bf23bb1e7f11e1c047. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->