### PR TITLE
fix(gcs): read bucket config at runtime to fix production sync jobs

### DIFF
--- a/functions/CHANGELOG.md
+++ b/functions/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Goodreads sync optimization** – Previously fetched 100 books from Goodreads, then called Google Books API and downloaded thumbnails for all of them, but only stored 18. Now fetches 30 books (per_page), processes only those 30 (early slice before pMap), and stores 24 for display. Reduces Google Books API usage and rate limiting. See [#175](https://github.com/chrisvogt/metrics/issues/175).
 
+## [0.22.18] - 2026-03-19
+
+### Fixed
+
+- **GCS bucket config timing** – `GcsMediaStore` previously read `CLOUD_STORAGE_IMAGES_BUCKET` from constants at module load time, before `FUNCTIONS_CONFIG_EXPORT` was applied. In production, the bucket was always undefined, causing "Bucket name not specified or invalid" on sync jobs. Now reads from `getStorageConfig()` at runtime (after the secret is loaded). If the bucket is still missing, throws a clearer error pointing to the secret. See [#177](https://github.com/chrisvogt/metrics/issues/177).
+
 ## [0.22.17] - 2026-03-19
 
 ### Fixed

--- a/functions/adapters/storage/gcs-media-store.test.ts
+++ b/functions/adapters/storage/gcs-media-store.test.ts
@@ -10,8 +10,8 @@ vi.mock('https', () => ({
   get: vi.fn(),
 }))
 
-vi.mock('../../config/constants.js', () => ({
-  CLOUD_STORAGE_IMAGES_BUCKET: 'test-bucket',
+vi.mock('../../config/backend-config.js', () => ({
+  getStorageConfig: vi.fn(() => ({ cloudStorageImagesBucket: 'test-bucket' })),
 }))
 
 import { GcsMediaStore } from './gcs-media-store.js'
@@ -97,5 +97,21 @@ describe('GcsMediaStore', () => {
       backend: 'gcs',
       target: 'test-bucket',
     })
+  })
+
+  it('throws when bucket is not configured', async () => {
+    const { getStorageConfig } = await import('../../config/backend-config.js')
+    vi.mocked(getStorageConfig).mockReturnValueOnce({
+      cloudStorageImagesBucket: undefined,
+      imageCdnBaseUrl: undefined,
+      localMediaRoot: '/tmp',
+      mediaPublicBaseUrl: undefined,
+      mediaStoreBackend: 'gcs',
+    } as ReturnType<typeof getStorageConfig>)
+
+    const adapterWithNoBucket = new GcsMediaStore()
+    await expect(adapterWithNoBucket.listFiles()).rejects.toThrow(
+      'Bucket name not specified or invalid. Set storage.cloud_storage_images_bucket in FUNCTIONS_CONFIG_EXPORT secret.'
+    )
   })
 })

--- a/functions/adapters/storage/gcs-media-store.ts
+++ b/functions/adapters/storage/gcs-media-store.ts
@@ -1,12 +1,22 @@
 import admin from 'firebase-admin'
 import https from 'https'
 
-import { CLOUD_STORAGE_IMAGES_BUCKET } from '../../config/constants.js'
+import { getStorageConfig } from '../../config/backend-config.js'
 import type { MediaDescriptor, MediaStore, StoredMedia } from '../../ports/media-store.js'
+
+function getBucketName(): string {
+  const bucket = getStorageConfig().cloudStorageImagesBucket
+  if (!bucket) {
+    throw new Error(
+      'Bucket name not specified or invalid. Set storage.cloud_storage_images_bucket in FUNCTIONS_CONFIG_EXPORT secret.'
+    )
+  }
+  return bucket
+}
 
 export class GcsMediaStore implements MediaStore {
   async listFiles(): Promise<string[]> {
-    const bucket = admin.storage().bucket(CLOUD_STORAGE_IMAGES_BUCKET)
+    const bucket = admin.storage().bucket(getBucketName())
     const [files] = await bucket.getFiles()
 
     return files.map(({ name }) => name)
@@ -19,7 +29,7 @@ export class GcsMediaStore implements MediaStore {
         return
       }
 
-      const bucket = admin.storage().bucket(CLOUD_STORAGE_IMAGES_BUCKET)
+      const bucket = admin.storage().bucket(getBucketName())
       const file = bucket.file(destinationPath)
 
       https.get(mediaURL, (res) => {
@@ -51,7 +61,7 @@ export class GcsMediaStore implements MediaStore {
   describe() {
     return {
       backend: 'gcs',
-      target: CLOUD_STORAGE_IMAGES_BUCKET ?? 'unknown-bucket',
+      target: getStorageConfig().cloudStorageImagesBucket ?? 'unknown-bucket',
     }
   }
 }

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics-functions",
-  "version": "0.22.17",
+  "version": "0.22.18",
   "description": "Personal metrics API. A hobby project tracking my online metrics.",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## Summary

Fixes production sync jobs failing with "Bucket name not specified or invalid".

`GcsMediaStore` previously read `CLOUD_STORAGE_IMAGES_BUCKET` from constants at module load time, before `FUNCTIONS_CONFIG_EXPORT` was applied. In production the bucket was always undefined.

Now reads from `getStorageConfig()` at runtime (after the secret is loaded). Throws a clearer error if the bucket is still missing.

## Changes

- `GcsMediaStore` uses `getStorageConfig()` at runtime instead of constants
- Added test for missing bucket configuration
- Bump to 0.22.18

Closes #177

Made with [Cursor](https://cursor.com)