### PR TITLE
fix(goodreads): early slice to 30 books, display 24

### DIFF
--- a/functions/CHANGELOG.md
+++ b/functions/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Goodreads sync optimization** – Previously fetched 100 books from Goodreads, then called Google Books API and downloaded thumbnails for all of them, but only stored 18. Now fetches 30 books (per_page), processes only those 30 (early slice before pMap), and stores 24 for display. Reduces Google Books API usage and rate limiting. See [#175](https://github.com/chrisvogt/metrics/issues/175).
+
 ## [0.22.17] - 2026-03-19
 
 ### Fixed

--- a/functions/api/goodreads/fetch-recently-read-books.test.ts
+++ b/functions/api/goodreads/fetch-recently-read-books.test.ts
@@ -153,7 +153,7 @@ describe('fetchRecentlyReadBooks', () => {
 
     // Verify Goodreads API was called
     expect(mockGot).toHaveBeenCalledWith(
-      'https://www.goodreads.com/review/list/test-user-id.xml?key=test-api-key&v=2&shelf=read&sort=date_read&per_page=100'
+      'https://www.goodreads.com/review/list/test-user-id.xml?key=test-api-key&v=2&shelf=read&sort=date_read&per_page=30'
     )
 
     // Verify XML parsing was called

--- a/functions/api/goodreads/fetch-recently-read-books.ts
+++ b/functions/api/goodreads/fetch-recently-read-books.ts
@@ -11,6 +11,7 @@ import {
   getGoodreadsConfig,
   getGoogleBooksApiKey,
 } from '../../config/backend-config.js'
+import { GOODREADS_BOOKS_TO_FETCH } from '../../config/goodreads-config.js'
 
 import type {
   GoogleBooksVolumeSubset,
@@ -79,7 +80,7 @@ export default async () => {
   const { apiKey: key, userId: userID } = getGoodreadsConfig()
 
   const { body } = await got(
-    `https://www.goodreads.com/review/list/${userID}.xml?key=${key}&v=2&shelf=read&sort=date_read&per_page=100`
+    `https://www.goodreads.com/review/list/${userID}.xml?key=${key}&v=2&shelf=read&sort=date_read&per_page=${GOODREADS_BOOKS_TO_FETCH}`
   )
 
   let rawReviewsResponse: GoodreadsReviewListRawReview[] = []
@@ -158,6 +159,10 @@ export default async () => {
     })
   })
 
+  // Early slice: only fetch Google Books data and download thumbnails for books we'll use.
+  // Avoids unnecessary API calls and rate limiting.
+  const bookReviewsToProcess = bookReviews.slice(0, GOODREADS_BOOKS_TO_FETCH)
+
   // NOTE(chrisvogt): I'd like to eventually phase this out, or replace Goodreads
   // altogether. The Goodreads data is not very good, and is often lacking detailed
   // information. The Google Books data is really clean and useful. So, I'm currently
@@ -165,7 +170,7 @@ export default async () => {
   // Google Books.
   // Use pMap with concurrency control to avoid rate limiting
   const bookResults = await pMap(
-    bookReviews,
+    bookReviewsToProcess,
     async (book: GoodreadsReviewListBookSource, index: number) => {
       // Add a small delay between requests to avoid rate limiting (except for first request)
       if (index > 0) {

--- a/functions/config/goodreads-config.ts
+++ b/functions/config/goodreads-config.ts
@@ -1,0 +1,8 @@
+/**
+ * Goodreads widget configuration.
+ * BOOKS_TO_FETCH: Number of books to fetch from Goodreads and process (Google Books API, thumbnails).
+ *   Includes buffer for failures—some books may not be found or lack thumbnails.
+ * BOOKS_TO_DISPLAY: Number of books to store and display in the widget.
+ */
+export const GOODREADS_BOOKS_TO_FETCH = 30
+export const GOODREADS_BOOKS_TO_DISPLAY = 24

--- a/functions/jobs/sync-goodreads-data.ts
+++ b/functions/jobs/sync-goodreads-data.ts
@@ -15,6 +15,7 @@ import type { DocumentStore } from '../ports/document-store.js'
 import fetchBookFromGoogle from '../api/google-books/fetch-book.js'
 import { getGoogleBooksApiKey } from '../config/backend-config.js'
 import { toProviderCollectionPath } from '../config/backend-paths.js'
+import { GOODREADS_BOOKS_TO_DISPLAY } from '../config/goodreads-config.js'
 import { getLogger } from '../services/logger.js'
 import { toStoredDateTime } from '../utils/time.js'
 import { getXmlTextOrNull } from '../utils/goodreads-xml.js'
@@ -480,7 +481,7 @@ const fetchAllGoodreadsPromises = async (): Promise<FetchAllGoodreadsPromisesRes
 
     return {
       collections: {
-        recentlyReadBooks: (recentlyRead.books ?? []).slice(0, 18),
+        recentlyReadBooks: (recentlyRead.books ?? []).slice(0, GOODREADS_BOOKS_TO_DISPLAY),
         updates: processedUpdates,
       },
       profile: user.profile,


### PR DESCRIPTION
## Summary

Optimizes Goodreads sync to avoid unnecessary Google Books API calls and media downloads.

**Before:** Fetched 100 books from Goodreads, called Google Books API and downloaded thumbnails for all 100, then only stored 18.

**After:** Fetches 30 books (per_page), processes only those 30 (early slice before pMap), and stores 24 for display.

<img width="858" height="425" alt="Screenshot 2026-03-19 at 6 45 31 PM" src="https://github.com/user-attachments/assets/5ef44be7-c197-4e54-9074-813df1256762" />


## Changes

- Add `GOODREADS_BOOKS_TO_FETCH` (30) and `GOODREADS_BOOKS_TO_DISPLAY` (24) in `functions/config/goodreads-config.ts`
- Reduce Goodreads API `per_page` from 100 to 30
- Slice `bookReviews` before Google Books fetch and media download loops
- Store 24 books in widget content (up from 18)

## Verification

Manual verification in local environment confirmed 24 books display correctly.

Closes #175

Made with [Cursor](https://cursor.com)