### PR TITLE
Add Firebase agent skills for AI-assisted development

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,19 @@
+# Agent Skills
+
+Firebase agent skills for AI-assisted development (Cursor, etc.). These skills provide Firebase-specific knowledge, instructions, and workflows.
+
+## Install
+
+```bash
+pnpm dlx skills add firebase/agent-skills
+```
+
+Then select the skills you need from the interactive prompt. This project uses: firebase-basics, firebase-hosting-basics, firebase-auth-basics, firebase-firestore-standard, firebase-local-env-setup, and firebase-ai-logic.
+
+## Upgrade
+
+To update all installed skills to their latest versions:
+
+```bash
+pnpm dlx skills update --all
+```

--- a/.agents/skills/firebase-ai-logic/SKILL.md
+++ b/.agents/skills/firebase-ai-logic/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: firebase-ai-logic
+description: Official skill for integrating Firebase AI Logic (Gemini API) into web applications. Covers setup, multimodal inference, structured output, and security.
+version: 1.0.0
+---
+
+# Firebase AI Logic Basics
+
+## Overview
+
+Firebase AI Logic is a product of Firebase that allows developers to add gen AI to their mobile and web apps using client-side SDKs. You can call Gemini models directly from your app without managing a dedicated backend. Firebase AI Logic, which was previously known as "Vertex AI for Firebase", represents the evolution of Google's AI integration platform for mobile and web developers.
+
+It supports the two Gemini API providers:
+- **Gemini Developer API**: It has a free tier ideal for prototyping, and pay-as-you-go for production 
+- **Vertex AI Gemini API**: Ideal for scale with enterprise-grade production readiness, requires Blaze plan
+
+Use the Gemini Developer API as a default, and only Vertex AI Gemini API if the application requires it.
+
+## Setup & Initialization
+
+### Prerequisites
+
+- Before starting, ensure you have **Node.js 16+** and npm installed. Install them if they aren’t already available. 
+- Identify the platform the user is interested in building on prior to starting: Android, iOS, Flutter or Web.
+- If their platform is unsupported, Direct the user to Firebase Docs to learn how to set up AI Logic for their application (share this link with the user https://firebase.google.com/docs/ai-logic/get-started)
+
+### Installation
+
+The library is part of the standard Firebase Web SDK.
+
+`npm install -g firebase@latest`
+
+If you're in a firebase directory (with a firebase.json) the currently selected project will be marked with "current" using this command:  
+
+`npx -y firebase-tools@latest projects:list`
+
+Ensure there's at least one app associated with the current project 
+
+`npx -y firebase-tools@latest apps:list`
+
+Initialize AI logic SDK with the init command
+
+`npx -y firebase-tools@latest init # Choose AI logic`
+
+This will automatically enable the Gemini Developer API in the Firebase console.
+
+More info in [Firebase AI Logic Getting Started](https://firebase.google.com/docs/ai-logic/get-started.md.txt)
+
+## Core Capabilities
+
+### Text-Only Generation
+
+### Multimodal (Text + Images/Audio/Video/PDF input)
+
+Firebase AI Logic allows Gemini models to analyze image files directly from your app. This enables features like creating captions, answering questions about images, detecting objects, and categorizing images. Beyond images, Gemini can analyze other media types like audio, video, and PDFs by passing them as inline data with their MIME type. For files larger than 20 megabytes (which can cause HTTP 413 errors as inline data), store them in Cloud Storage for Firebase and pass their URLs to the Gemini Developer API.
+
+### Chat Session (Multi-turn)
+
+Maintain history automatically using `startChat`.
+
+### Streaming Responses
+
+To improve the user experience by showing partial results as they arrive (like a typing effect), use `generateContentStream` instead of `generateContent` for faster display of results.
+
+### Generate Images with Nano Banana
+
+- Start with Gemini for most use cases, and choose Imagen for specialized tasks where image quality and specific styles are critical. (Example: gemini-2.5-flash-image)
+- Requires an upgraded Blaze pay-as-you-go billing plan.
+
+### Search Grounding with the built in googleSearch tool
+
+## Supported Platforms and Frameworks
+
+Supported Platforms and Frameworks include Kotlin and Java for Android, Swift for iOS, JavaScript for web apps, Dart for Flutter, and C Sharp for Unity.
+
+## Advanced Features
+
+### Structured Output (JSON)
+
+Enforce a specific JSON schema for the response.
+
+### On-Device AI (Hybrid)
+
+Hybrid on-device inference for web apps, where the Firebase Javascript SDK automatically checks for Gemini Nano's availability (after installation) and switches between on-device or cloud-hosted prompt execution. This requires specific steps to enable model usage in the Chrome browser, more info in the [hybrid-on-device-inference documentation](https://firebase.google.com/docs/ai-logic/hybrid-on-device-inference.md.txt).
+
+## Security & Production
+
+### App Check
+
+Recommended: The developer must enable Firebase App Check to prevent unauthorized clients from using their API quota. see [App-check recaptcha enterprise](https://firebase.google.com/docs/app-check/web/recaptcha-enterprise-provider.md.txt).
+
+### Remote Config
+
+Consider that you do not need to hardcode model names (e.g., `gemini-flash-lite-latest`). Use Firebase Remote Config to update model versions dynamically without deploying new client code.  See [Changing model names remotely](https://firebase.google.com/docs/ai-logic/change-model-name-remotely.md.txt) 
+
+## Initialization Code References
+
+| Language, Framework, Platform | Gemini API provider | Context URL |
+| :---- | :---- | :---- |
+| Web Modular API | Gemini Developer API (Developer API) | firebase://docs/ai-logic/get-started  |
+
+**Always use the most recent version of Gemini (gemini-flash-latest) unless another model is requested by the docs or the user. DO NOT USE gemini-1.5-flash**
+
+## References
+
+[Web SDK code examples and usage patterns](references/usage_patterns_web.md)
+
+
+

--- a/.agents/skills/firebase-ai-logic/references/usage_patterns_web.md
+++ b/.agents/skills/firebase-ai-logic/references/usage_patterns_web.md
@@ -1,0 +1,174 @@
+# Firebase AI Logic Basics
+
+## Initialization Pattern
+You must initialize the ai-logic service after the main Firebase App.
+```JavaScript
+import { initializeApp } from "firebase/app";
+import { getAI, getGenerativeModel, GoogleAIBackend } from "firebase/ai";
+
+
+// If running in Firebase App Hosting, you can skip Firebase Config and instead use:
+// const app = initializeApp();
+
+const firebaseConfig = {
+  // ... your firebase config
+};
+
+const app = initializeApp(firebaseConfig);
+
+// Initialize the AI Logic service (defaults to Gemini Developer API)
+// To set the AI provider, set the backend as the second parameter
+const ai = getAI(firebaseApp, { backend: new GoogleAIBackend() });
+
+const generationConfig = {
+  candidate_count: 1,
+  maxOutputTokens: 2048,
+  stopSequences: [],
+  temperature: 0.7,      // Balanced: creative but focused
+  topP: 0.95,            // Standard: allows a wide range of probable tokens
+  topK: 40,              // Standard: considers the top 40 tokens
+};
+
+// Specify the config as part of creating the `GenerativeModel` instance
+const model = getGenerativeModel(ai, { model: "gemini-2.5-flash-lite",  generationConfig });
+```
+
+## Core Capabilities
+Text-Only Generation
+```JavaScript
+async function generateText(prompt) {
+  const result = await model.generateContent(prompt);
+  const response = await result.response;
+  return response.text();
+}
+```
+
+## Multimodal (Text + Images/Audio/Video/PDF input)
+Firebase AI Logic accepts Base64 encoded data or specific file references.
+```JavaScript
+// Helper to convert file to base64 generic object
+async function fileToGenerativePart(file) {
+  const base64EncodedDataPromise = new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(reader.result.split(',')[1]);
+    reader.readAsDataURL(file);
+  });
+  
+  return {
+    inlineData: {
+      data: await base64EncodedDataPromise,
+      mimeType: file.type,
+    },
+  };
+}
+
+async function analyzeImage(prompt, imageFile) {
+  const imagePart = await fileToGenerativePart(imageFile);
+  const result = await model.generateContent([prompt, imagePart]);
+  return result.response.text();
+}
+```
+
+## Chat Session (Multi-turn)
+Maintain history automatically using startChat.
+```JavaScript
+const chat = model.startChat({
+  history: [
+    {
+      role: "user",
+      parts: [{ text: "Hello, I am a developer." }],
+    },
+    {
+      role: "model",
+      parts: [{ text: "Great to meet you. How can I help with code?" }],
+    },
+  ],
+});
+
+async function sendMessage(msg) {
+  const result = await chat.sendMessage(msg);
+  return result.response.text();
+}
+```
+
+## Streaming Responses
+For real-time UI updates (like a typing effect).
+```JavaScript
+async function streamResponse(prompt) {
+  const result = await model.generateContentStream(prompt);
+  for await (const chunk of result.stream) {
+    const chunkText = chunk.text();
+    console.log("Stream chunk:", chunkText);
+    // Update UI here
+  }
+}
+```
+
+Generate Images with Nano Banana
+
+```Javascript
+import { initializeApp } from "firebase/app";
+import { getAI, getGenerativeModel, GoogleAIBackend, ResponseModality } from "firebase/ai";
+
+
+// Initialize FirebaseApp
+const firebaseApp = initializeApp(firebaseConfig);
+
+// Initialize the Gemini Developer API backend service
+const ai = getAI(firebaseApp, { backend: new GoogleAIBackend() });
+
+// Create a `GenerativeModel` instance with a model that supports your use case
+const model = getGenerativeModel(ai, {
+  model: "gemini-2.5-flash-image",
+  // Configure the model to respond with text and images (required)
+  generationConfig: {
+    responseModalities: [ResponseModality.TEXT, ResponseModality.IMAGE],
+  },
+});
+
+// Provide a text prompt instructing the model to generate an image
+const prompt = 'Generate an image of the Eiffel Tower with fireworks in the background.';
+
+// To generate an image, call `generateContent` with the text input
+const result = model.generateContent(prompt);
+
+// Handle the generated image
+try {
+  const inlineDataParts = result.response.inlineDataParts();
+  if (inlineDataParts?.[0]) {
+    const image = inlineDataParts[0].inlineData;
+    console.log(image.mimeType, image.data);
+  }
+} catch (err) {
+  console.error('Prompt or candidate was blocked:', err);
+}
+```
+
+## Advanced Features
+Structured Output (JSON)
+Enforce a specific JSON schema for the response.
+```JavaScript
+import { getGenerativeModel, Schema } from "firebase/ai";
+const jsonModel = getGenerativeModel(ai, {
+    model: "gemini-2.5-flash-lite",
+    generationConfig: {
+        responseMimeType: "application/json",
+        // Optional: Define a schema
+        schema = Schema.object({ ... });
+    }
+});
+
+async function getJsonData(prompt) {
+    const result = await jsonModel.generateContent(prompt);
+    return JSON.parse(result.response.text());
+}
+```
+
+On-Device AI (Hybrid)
+Automatically switch between local Gemini Nano and cloud models based on device capability.
+```JavaScript
+import {getGenerativeModel, InferenceMode } from "firebase/ai";
+
+const hybridModel = getGenerativeModel(ai, { mode: InferenceMode.PREFER_ON_DEVICE });
+```
+

--- a/.agents/skills/firebase-auth-basics/SKILL.md
+++ b/.agents/skills/firebase-auth-basics/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: firebase-auth-basics
+description: Guide for setting up and using Firebase Authentication. Use this skill when the user's app requires user sign-in, user management, or secure data access using auth rules.
+compatibility: This skill is best used with the Firebase CLI, but does not require it. Install it by running `npm install -g firebase-tools`.
+---
+
+## Prerequisites
+
+- **Firebase Project**: Created via `npx -y firebase-tools@latest projects:create` (see `firebase-basics`).
+- **Firebase CLI**: Installed and logged in (see `firebase-basics`).
+
+## Core Concepts
+
+Firebase Authentication provides backend services, easy-to-use SDKs, and ready-made UI libraries to authenticate users to your app.
+
+### Users
+
+A user is an entity that can sign in to your app. Each user is identified by a unique ID (`uid`) which is guaranteed to be unique across all providers.
+User properties include:
+- `uid`: Unique identifier.
+- `email`: User's email address (if available).
+- `displayName`: User's display name (if available).
+- `photoURL`: URL to user's photo (if available).
+- `emailVerified`: Boolean indicating if the email is verified.
+
+### Identity Providers
+
+Firebase Auth supports multiple ways to sign in:
+- **Email/Password**: Basic email and password authentication.
+- **Federated Identity Providers**: Google, Facebook, Twitter, GitHub, Microsoft, Apple, etc.
+- **Phone Number**: SMS-based authentication.
+- **Anonymous**: Temporary guest accounts that can be linked to permanent accounts later.
+- **Custom Auth**: Integrate with your existing auth system.
+
+Google Sign In is recommended as a good and secure default provider.
+
+### Tokens
+
+When a user signs in, they receive an ID Token (JWT). This token is used to identify the user when making requests to Firebase services (Realtime Database, Cloud Storage, Firestore) or your own backend.
+- **ID Token**: Short-lived (1 hour), verifies identity.
+- **Refresh Token**: Long-lived, used to get new ID tokens.
+
+## Workflow
+
+### 1. Provisioning
+
+#### Option 1. Enabling Authentication via CLI
+
+Only Google Sign In, anonymous auth, and email/password auth can be enabled via CLI. For other providers, use the Firebase Console.
+
+Configure Firebase Authentication in `firebase.json` by adding an 'auth' block:
+
+```
+{
+  "auth": {
+    "providers": {
+      "anonymous": true,
+      "emailPassword": true,
+      "googleSignIn": {
+        "oAuthBrandDisplayName": "Your Brand Name",
+        "supportEmail": "support@example.com",
+        "authorizedRedirectUris": ["https://example.com"]
+      }
+    }
+  }
+}
+```
+
+#### Option 2. Enabling Authentication in Console
+
+Enable other providers in the Firebase Console.
+
+1.  Go to the https://console.firebase.google.com/project/_/authentication/providers
+2.  Select your project.
+3.  Enable the desired Sign-in providers (e.g., Email/Password, Google).
+
+### 2. Client Setup & Usage
+
+**Web**
+See [references/client_sdk_web.md](references/client_sdk_web.md).
+
+### 3. Security Rules
+
+Secure your data using `request.auth` in Firestore/Storage rules.
+
+See [references/security_rules.md](references/security_rules.md).

--- a/.agents/skills/firebase-auth-basics/references/client_sdk_web.md
+++ b/.agents/skills/firebase-auth-basics/references/client_sdk_web.md
@@ -1,0 +1,287 @@
+# Firebase Authentication Web SDK
+
+## Initialization
+
+First, ensure you have initialized the Firebase App (see `firebase-basics` skill). Then, initialize the Auth service:
+
+```javascript
+import { getAuth } from "firebase/auth";
+import { app } from "./firebase"; // Your initialized Firebase App
+
+const auth = getAuth(app);
+export { auth };
+```
+
+## Connect to Emulator
+
+If you are running the Authentication emulator (usually on port 9099), connect to it immediately after initialization.
+
+```javascript
+import { getAuth, connectAuthEmulator } from "firebase/auth";
+
+const auth = getAuth();
+// Connect to emulator if running locally
+if (location.hostname === "localhost") {
+  connectAuthEmulator(auth, "http://localhost:9099");
+}
+```
+
+## Sign Up with Email/Password
+
+```javascript
+import { getAuth, createUserWithEmailAndPassword } from "firebase/auth";
+
+const auth = getAuth();
+createUserWithEmailAndPassword(auth, email, password)
+  .then((userCredential) => {
+    const user = userCredential.user;
+    // ...
+  })
+  .catch((error) => {
+    const errorCode = error.code;
+    const errorMessage = error.message;
+    // ..
+  });
+```
+
+## Sign In with Google (Popup)
+
+```javascript
+import { getAuth, signInWithPopup, GoogleAuthProvider } from "firebase/auth";
+
+const auth = getAuth();
+const provider = new GoogleAuthProvider();
+
+signInWithPopup(auth, provider)
+  .then((result) => {
+    // This gives you a Google Access Token. You can use it to access the Google API.
+    const credential = GoogleAuthProvider.credentialFromResult(result);
+    const token = credential.accessToken;
+    // The signed-in user info.
+    const user = result.user;
+    // ...
+  })
+  .catch((error) => {
+    // Handle Errors here.
+    const errorCode = error.code;
+    const errorMessage = error.message;
+    // ...
+  });
+```
+
+## Sign In with Facebook (Popup)
+
+```javascript
+import { getAuth, signInWithPopup, FacebookAuthProvider } from "firebase/auth";
+
+const auth = getAuth();
+const provider = new FacebookAuthProvider();
+
+signInWithPopup(auth, provider)
+  .then((result) => {
+    // The signed-in user info.
+    const user = result.user;
+    // This gives you a Facebook Access Token. You can use it to access the Facebook API.
+    const credential = FacebookAuthProvider.credentialFromResult(result);
+    const accessToken = credential.accessToken;
+  })
+  .catch((error) => {
+    // Handle Errors here.
+  });
+```
+
+## Sign In with Apple (Popup)
+
+```javascript
+import { getAuth, signInWithPopup, OAuthProvider } from "firebase/auth";
+
+const auth = getAuth();
+const provider = new OAuthProvider('apple.com');
+
+signInWithPopup(auth, provider)
+  .then((result) => {
+    const user = result.user;
+    // Apple credential
+    const credential = OAuthProvider.credentialFromResult(result);
+    const accessToken = credential.accessToken;
+  })
+  .catch((error) => {
+    // Handle Errors here.
+  });
+```
+
+## Sign In with Twitter (Popup)
+
+```javascript
+import { getAuth, signInWithPopup, TwitterAuthProvider } from "firebase/auth";
+
+const auth = getAuth();
+const provider = new TwitterAuthProvider();
+
+signInWithPopup(auth, provider)
+  .then((result) => {
+    const user = result.user;
+    // Twitter credential
+    const credential = TwitterAuthProvider.credentialFromResult(result);
+    const token = credential.accessToken;
+    const secret = credential.secret;
+  })
+  .catch((error) => {
+    // Handle Errors here.
+  });
+```
+
+## Sign In with GitHub (Popup)
+
+```javascript
+import { getAuth, signInWithPopup, GithubAuthProvider } from "firebase/auth";
+
+const auth = getAuth();
+const provider = new GithubAuthProvider();
+
+signInWithPopup(auth, provider)
+  .then((result) => {
+    const user = result.user;
+    const credential = GithubAuthProvider.credentialFromResult(result);
+    const token = credential.accessToken;
+  })
+  .catch((error) => {
+    // Handle Errors here.
+  });
+```
+
+## Sign In with Microsoft (Popup)
+
+```javascript
+import { getAuth, signInWithPopup, OAuthProvider } from "firebase/auth";
+
+const auth = getAuth();
+const provider = new OAuthProvider('microsoft.com');
+
+signInWithPopup(auth, provider)
+  .then((result) => {
+    const user = result.user;
+    const credential = OAuthProvider.credentialFromResult(result);
+    const accessToken = credential.accessToken;
+  })
+  .catch((error) => {
+    // Handle Errors here.
+  });
+```
+
+## Sign In with Yahoo (Popup)
+
+```javascript
+import { getAuth, signInWithPopup, OAuthProvider } from "firebase/auth";
+
+const auth = getAuth();
+const provider = new OAuthProvider('yahoo.com');
+
+signInWithPopup(auth, provider)
+  .then((result) => {
+    const user = result.user;
+    const credential = OAuthProvider.credentialFromResult(result);
+    const accessToken = credential.accessToken;
+  })
+  .catch((error) => {
+    // Handle Errors here.
+  });
+```
+
+## Sign In Anonymously
+
+```javascript
+import { getAuth, signInAnonymously } from "firebase/auth";
+
+const auth = getAuth();
+signInAnonymously(auth)
+  .then(() => {
+    // Signed in..
+  })
+  .catch((error) => {
+    const errorCode = error.code;
+    const errorMessage = error.message;
+  });
+```
+
+## Email Link Authentication
+
+**1. Send Auth Link**
+
+```javascript
+import { getAuth, sendSignInLinkToEmail } from "firebase/auth";
+
+const auth = getAuth();
+const actionCodeSettings = {
+  // URL you want to redirect back to. The domain must be in the authorized domains list in Firebase Console.
+  url: 'https://www.example.com/finishSignUp?cartId=1234',
+  handleCodeInApp: true,
+};
+
+sendSignInLinkToEmail(auth, email, actionCodeSettings)
+  .then(() => {
+    // Save the email locally so you don't need to ask the user for it again
+    window.localStorage.setItem('emailForSignIn', email);
+  })
+  .catch((error) => {
+    // Error
+  });
+```
+
+**2. Complete Sign In (on landing page)**
+
+```javascript
+import { getAuth, isSignInWithEmailLink, signInWithEmailLink } from "firebase/auth";
+
+const auth = getAuth();
+
+if (isSignInWithEmailLink(auth, window.location.href)) {
+  let email = window.localStorage.getItem('emailForSignIn');
+  if (!email) {
+    email = window.prompt('Please provide your email for confirmation');
+  }
+
+  signInWithEmailLink(auth, email, window.location.href)
+    .then((result) => {
+      window.localStorage.removeItem('emailForSignIn');
+      // You can check result.user
+    })
+    .catch((error) => {
+      // Error
+    });
+}
+```
+
+## Observe Auth State
+
+Recommended way to get the current user. This listener triggers whenever the user signs in or out.
+
+```javascript
+import { getAuth, onAuthStateChanged } from "firebase/auth";
+
+const auth = getAuth();
+onAuthStateChanged(auth, (user) => {
+  if (user) {
+    // User is signed in, see docs for a list of available properties
+    // https://firebase.google.com/docs/reference/js/firebase.User
+    const uid = user.uid;
+    // ...
+  } else {
+    // User is signed out
+    // ...
+  }
+});
+```
+
+## Sign Out
+
+```javascript
+import { getAuth, signOut } from "firebase/auth";
+
+const auth = getAuth();
+signOut(auth).then(() => {
+  // Sign-out successful.
+}).catch((error) => {
+  // An error happened.
+});
+```

--- a/.agents/skills/firebase-auth-basics/references/security_rules.md
+++ b/.agents/skills/firebase-auth-basics/references/security_rules.md
@@ -1,0 +1,38 @@
+# Authentication in Security Rules
+
+Firebase Security Rules work with Firebase Authentication to provide rule-based access control. For better advice on writing safe security rules,
+enable the `firebase-firestore-basics`  or `firebase-storage-basics` skills.
+ 
+The `request.auth` variable contains authentication information for the user requesting data.
+
+## Basic Checks
+
+### Check if user is signed in
+```
+allow read, write: if request.auth != null;
+```
+
+### Check if user owns the data
+Access data only if the document ID matches the user's UID.
+```
+allow read, write: if request.auth != null && request.auth.uid == userId;
+```
+(Where `userId` is a path variable, e.g., `match /users/{userId}`)
+
+### Check if user owns the document (field-based)
+Access data only if the document has a `owner_uid` field matching the user's UID.
+```
+allow read, write: if request.auth != null && request.auth.uid == resource.data.owner_uid;
+```
+
+## Token Properties
+`request.auth.token` contains standard JWT claims and custom claims.
+
+- `request.auth.token.email`: The user's email address.
+- `request.auth.token.email_verified`: If the email is verified.
+- `request.auth.token.name`: The user's display name.
+
+### Example: Email Verification Check
+```
+allow create: if request.auth.token.email_verified == true;
+```

--- a/.agents/skills/firebase-basics/SKILL.md
+++ b/.agents/skills/firebase-basics/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: firebase-basics
+description: Core principles, workflow, and maintenance for using Firebase. Use this for all Firebase CLI tasks, building, service setup, and REFRESHING or UPDATING an existing environment. Make sure to ALWAYS use this skill whenever you are trying to use Firebase, even if not explicitly asked.
+---
+# Prerequisites
+
+Please complete these setup steps before proceeding, and remember your progress to avoid repeating them in future interactions.
+
+1. **Local Environment Setup:** Verify the environment is properly set up so we can use Firebase tools:
+   - Run `npx -y firebase-tools@latest --version` to check if the Firebase CLI is installed.
+   - Verify if the Firebase MCP server is installed using your existing tools.
+   - If either of these checks fails, please use the `firebase-local-env-setup` skill to get the environment ready.
+
+2. **Authentication:**
+   Ensure you are logged in to Firebase so that commands have the correct permissions. Run `npx -y firebase-tools@latest login`. For environments without a browser (e.g., remote shells), use `npx -y firebase-tools@latest login --no-localhost`.
+   - The command should output the current user. 
+   - If you are not logged in, follow the interactive instructions from this command to authenticate.
+
+3. **Active Project:**
+   Most Firebase tasks require an active project context. Check the current project by running `npx -y firebase-tools@latest use`.
+   - If the command outputs `Active Project: <project-id>`, you can proceed with your task.
+   - If not, ask the user if they have an existing Firebase Project ID.
+     - If yes: Set it as the active project and add a default alias by running:
+       ```bash
+       npx -y firebase-tools@latest use --add <PROJECT_ID>
+       ```
+     - If no: Follow the project creation instructions in [references/firebase-project-create.md](references/firebase-project-create.md).
+
+# Firebase Usage Principles
+
+Please adhere to these principles when working with Firebase, as they ensure reliability and up-to-date project tools:
+
+1. **Use npx for CLI commands:** To ensure you always use the latest version of the Firebase CLI, always prepend commands with `npx -y firebase-tools@latest` instead of just `firebase`. (e.g., use `npx -y firebase-tools@latest --version` instead of `firebase --version`).
+2. **Prioritize official knowledge:** For any Firebase-related knowledge, consult the `developerknowledge_search_documents` MCP tool before falling back to Google Search or your internal knowledge base. Including "Firebase" in your search query significantly improves relevance.
+3. **Follow Agent Skills for implementation guidance:** Skills provide opinionated workflows (CUJs), security rules, and best practices. Always consult them to understand *how* to implement Firebase features correctly instead of relying on general knowledge.
+4. **Use Firebase MCP Server tools instead of direct API calls:** Whenever you need to interact with remote Firebase APIs (such as fetching Crashlytics logs or executing Data Connect queries), use the tools provided by the Firebase MCP Server instead of attempting manual API calls.
+5. **Keep Plugin / Agent Skills updated:** Since Firebase best practices evolve quickly, remind the user to regularly check for and install updates to their Firebase plugin or Agent Skills, ensuring you both operate with the latest workflows. Similarly, if you encounter issues with outdated tools or commands, follow the steps below based on your agent environment:
+   - **Antigravity**: Follow [references/refresh-antigravity.md](references/refresh-antigravity.md)
+   - **Gemini CLI**: Follow [references/refresh-gemini-cli.md](references/refresh-gemini-cli.md)
+   - **Claude Code**: Follow [references/refresh-claude.md](references/refresh-claude.md)
+   - **Cursor**: Follow [references/refresh-cursor.md](references/refresh-cursor.md)
+   - **Others**: Follow [references/refresh-other.md](references/refresh-other-agents.md)
+
+# References
+
+- **Initialize Firebase:** See [references/firebase-service-init.md](references/firebase-service-init.md) when you need to initialize new Firebase services using the CLI.
+- **Exploring Commands:** See [references/firebase-cli-guide.md](references/firebase-cli-guide.md) to discover and understand CLI functionality.
+- **SDK Setup:** For detailed guides on adding Firebase to a web app, see [references/web_setup.md](references/web_setup.md).
+
+# Common Issues
+
+- **Login Issues:** If the browser fails to open during the login step, use `npx -y firebase-tools@latest login --no-localhost` instead.

--- a/.agents/skills/firebase-basics/references/firebase-cli-guide.md
+++ b/.agents/skills/firebase-basics/references/firebase-cli-guide.md
@@ -1,0 +1,16 @@
+# Exploring Commands
+
+The Firebase CLI documents itself. Use help commands to discover functionality.
+
+- **Global Help**: List all available commands and categories.
+  ```bash
+  npx -y firebase-tools@latest --help
+  ```
+
+- **Command Help**: Get detailed usage for a specific command.
+  ```bash
+  npx -y firebase-tools@latest [command] --help
+  # Example:
+  npx -y firebase-tools@latest deploy --help
+  npx -y firebase-tools@latest firestore:indexes --help
+  ```

--- a/.agents/skills/firebase-basics/references/firebase-project-create.md
+++ b/.agents/skills/firebase-basics/references/firebase-project-create.md
@@ -1,0 +1,11 @@
+# Creating a Project
+
+To create a new Firebase project from the CLI:
+
+```bash
+npx -y firebase-tools@latest projects:create
+```
+
+You will be prompted to:
+1. Enter a **Project ID** (must be 6-30 chars, lowercase, digits, and hyphens; must be unique globally).
+2. Enter a **display name**.

--- a/.agents/skills/firebase-basics/references/firebase-service-init.md
+++ b/.agents/skills/firebase-basics/references/firebase-service-init.md
@@ -1,0 +1,18 @@
+# Initialization
+
+Before initializing, check if you are already in a Firebase project directory by looking for `firebase.json`.
+
+1. **Project Directory:**
+   Navigate to the root directory of the codebase. 
+   *(Only if starting a completely new project from scratch without an existing codebase, create a directory first: `mkdir my-project && cd my-project`)*
+
+2. **Initialize Services:**
+   Run the initialization command:
+   ```bash
+   npx -y firebase-tools@latest init
+   ```
+
+The CLI will guide you through:
+- Selecting features (Firestore, Functions, Hosting, etc.).
+- Associating with an existing project or creating a new one.
+- Configuring files (e.g. `firebase.json`, `.firebaserc`).

--- a/.agents/skills/firebase-basics/references/refresh-antigravity.md
+++ b/.agents/skills/firebase-basics/references/refresh-antigravity.md
@@ -1,0 +1,46 @@
+# Refresh Antigravity Local Environment
+
+Follow these steps to refresh Antigravity's local environment, ensuring that their agent skills and plugins are fully up-to-date.
+
+Antigravity relies on `npx skills`. Updates should prioritize the global level; if skills are installed at the project level, omit the `--global` flag.
+
+1. **List Available Skills:** Identify all Firebase skills available in the repository:
+   ```bash
+   npx -y skills add firebase/agent-skills --list
+   ```
+
+2. **Check Currently Installed Skills:** Determine which skills are already installed and linked at both project and global levels:
+   ```bash
+   # Check project-level skills
+   npx -y skills list --agent antigravity
+
+   # Check global-level skills
+   npx -y skills list --agent antigravity --global
+   ```
+   *Note: If a skill shows `Agents: not linked` in the output, it is installed but not currently available to Antigravity.*
+
+3. **Add Missing or Unlinked Skills:** Compare the results from Step 1 and Step 2. For each missing or unlinked skill, follow the appropriate conditional instruction below:
+
+   - **IF any Firebase skills were found at the PROJECT level in Step 2:** Add the missing skill to the project level:
+     ```bash
+     npx -y skills add firebase/agent-skills --agent antigravity --skill "<SKILL_NAME>" --yes
+     ```
+
+   - **IF any Firebase skills were found at the GLOBAL level in Step 2:** Add the missing skill to the global level:
+     ```bash
+     npx -y skills add firebase/agent-skills --agent antigravity --skill "<SKILL_NAME>" --global --yes
+     ```
+
+   - **IF NO Firebase skills were found in Step 2:** Add each missing skill to the global level:
+     ```bash
+     npx -y skills add firebase/agent-skills --agent antigravity --skill "<SKILL_NAME>" --global --yes
+     ```
+
+4. **Update Existing Skills:** Update all currently installed skills to their latest versions:
+   ```bash
+   # Update project-level skills
+   npx -y skills update --agent antigravity --yes
+
+   # Update global-level skills
+   npx -y skills update --agent antigravity --global --yes
+   ```

--- a/.agents/skills/firebase-basics/references/refresh-claude.md
+++ b/.agents/skills/firebase-basics/references/refresh-claude.md
@@ -1,0 +1,10 @@
+# Refresh Claude Code Local Environment
+
+Follow these steps to refresh Claude Code's local environment, ensuring that their agent skills and plugins are fully up-to-date.
+
+Use Claude Code's native plugin manager instead of `npx`.
+
+1. **Update the Plugin:** Run the specific CLI command to update the Firebase plugin:
+   ```bash
+   claude plugin update firebase@firebase
+   ```

--- a/.agents/skills/firebase-basics/references/refresh-gemini-cli.md
+++ b/.agents/skills/firebase-basics/references/refresh-gemini-cli.md
@@ -1,0 +1,11 @@
+# Refresh Gemini CLI Local Environment
+
+Follow these steps to refresh Gemini CLI's local environment, ensuring that their agent skills and plugins are fully up-to-date.
+
+Use the native Gemini CLI extension manager instead of `npx`.
+
+1. **Update the Extension:** Run the specific CLI command to update:
+   ```bash
+   gemini extensions update firebase
+   ```
+   *Note: If the extension is named differently, replace `firebase` with the correct name from `gemini extensions list`.*

--- a/.agents/skills/firebase-basics/references/refresh-other-agents.md
+++ b/.agents/skills/firebase-basics/references/refresh-other-agents.md
@@ -1,0 +1,48 @@
+# Refresh Other Local Environment
+
+Follow these steps to refresh the local environment of other agents, ensuring that their agent skills and plugins are fully up-to-date.
+
+Other agents rely on `npx skills`. Updates should prioritize the global level; if skills are installed at the project level, omit the `--global` flag.
+
+Replace `<AGENT_NAME>` with the actual agent name, which can be found in the [skills repository README](https://github.com/vercel-labs/skills/blob/main/README.md).
+
+1. **List Available Skills:** Identify all Firebase skills available in the repository:
+   ```bash
+   npx -y skills add firebase/agent-skills --list
+   ```
+
+2. **Check Currently Installed Skills:** Determine which skills are already installed and linked for the agent at both project and global levels:
+   ```bash
+   # Check project-level skills
+   npx -y skills list --agent <AGENT_NAME>
+
+   # Check global-level skills
+   npx -y skills list --agent <AGENT_NAME> --global
+   ```
+   *Note: If a skill shows `Agents: not linked` in the output, it is installed but not currently available to the agent.*
+
+3. **Add Missing or Unlinked Skills:** Compare the results from Step 1 and Step 2. For each missing or unlinked skill, follow the appropriate conditional instruction below:
+
+   - **IF any Firebase skills were found at the PROJECT level in Step 2:** Add the missing skill to the project level:
+     ```bash
+     npx -y skills add firebase/agent-skills --agent <AGENT_NAME> --skill "<SKILL_NAME>" --yes
+     ```
+
+   - **IF any Firebase skills were found at the GLOBAL level in Step 2:** Add the missing skill to the global level:
+     ```bash
+     npx -y skills add firebase/agent-skills --agent <AGENT_NAME> --skill "<SKILL_NAME>" --global --yes
+     ```
+
+   - **IF NO Firebase skills were found in Step 2:** Add each missing skill to the global level:
+     ```bash
+     npx -y skills add firebase/agent-skills --agent <AGENT_NAME> --skill "<SKILL_NAME>" --global --yes
+     ```
+
+4. **Update Existing Skills:** Update all currently installed skills to their latest versions:
+   ```bash
+   # Update project-level skills
+   npx -y skills update --agent <AGENT_NAME> --yes
+
+   # Update global-level skills
+   npx -y skills update --agent <AGENT_NAME> --global --yes
+   ```

--- a/.agents/skills/firebase-basics/references/web_setup.md
+++ b/.agents/skills/firebase-basics/references/web_setup.md
@@ -1,0 +1,69 @@
+# Firebase Web Setup Guide
+
+## 1. Create a Firebase Project and App
+If you haven't already created a project:
+
+```bash
+npx -y firebase-tools@latest projects:create
+```
+
+Register your web app:
+```bash
+npx -y firebase-tools@latest apps:create web my-web-app
+```
+(Note the **App ID** returned by this command).
+
+## 2. Installation
+Install the Firebase SDK via npm:
+
+```bash
+npm install firebase
+```
+
+## 3. Initialization
+Create a `firebase.js` (or `firebase.ts`) file. You can fetch your config object using the CLI:
+
+```bash
+npx -y firebase-tools@latest apps:sdkconfig <APP_ID>
+```
+
+Copy the output config object into your initialization file:
+
+```javascript
+import { initializeApp } from "firebase/app";
+import { getAuth } from "firebase/auth";
+
+// Your web app's Firebase configuration
+const firebaseConfig = {
+  apiKey: "API_KEY",
+  authDomain: "PROJECT_ID.firebaseapp.com",
+  projectId: "PROJECT_ID",
+  storageBucket: "PROJECT_ID.firebasestorage.app",
+  messagingSenderId: "SENDER_ID",
+  appId: "APP_ID",
+  measurementId: "G-MEASUREMENT_ID"
+};
+
+// Initialize Firebase
+const app = initializeApp(firebaseConfig);
+const auth = getAuth(app);
+
+export { app };
+```
+
+## 4. Using Services
+Import specific services as needed (Modular API):
+
+```javascript
+import { getFirestore, collection, getDocs } from "firebase/firestore";
+import { app } from "./firebase"; // Import the initialized app
+
+const db = getFirestore(app);
+
+async function getUsers() {
+  const querySnapshot = await getDocs(collection(db, "users"));
+  querySnapshot.forEach((doc) => {
+    console.log(`${doc.id} => ${doc.data()}`);
+  });
+}
+```

--- a/.agents/skills/firebase-firestore-standard/SKILL.md
+++ b/.agents/skills/firebase-firestore-standard/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: firebase-firestore-standard
+description: Comprehensive guide for Firestore Standard Edition, including provisioning, security rules, and SDK usage. Use this skill when the user needs help setting up Firestore, writing security rules, or using the Firestore SDK in their application.
+compatibility: This skill is best used with the Firebase CLI, but does not require it. Install it by running `npm install -g firebase-tools`. 
+---
+
+# Firestore Standard Edition
+
+This skill provides a complete guide for getting started with Cloud Firestore Standard Edition, including provisioning, securing, and integrating it into your application.
+
+## Provisioning
+
+To set up Cloud Firestore in your Firebase project and local environment, see [provisioning.md](references/provisioning.md).
+
+## Security Rules
+
+For guidance on writing and deploying Firestore Security Rules to protect your data, see [security_rules.md](references/security_rules.md).
+
+## SDK Usage
+
+To learn how to use Cloud Firestore in your application code, choose your platform:
+
+*   **Web (Modular SDK)**: [web_sdk_usage.md](references/web_sdk_usage.md)
+
+## Indexes
+
+For checking index types, query support tables, and best practices, see [indexes.md](references/indexes.md).

--- a/.agents/skills/firebase-firestore-standard/references/indexes.md
+++ b/.agents/skills/firebase-firestore-standard/references/indexes.md
@@ -1,0 +1,82 @@
+# Firestore Indexes Reference
+
+Indexes allow Firestore to ensure that query performance depends on the size of the result set, not the size of the database.
+
+## Index Types
+
+### Single-Field Indexes
+In Standard Edition, Firestore **automatically creates** a single-field index for every field in a document (and subfields in maps).
+*   **Support**: Simple equality queries (`==`) and single-field range/sort queries (`<`, `<=`, `orderBy`).
+*   **Behavior**: You generally don't need to manage these unless you want to *exempt* a field.
+
+### Composite Indexes
+A composite index stores a sorted mapping of all documents based on an ordered list of fields.
+*   **Support**: Complex queries that filter or sort by **multiple fields**.
+*   **Creation**: These are **NOT** automatically created. You must define them manually or via the console/CLI.
+
+## Automatic vs. Manual Management
+
+### What is Automatic?
+*   Indexes for simple queries.
+*   Merging of single-field indexes for multiple equality filters (e.g., `where("state", "==", "CA").where("country", "==", "USA")`).
+
+### When Do I Need to Act?
+If you attempt a query that requires a composite index, the SDK will throw an error containing a **direct link** to the Firebase Console to create that specific index.
+
+**Example Error:**
+> "The query requires an index. You can create it here: https://console.firebase.google.com/project/..."
+
+## Query Support Examples
+
+| Query Type | Index Required |
+| :--- | :--- |
+| **Simple Equality**<br>`where("a", "==", 1)` | Automatic (Single-Field) |
+| **Simple Range/Sort**<br>`where("a", ">", 1).orderBy("a")` | Automatic (Single-Field) |
+| **Multiple Equality**<br>`where("a", "==", 1).where("b", "==", 2)` | Automatic (Merged Single-Field) |
+| **Equality + Range/Sort**<br>`where("a", "==", 1).where("b", ">", 2)` | **Composite Index** |
+| **Multiple Ranges**<br>`where("a", ">", 1).where("b", ">", 2)` | **Composite Index** (and technically limited query support) |
+| **Array Contains + Equality**<br>`where("tags", "array-contains", "news").where("active", "==", true)` | **Composite Index** |
+
+## Best Practices & Exemptions
+
+You can **exempt** fields from automatic indexing to save storage or strictly enforce write limits.
+
+### 1. High Write Rates (Sequential Values)
+*   **Problem**: Indexing fields that increase sequentially (like `timestamp`) limits the write rate to ~500 writes/second per collection.
+*   **Solution**: If you don't query on this field, **exempt** it from simple indexing.
+
+### 2. Large String/Map/Array Fields
+*   **Problem**: Indexing limits (40k entries per doc). Indexing large blobs wastes storage.
+*   **Solution**: Exempt large text blobs or huge arrays if they aren't used for filtering.
+
+### 3. TTL Fields
+*   **Problem**: TTL (Time-To-Live) deletion can cause index churn.
+*   **Solution**: Exempt the TTL timestamp field from indexing if you don't query it.
+
+## Management
+
+### Config files
+Your indexes should be defined in `firestore.indexes.json` (pointed to by `firebase.json`).
+
+```json
+{
+  "indexes": [
+    {
+      "collectionGroup": "cities",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "country", "order": "ASCENDING" },
+        { "fieldPath": "population", "order": "DESCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}
+```
+
+### CLI Commands
+
+Deploy indexes only:
+```bash
+npx -y firebase-tools@latest deploy --only firestore:indexes
+```

--- a/.agents/skills/firebase-firestore-standard/references/provisioning.md
+++ b/.agents/skills/firebase-firestore-standard/references/provisioning.md
@@ -1,0 +1,87 @@
+# Provisioning Cloud Firestore
+
+## Manual Initialization
+
+Initialize the following firebase configuration files manually. Do not use `npx -y firebase-tools@latest init`, as it expects interactive inputs.
+
+1.  **Create `firebase.json`**: This file configures the Firebase CLI.
+2.  **Create `firestore.rules`**: This file contains your security rules.
+3.  **Create `firestore.indexes.json`**: This file contains your index definitions.
+
+### 1. Create `firebase.json`
+
+Create a file named `firebase.json` in your project root with the following content. If this file already exists, instead append to the existing JSON:
+
+```json
+{
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json"
+  }
+}
+```
+
+This will use the default database with the Standard edition. To use a different database, specify the database ID and location. You can check the list of available databases using `npx -y firebase-tools@latest firestore:databases:list`. If the database does not exist, it will be created when you deploy:
+
+```json
+{
+  "firestore": {
+    "rules": "firestore.rules",
+    "indexes": "firestore.indexes.json",
+    "database": "my-database-id",
+    "location": "us-central1"
+  }
+}
+```
+ 
+### 2. Create `firestore.rules`
+
+Create a file named `firestore.rules`. A good starting point (locking down the database) is:
+
+```
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /{document=**} {
+      allow read, write: if false;
+    }
+  }
+}
+```
+*See [security_rules.md](security_rules.md) for how to write actual rules.*
+
+### 3. Create `firestore.indexes.json`
+
+Create a file named `firestore.indexes.json` with an empty configuration to start:
+
+```json
+{
+  "indexes": [],
+  "fieldOverrides": []
+}
+```
+
+*See [indexes.md](indexes.md) for how to configure indexes.*
+
+
+## Deploy rules and indexes
+```bash
+# To deploy all rules and indexes
+npx -y firebase-tools@latest deploy --only firestore
+
+# To deploy just rules
+npx -y firebase-tools@latest deploy --only firestore:rules
+
+# To deploy just indexes
+npx -y firebase-tools@latest deploy --only firestore:indexes
+```
+
+## Local Emulation
+
+To run Firestore locally for development and testing:
+
+```bash
+npx -y firebase-tools@latest emulators:start --only firestore
+```
+
+This starts the Firestore emulator, typically on port 8080. You can interact with it using the Emulator UI (usually at http://localhost:4000/firestore).

--- a/.agents/skills/firebase-firestore-standard/references/security_rules.md
+++ b/.agents/skills/firebase-firestore-standard/references/security_rules.md
@@ -1,0 +1,299 @@
+# Firestore Security Rules Structure
+
+Security rules determine who has read and write access to your database.
+
+## Service and Database Declaration
+
+All Firestore rules begin with the service declaration and a match block for the database (usually default).
+
+```
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // Rules go here
+    // {database} wildcard represents the database name
+  }
+}
+```
+
+## Basic Read/Write Operations
+
+Rules describe **conditions** that must be true to allow an operation.
+
+```
+match /cities/{city} {
+  allow read: if <condition>;
+  allow write: if <condition>;
+}
+```
+
+## Common Patterns
+
+### Locked Mode (Deny All)
+Good for starting development or private data.
+```
+match /{document=**} {
+  allow read, write: if false;
+}
+```
+
+### Test Mode (Allow All)
+**WARNING: insecure.** Only for quick prototyping. Unsafe to deploy for production apps.
+```
+match /{document=**} {
+  allow read, write: if true;
+}
+```
+
+### Auth Required
+Allow access only to authenticated users. This allows any logged in user access to all data.
+```
+match /{document=**} {
+  allow read, write: if request.auth != null;
+}
+```
+
+### User-Specific Data
+Allow users to access only their own data.
+```
+match /users/{userId} {
+  allow read, write: if request.auth != null && request.auth.uid == userId;
+}
+```
+
+### Allow only verified emails
+Requires users to verify ownership of the email address before using it to read or write data
+```
+// Allow access based on email domain
+match /some_collection/{document} {
+  allow read: if request.auth != null
+              && request.auth.email_verified
+              && request.auth.email.endsWith('@example.com');
+}
+```
+
+### Validate data in write operations
+```
+// Example for creating a user profile
+match /users/{userId} {
+  allow create: if request.auth.uid == userId &&
+                   request.resource.data.email is string &&
+                   request.resource.data.createdAt == request.time;
+}
+```
+
+### Granular Operations
+
+You can break down `read` and `write` into more specific operations:
+
+*   **read**
+    *   `get`: Retrieval of a single document.
+    *   `list`: Queries and collection reads.
+*   **write**
+    *   `create`: Writing to a nonexistent document.
+    *   `update`: Writing to an existing document.
+    *   `delete`: Removing a document.
+
+```firestore
+match /cities/{city} {
+  allow get: if <condition>;
+  allow list: if <condition>;
+  allow create: if <condition>;
+  allow update: if <condition>;
+  allow delete: if <condition>;
+}
+```
+
+## Hierarchical Data
+
+Rules applied to a parent collection **do not** cascade to subcollections. You must explicitly match subcollections.
+
+### Nested Match Statements
+
+Inner matches are relative to the outer match path.
+
+```firestore
+match /cities/{city} {
+  allow read, write: if <condition>;
+
+  // Explicitly match the subcollection 'landmarks'
+  match /landmarks/{landmark} {
+    allow read, write: if <condition>;
+  }
+}
+```
+
+### Recursive Wildcards (`{name=**}`)
+
+Use recursive wildcards to apply rules to an arbitrarily deep hierarchy.
+
+*   **Version 2** (recommended): `{path=**}` matches zero or more path segments.
+
+```firestore
+// Allow read access to ANY document in the 'cities' collection or its subcollections
+match /cities/{document=**} {
+  allow read: if true;
+}
+```
+
+## Controlling Field Access
+
+### Read Limitations
+
+Reads in Firestore are **document-level**. You cannot retrieve a partial document.
+*   **Allowed**: Read the entire document.
+*   **Denied**: logical failure, no data returned.
+
+To secure specific fields (e.g., private user data), you must **split them into a separate document** (e.g., a `private` subcollection).
+
+### Write Restrictions
+
+You can strictly control which fields can be written or updated.
+
+#### On Creation
+Use `request.resource.data.keys()` to validate fields.
+
+```firestore
+match /restaurant/{restId} {
+  allow create: if request.resource.data.keys().hasAll(['name', 'location']) &&
+                   request.resource.data.keys().hasOnly(['name', 'location', 'city', 'address']);
+}
+```
+
+#### On Update
+Use `diff()` to see what changed between the existing document (`resource.data`) and the incoming data (`request.resource.data`).
+
+```firestore
+match /restaurant/{restId} {
+  allow update: if request.resource.data.diff(resource.data).affectedKeys()
+        .hasOnly(['name', 'location', 'city']); // Prevent others from changing
+}
+```
+
+### Enforcing Field Types
+Use the `is` operator to validate data types.
+
+```firestore
+allow create: if request.resource.data.score is int &&
+                 request.resource.data.active is bool &&
+                 request.resource.data.tags is list;
+```
+
+## Understanding Rule Evaluation
+
+### Overlapping Matches -> OR Logic
+
+If a document matches more than one rule statement, access is allowed if **ANY** of the matching rules allow it.
+
+```firestore
+// Document: /cities/SF
+
+match /cities/{city} {
+  allow read: if false; // Deny
+}
+
+match /cities/{document=**} {
+  allow read: if true;  // Allow
+}
+
+// Result: ALLOWED (because one rule returned true)
+```
+
+## Common Limits
+
+*   **Call Depth**: Maximum call depth for custom functions is 20.
+*   **Document Access**:
+    *   10 access calls for single-doc requests/queries.
+    *   20 access calls for multi-doc reads/transactions/batches.
+*   **Size**: Ruleset source max 256 KB. Compiled max 250 KB.
+
+## Deploying
+
+```bash
+npx -y firebase-tools@latest deploy --only firestore:rules
+```
+
+## Security Rules Development Workflow
+
+For complex applications, follow this structured 6-phase workflow to ensure your rules are secure and comprehensive.
+
+### Phase 1: Codebase Analysis
+
+Before writing rules, scan your codebase to identify:
+1.  **Collections & Paths**: List all collections and document structures.
+2.  **Data Models**: Define required fields, data types, and constraints (e.g., string length, regex patterns).
+3.  **Access Patterns**: Document who can read/write what and under what conditions (e.g., exact ownership, role-based).
+4.  **Authentication**: Identify if you use Firebase Auth, anonymous auth, or custom tokens.
+
+### Phase 2: Security Rules Generation
+
+Write your rules following these core principles:
+*   **Default Deny**: Start with `allow read, write: if false;` and whitelist specific operations.
+*   **Least Privilege**: Grant only the minimum permissions required.
+*   **Validate Data**: Check types (e.g., `is string`), required fields, and values on `create` and `update`.
+*   **UID Protection**: Ensure users cannot create documents with another user's UID or change ownership.
+
+#### Recommended Structure
+
+It is helpful to define a `User` type or similar helper functions at the top of your rules file.
+
+```javascript
+// Helper Functions
+function isAuthenticated() {
+  return request.auth != null;
+}
+
+function isOwner(userId) {
+  return isAuthenticated() && request.auth.uid == userId;
+}
+
+// Validate data types and required fields
+function isValidUser() {
+  let user = request.resource.data;
+  return user.keys().hasAll(['name', 'email', 'createdAt']) &&
+         user.name is string && user.name.size() > 0 &&
+         user.email is string && user.email.matches('.+@.+\\..+') &&
+         user.createdAt is timestamp;
+}
+
+// Prevent UID tampering
+function isUidUnchanged() {
+  return request.resource.data.uid == resource.data.uid;
+}
+```
+
+### Phase 3: Devil's Advocate Attack
+
+Attempt to mentally "break" your rules by checking for common vulnerabilities:
+1.  Can I read data I shouldn't?
+2.  Can I create a document with someone else's UID?
+3.  Can I update a document and steal ownership (change the `uid` field)?
+4.  Can I send a massive string to a field with no length limit?
+5.  Can I delete a document I don't own?
+6.  Can I bypass validation by sending `null` or missing fields?
+
+If *any* of these succeed, fix the rule and repeat.
+
+### Phase 4: Syntactic Validation
+
+Use `npx -y firebase-tools@latest deploy --only firestore:rules --dry-run` to validate syntax.
+
+### Phase 5: Test Suite Generation
+
+Create a comprehensive test suite using `@firebase/rules-unit-testing`. Ideally, create a dedicated `rules_test/` directory.
+
+**Test Coverage Checklist:**
+*   [ ] **Authorized Operations**: Users *can* do what they are supposed to.
+*   [ ] **Unauthorized Operations**: Users *cannot* do what is forbidden.
+*   [ ] **UID Tampering**: Users cannot create/update data with another's UID.
+*   [ ] **Data Validation**: Invalid types, missing fields, or malformed data (bad emails, URLs) must fail.
+*   [ ] **Immutable Fields**: Fields like `createdAt` or `authorId` cannot be changed on update.
+
+### Phase 6: Test Validation Loop
+
+1.  Start the emulator: `npx -y firebase-tools@latest emulators:start --only firestore`
+2.  Run tests: `npm test` (inside your test directory)
+3.  If tests fail due to **rules**: Fix the rules.
+4.  If tests fail due to **test bugs**: Fix the tests.
+5.  Repeat until 100% pass rate.

--- a/.agents/skills/firebase-firestore-standard/references/web_sdk_usage.md
+++ b/.agents/skills/firebase-firestore-standard/references/web_sdk_usage.md
@@ -1,0 +1,183 @@
+# Firestore Web SDK Usage Guide
+
+This guide focuses on the **Modular Web SDK** (v9+), which is tree-shakeable and efficient.
+
+## Initialization
+
+```javascript
+import { initializeApp } from "firebase/app";
+import { getFirestore } from "firebase/firestore";
+
+// If running in Firebase App Hosting, you can skip Firebase Config and instead use:
+// const app = initializeApp();
+
+const firebaseConfig = {
+  // Your config options. Get the values by running 'npx -y firebase-tools@latest apps:sdkconfig <platform> <app-id>'
+};
+
+const app = initializeApp(firebaseConfig);
+const db = getFirestore(app);
+
+```
+
+## Writing Data
+
+### Set a Document (`setDoc`)
+Creates a document if it doesn't exist, or overwrites it if it does.
+
+```javascript
+import { doc, setDoc } from "firebase/firestore"; 
+
+// Create/Overwrite document with ID "LA"
+await setDoc(doc(db, "cities", "LA"), {
+  name: "Los Angeles",
+  state: "CA",
+  country: "USA"
+});
+
+// To merge with existing data instead of overwriting:
+await setDoc(doc(db, "cities", "LA"), { population: 3900000 }, { merge: true });
+```
+
+### Add a Document with Auto-ID (`addDoc`)
+Use when you don't care about the document ID.
+
+```javascript
+import { collection, addDoc } from "firebase/firestore"; 
+
+const docRef = await addDoc(collection(db, "cities"), {
+  name: "Tokyo",
+  country: "Japan"
+});
+console.log("Document written with ID: ", docRef.id);
+```
+
+### Update a Document (`updateDoc`)
+Update some fields of an existing document without overwriting the entire document. Fails if the document doesn't exist.
+
+```javascript
+import { doc, updateDoc } from "firebase/firestore";
+
+const laRef = doc(db, "cities", "LA");
+
+await updateDoc(laRef, {
+  capital: true
+});
+```
+
+### Transactions
+Perform an atomic read-modify-write operation.
+
+```javascript
+import { runTransaction, doc } from "firebase/firestore";
+
+const sfDocRef = doc(db, "cities", "SF");
+
+try {
+  await runTransaction(db, async (transaction) => {
+    const sfDoc = await transaction.get(sfDocRef);
+    if (!sfDoc.exists()) {
+      throw "Document does not exist!";
+    }
+
+    const newPopulation = sfDoc.data().population + 1;
+    transaction.update(sfDocRef, { population: newPopulation });
+  });
+  console.log("Transaction successfully committed!");
+} catch (e) {
+  console.log("Transaction failed: ", e);
+}
+```
+
+## Reading Data
+
+### Get a Single Document (`getDoc`)
+
+```javascript
+import { doc, getDoc } from "firebase/firestore";
+
+const docRef = doc(db, "cities", "SF");
+const docSnap = await getDoc(docRef);
+
+if (docSnap.exists()) {
+  console.log("Document data:", docSnap.data());
+} else {
+  console.log("No such document!");
+}
+```
+
+### Get Multiple Documents (`getDocs`)
+Fetches all documents in a query or collection once.
+
+```javascript
+import { collection, getDocs } from "firebase/firestore";
+
+const querySnapshot = await getDocs(collection(db, "cities"));
+querySnapshot.forEach((doc) => {
+  // doc.data() is never undefined for query doc snapshots
+  console.log(doc.id, " => ", doc.data());
+});
+```
+
+## Realtime Updates
+
+### Listen to a Document/Query (`onSnapshot`)
+
+```javascript
+import { doc, onSnapshot } from "firebase/firestore";
+
+const unsub = onSnapshot(doc(db, "cities", "SF"), (doc) => {
+    console.log("Current data: ", doc.data());
+});
+
+// Stop listening
+// unsub();
+```
+
+### Handle Changes (Added/Modified/Removed)
+
+```javascript
+import { collection, query, where, onSnapshot } from "firebase/firestore";
+
+const q = query(collection(db, "cities"), where("state", "==", "CA"));
+const unsubscribe = onSnapshot(q, (snapshot) => {
+  snapshot.docChanges().forEach((change) => {
+    if (change.type === "added") {
+        console.log("New city: ", change.doc.data());
+    }
+    if (change.type === "modified") {
+        console.log("Modified city: ", change.doc.data());
+    }
+    if (change.type === "removed") {
+        console.log("Removed city: ", change.doc.data());
+    }
+  });
+});
+```
+
+## Queries
+
+### Simple and Compound Queries
+Use `query()` to combine filters.
+
+```javascript
+import { collection, query, where, getDocs } from "firebase/firestore";
+
+const citiesRef = collection(db, "cities");
+
+// Simple equality
+const q1 = query(citiesRef, where("state", "==", "CA"));
+
+// Compound (AND)
+// Note: Requires an index if filtering on different fields
+const q2 = query(citiesRef, where("state", "==", "CA"), where("population", ">", 1000000));
+```
+
+### Order and Limit
+Sort and limit results.
+
+```javascript
+import { orderBy, limit } from "firebase/firestore";
+
+const q = query(citiesRef, orderBy("name"), limit(3));
+```

--- a/.agents/skills/firebase-hosting-basics/SKILL.md
+++ b/.agents/skills/firebase-hosting-basics/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: firebase-hosting-basics
+description: Skill for working with Firebase Hosting (Classic). Use this when you want to deploy static web apps, Single Page Apps (SPAs), or simple microservices. Do NOT use for Firebase App Hosting.
+---
+
+# hosting-basics
+
+This skill provides instructions and references for working with Firebase Hosting, a fast and secure hosting service for your web app, static and dynamic content, and microservices.
+
+## Overview
+
+Firebase Hosting provides production-grade web content hosting for developers. With a single command, you can deploy web apps and serve both static and dynamic content to a global CDN (content delivery network).
+
+**Key Features:**
+- **Fast Content Delivery:** Files are cached on SSDs at CDN edges around the world.
+- **Secure by Default:** Zero-configuration SSL is built-in.
+- **Preview Channels:** View and test changes on temporary preview URLs before deploying live.
+- **GitHub Integration:** Automate previews and deploys with GitHub Actions.
+- **Dynamic Content:** Serve dynamic content and microservices using Cloud Functions or Cloud Run.
+
+## Hosting vs App Hosting
+
+**Choose Firebase Hosting if:**
+- You are deploying a static site (HTML/CSS/JS).
+- You are deploying a simple SPA (React, Vue, etc. without SSR).
+- You want full control over the build and deploy process via CLI.
+
+**Choose Firebase App Hosting if:**
+- You are using a supported full-stack framework like Next.js or Angular.
+- You need Server-Side Rendering (SSR) or ISR.
+- You want an automated "git push to deploy" workflow with zero configuration.
+
+## Instructions
+
+### 1. Configuration (`firebase.json`)
+For details on configuring Hosting behavior, including public directories, redirects, rewrites, and headers, see [configuration.md](references/configuration.md).
+
+### 2. Deploying
+For instructions on deploying your site, using preview channels, and managing releases, see [deploying.md](references/deploying.md).
+
+### 3. Emulation
+To test your app locally:
+```bash
+npx -y firebase-tools@latest emulators:start --only hosting
+```
+This serves your app at `http://localhost:5000` by default.

--- a/.agents/skills/firebase-hosting-basics/references/configuration.md
+++ b/.agents/skills/firebase-hosting-basics/references/configuration.md
@@ -1,0 +1,101 @@
+# Hosting Configuration (`firebase.json`)
+
+The `hosting` section of `firebase.json` configures how your site is deployed and served.
+
+## Key Attributes
+
+### `public` (Required)
+Specifies the directory to deploy to Firebase Hosting.
+```json
+"hosting": {
+  "public": "public"
+}
+```
+
+### `ignore` (Optional)
+Files to ignore on deploy. Uses glob patterns (like `.gitignore`).
+**Default ignores:** `firebase.json`, `**/.*`, `**/node_modules/**`
+
+### `redirects` (Optional)
+URL redirects to prevent broken links or shorten URLs.
+```json
+"redirects": [
+  {
+    "source": "/foo",
+    "destination": "/bar",
+    "type": 301
+  }
+]
+```
+
+### `rewrites` (Optional)
+Serve the same content for multiple URLs, useful for SPAs or Dynamic Content.
+```json
+"rewrites": [
+  {
+    "source": "**",
+    "destination": "/index.html"
+  },
+  {
+    "source": "/api/**",
+    "function": "apiFunction"
+  },
+  {
+    "source": "/container/**",
+    "run": {
+      "serviceId": "helloworld",
+      "region": "us-central1"
+    }
+  }
+]
+```
+
+### `headers` (Optional)
+Custom response headers.
+```json
+"headers": [
+  {
+    "source": "**/*.@(eot|otf|ttf|ttc|woff|font.css)",
+    "headers": [
+      {
+        "key": "Access-Control-Allow-Origin",
+        "value": "*"
+      }
+    ]
+  }
+]
+```
+
+### `cleanUrls` (Optional)
+If `true`, drops `.html` extension from URLs.
+```json
+"cleanUrls": true
+```
+
+### `trailingSlash` (Optional)
+Controls trailing slashes in static content URLs.
+- `true`: Adds trailing slash.
+- `false`: Removes trailing slash.
+
+## Full Example
+
+```json
+{
+  "hosting": {
+    "public": "dist",
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ],
+    "rewrites": [
+      {
+        "source": "**",
+        "destination": "/index.html"
+      }
+    ],
+    "cleanUrls": true,
+    "trailingSlash": false
+  }
+}
+```

--- a/.agents/skills/firebase-hosting-basics/references/deploying.md
+++ b/.agents/skills/firebase-hosting-basics/references/deploying.md
@@ -1,0 +1,39 @@
+# Deploying to Firebase Hosting
+
+## Standard Deployment
+To deploy your Hosting content and configuration to your live site:
+
+```bash
+npx -y firebase-tools@latest deploy --only hosting
+```
+
+This deploys to your default sites (`PROJECT_ID.web.app` and `PROJECT_ID.firebaseapp.com`).
+
+## Preview Channels
+Preview channels allow you to test changes on a temporary URL before going live.
+
+### Deploy to a Preview Channel
+```bash
+npx -y firebase-tools@latest hosting:channel:deploy CHANNEL_ID
+```
+Replace `CHANNEL_ID` with a name (e.g., `feature-beta`).
+This returns a preview URL like `PROJECT_ID--CHANNEL_ID-RANDOM_HASH.web.app`.
+
+### Expiration
+Channels expire after 7 days by default. To set a different expiration:
+```bash
+npx -y firebase-tools@latest hosting:channel:deploy CHANNEL_ID --expires 1d
+```
+
+## Cloning to Live
+You can promote a version from a preview channel to your live channel without rebuilding.
+
+```bash
+npx -y firebase-tools@latest hosting:clone SOURCE_SITE_ID:SOURCE_CHANNEL_ID TARGET_SITE_ID:live
+```
+
+**Example:**
+Clone the `feature-beta` channel on your default site to live:
+```bash
+npx -y firebase-tools@latest hosting:clone my-project:feature-beta my-project:live
+```

--- a/.agents/skills/firebase-local-env-setup/SKILL.md
+++ b/.agents/skills/firebase-local-env-setup/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: firebase-local-env-setup
+description: Bare minimum INITIAL setup for getting started with Firebase (Node.js, CLI installation, first-time login). Use ONLY for first-time setup. For updating, troubleshooting, or refreshing an existing environment, use the firebase-basics skill instead.
+---
+
+# Firebase Local Environment Setup
+
+This skill documents the bare minimum setup required for a full Firebase experience for the agent. Before starting to use any Firebase features, you MUST verify that each of the following steps has been completed.
+
+## 1. Verify Node.js
+- **Action**: Run `node --version`.
+- **Handling**: Ensure Node.js is installed and the version is `>= 20`. If Node.js is missing or `< v20`, install it based on the operating system:
+
+  **Recommended: Use a Node Version Manager**
+  This avoids permission issues when installing global packages.
+
+  **For macOS or Linux:**
+  1. Guide the user to the [official nvm repository](https://github.com/nvm-sh/nvm#installing-and-updating).
+  2. Request the user to manually install `nvm` and reply when finished. **Stop and wait** for the user's confirmation.
+  3. Make `nvm` available in the current terminal session by sourcing the appropriate profile:
+     ```bash
+     # For Bash
+     source ~/.bash_profile
+     source ~/.bashrc
+
+     # For Zsh
+     source ~/.zprofile
+     source ~/.zshrc
+     ```
+  4. Install Node.js:
+     ```bash
+     nvm install 24
+     nvm use 24
+     ```
+
+  **For Windows:**
+  1. Guide the user to download and install [nvm-windows](https://github.com/coreybutler/nvm-windows/releases).
+  2. Request the user to manually install `nvm-windows` and Node.js, and reply when finished. **Stop and wait** for the user's confirmation.
+  3. After the user confirms, verify Node.js is available:
+     ```bash
+     node --version
+     ```
+
+  **Alternative: Official Installer**
+  1. Guide the user to download and install the LTS version from [nodejs.org](https://nodejs.org/en/download).
+  2. Request the user to manually install Node.js and reply when finished. **Stop and wait** for the user's confirmation.
+
+## 2. Verify Firebase CLI
+The Firebase CLI is the primary tool for interacting with Firebase services.
+- **Action**: Run `npx -y firebase-tools@latest --version`.
+- **Handling**: Ensure this command runs successfully and outputs a version number.
+
+## 3. Verify Firebase Authentication
+You must be authenticated to manage Firebase projects.
+- **Action**: Run `npx -y firebase-tools@latest login`.
+- **Handling**: If the environment is remote or restricted (no browser access), run `npx -y firebase-tools@latest login --no-localhost` instead.
+
+## 4. Install Agent Skills and MCP Server
+To fully manage Firebase, the agent needs specific skills and the Firebase MCP server installed. Identify the agent environment you are currently running in and follow the corresponding setup document strictly.
+
+**Read the setup document for your current agent:**
+- **Gemini CLI**: Review [references/gemini_cli.md](references/gemini_cli.md)
+- **Antigravity**: Review [references/antigravity.md](references/antigravity.md)
+- **Claude Code**: Review [references/claude_code.md](references/claude_code.md)
+- **Cursor**: Review [references/cursor.md](references/cursor.md)
+- **GitHub Copilot**: Review [references/github_copilot.md](references/github_copilot.md)
+- **Other Agents** (Windsurf, Cline, etc.): Review [references/other_agents.md](references/other_agents.md)
+
+---
+**CRITICAL AGENT RULE:** Do NOT proceed with any other Firebase tasks until EVERY step above has been successfully verified and completed.

--- a/.agents/skills/firebase-local-env-setup/references/antigravity.md
+++ b/.agents/skills/firebase-local-env-setup/references/antigravity.md
@@ -1,0 +1,63 @@
+# Antigravity Setup
+
+To get the most out of Firebase in Antigravity, follow these steps to install the agent skills and the MCP server.
+
+### 1. Install and Verify Firebase Skills
+Check if the skills are already installed before proceeding:
+
+1. **Check Local skills**: Run `ls -d .agent/skills/firebase-basics` or `ls -d .agents/skills/firebase-basics`. If the directory exists, the skills are already installed locally.
+2. **Check Global skills**: If not found locally, check the global installation by running:
+   ```bash
+   npx skills list --global --agent antigravity
+   ```
+   If the output includes `firebase-basics`, the skills are already installed globally.
+3. **Install Skills**: If both checks fail, run the following command to install the Firebase agent skills:
+   ```bash
+   npx skills add firebase/agent-skills --agent antigravity --skill "*"
+   ```
+   *Note: Omit `--yes` and `--global` to choose the installation location manually. If prompted interactively in the terminal, ensure you send the appropriate user choices via standard input to complete the installation.*
+4. **Verify Installation**: Re-run the checks in steps 1 or 2 to confirm that `firebase-basics` is now available.
+
+### 2. Configure and Verify Firebase MCP Server
+The MCP server allows Antigravity to interact directly with Firebase projects.
+
+1. **Locate `mcp_config.json`**: Find the configuration file for your operating system:
+   - macOS / Linux: `~/.gemini/antigravity/mcp_config.json`
+   - Windows: `%USERPROFILE%\\.gemini\\antigravity\\mcp_config.json`
+   
+   *Note: If the `.gemini/antigravity/` directory or `mcp_config.json` file does not exist, create them and initialize the file with `{ "mcpServers": {} }` before proceeding.*
+2. **Check Existing Configuration**: Open `mcp_config.json` and check the `mcpServers` section for a `firebase` entry.
+   - It is already configured if the `command` is `"firebase"` OR if the `command` is `"npx"` with `"firebase-tools"` and `"mcp"` in the `args`.
+   - **Important**: If a valid `firebase` entry is found, the MCP server is already configured. **Skip step 3** and proceed directly to step 4.
+   
+   **Example valid configurations**:
+   ```json
+   "firebase": {
+     "command": "npx",
+     "args": ["-y", "firebase-tools@latest", "mcp"]
+   }
+   ```
+   OR
+   ```json
+   "firebase": {
+     "command": "firebase",
+     "args": ["mcp"]
+   }
+   ```
+3. **Add or Update Configuration**: If the `firebase` block is missing or incorrect, add it to the `mcpServers` object:
+   ```json
+   "firebase": {
+     "command": "npx",
+     "args": [
+       "-y",
+       "firebase-tools@latest",
+       "mcp"
+     ]
+   }
+   ```
+   *CRITICAL: Merge this configuration into the existing `mcp_config.json` file. You MUST preserve any other existing servers inside the `mcpServers` object.*
+4. **Verify Configuration**: Save the file and confirm the `firebase` block is present and properly formatted JSON.
+
+### 3. Restart and Verify Connection
+1. **Restart Antigravity**: Instruct the user to restart the Antigravity application. **Stop and wait** for their confirmation before proceeding.
+2. **Confirm Connection**: Check the MCP server list in the Antigravity UI to confirm that the Firebase MCP server is connected.

--- a/.agents/skills/firebase-local-env-setup/references/claude_code.md
+++ b/.agents/skills/firebase-local-env-setup/references/claude_code.md
@@ -1,0 +1,30 @@
+# Claude Code Setup
+
+To get the most out of Firebase in Claude Code, follow these steps to install the agent skills and the MCP server.
+
+## Recommended Method: Using Plugins
+
+The recommended method is using the plugin marketplace to install both the agent skills and the MCP functionality.
+
+### 1. Install and Verify Plugins
+
+Check if the plugins are already installed before proceeding:
+
+1. **Check Existing Skills**: Run `npx skills list --agent claude-code` to check for local skills. Run `npx skills list --global --agent claude-code` to check for global skills. Note whether the output includes `firebase-basics`.
+2. **Check Existing MCP Configuration**: Run `claude mcp list -s user` and `claude mcp list -s project`. Note whether the output of either command includes `firebase`.
+3. **Determine Installation Path**:
+   - If **both** skills and MCP configuration are found, the plugin is fully installed. **Stop here and skip all remaining setup steps in this document.**
+   - If **neither** are found, proceed to step 4.
+   - If **only one** is found (e.g., skills are installed but MCP is missing, or vice versa), **stop and prompt the user**. Explain the mixed state and ask if they want to proceed with installing the Firebase plugin before continuing to step 4.
+4. **Add Marketplace**: Run the following command to add the marketplace (this uses the default User scope):
+   ```bash
+   claude plugin marketplace add firebase/agent-skills
+   ```
+5. **Install Plugins**: Run the following command to install the plugin:
+   ```bash
+   claude plugin install firebase@firebase
+   ```
+6. **Verify Installation**: Re-run the checks in steps 1 and 2 to confirm the skills and the MCP server are now available.
+
+### 2. Restart and Verify Connection
+1. **Restart Claude Code**: Instruct the user to restart Claude Code. **Stop and wait** for their confirmation before proceeding.

--- a/.agents/skills/firebase-local-env-setup/references/cursor.md
+++ b/.agents/skills/firebase-local-env-setup/references/cursor.md
@@ -1,0 +1,63 @@
+# Cursor Setup
+
+To get the most out of Firebase in Cursor, follow these steps to install the agent skills and the MCP server.
+
+### 1. Install and Verify Firebase Skills
+Check if the skills are already installed before proceeding:
+
+1. **Check Local skills**: Run `npx skills list --agent cursor`. If the output includes `firebase-basics`, the skills are already installed locally.
+2. **Check Global skills**: If not found locally, check the global installation by running:
+   ```bash
+   npx skills list --global --agent cursor
+   ```
+   If the output includes `firebase-basics`, the skills are already installed globally.
+3. **Install Skills**: If both checks fail, run the following command to install the Firebase agent skills:
+   ```bash
+   npx skills add firebase/agent-skills --agent cursor --skill "*"
+   ```
+   *Note: Omit `--yes` and `--global` to choose the installation location manually. If prompted interactively in the terminal, ensure you send the appropriate user choices via standard input to complete the installation.*
+4. **Verify Installation**: Re-run the checks in steps 1 or 2 to confirm that `firebase-basics` is now available.
+
+### 2. Configure and Verify Firebase MCP Server
+The MCP server allows Cursor to interact directly with Firebase projects.
+
+1. **Locate `mcp.json`**: Find the configuration file for your operating system:
+   - Global: `~/.cursor/mcp.json`
+   - Project: `.cursor/mcp.json`
+   
+   *Note: If the directory or `mcp.json` file does not exist, create them and initialize the file with `{ "mcpServers": {} }` before proceeding.*
+2. **Check Existing Configuration**: Open `mcp.json` and check the `mcpServers` section for a `firebase` entry.
+   - It is already configured if the `command` is `"firebase"` OR if the `command` is `"npx"` with `"firebase-tools"` and `"mcp"` in the `args`.
+   - **Important**: If a valid `firebase` entry is found, the MCP server is already configured. **Skip step 3** and proceed directly to step 4.
+   
+   **Example valid configurations**:
+   ```json
+   "firebase": {
+     "command": "npx",
+     "args": ["-y", "firebase-tools@latest", "mcp"]
+   }
+   ```
+   OR
+   ```json
+   "firebase": {
+     "command": "firebase",
+     "args": ["mcp"]
+   }
+   ```
+3. **Add or Update Configuration**: If the `firebase` block is missing or incorrect, add it to the `mcpServers` object:
+   ```json
+   "firebase": {
+     "command": "npx",
+     "args": [
+       "-y",
+       "firebase-tools@latest",
+       "mcp"
+     ]
+   }
+   ```
+   *CRITICAL: Merge this configuration into the existing `mcp.json` file. You MUST preserve any other existing servers inside the `mcpServers` object.*
+4. **Verify Configuration**: Save the file and confirm the `firebase` block is present and properly formatted JSON.
+
+### 3. Restart and Verify Connection
+1. **Restart Cursor**: Instruct the user to restart the Cursor application. **Stop and wait** for their confirmation before proceeding.
+2. **Confirm Connection**: Check the MCP server list in the Cursor UI to confirm that the Firebase MCP server is connected.

--- a/.agents/skills/firebase-local-env-setup/references/gemini_cli.md
+++ b/.agents/skills/firebase-local-env-setup/references/gemini_cli.md
@@ -1,0 +1,39 @@
+# Gemini CLI Setup
+
+To get the most out of Firebase in the Gemini CLI, follow these steps to install the agent extension and the MCP server.
+
+## Recommended: Installing Extensions
+
+The best way to get both the agent skills and the MCP server is via the Gemini extension.
+
+### 1. Install and Verify Firebase Extension
+Check if the extension is already installed before proceeding:
+
+1. **Check Existing Extensions**: Run `gemini extensions list`. If the output includes `firebase`, the extension is already installed.
+2. **Install Extension**: If not found, run the following command to install the Firebase agent skills and MCP server:
+   ```bash
+   gemini extensions install https://github.com/firebase/agent-skills
+   ```
+3. **Verify Installation**: Run the following checks to confirm installation:
+   - `gemini mcp list` -> Output should include `firebase-tools`.
+   - `gemini skills list` -> Output should include `firebase-basic`.
+
+### 2. Restart and Verify Connection
+1. **Restart Gemini CLI**: Instruct the user to restart the Gemini CLI if any new installation occurred. **Stop and wait** for their confirmation before proceeding.
+
+---
+
+## Alternative: Manual MCP Configuration (Project Scope)
+
+If the user only wants to use the MCP server for the current project:
+
+### 1. Configure and Verify Firebase MCP Server
+1. **Check Existing Configuration**: Run `gemini mcp list`. If the output includes `firebase-tools`, the MCP server is already configured.
+2. **Add the MCP Server**: If not found, run the following command to configure the Firebase MCP Server:
+   ```bash
+   gemini mcp add -e IS_GEMINI_CLI_EXTENSION=true firebase npx -y firebase-tools@latest mcp
+   ```
+3. **Verify Configuration**: Re-run `gemini mcp list` to confirm `firebase-tools` is connected.
+
+### 2. Restart and Verify Connection
+1. **Restart Gemini CLI**: Instruct the user to restart the Gemini CLI. **Stop and wait** for their confirmation before proceeding.

--- a/.agents/skills/firebase-local-env-setup/references/github_copilot.md
+++ b/.agents/skills/firebase-local-env-setup/references/github_copilot.md
@@ -1,0 +1,70 @@
+# GitHub Copilot Setup
+
+To get the most out of Firebase with GitHub Copilot in VS Code, follow these steps to install the agent skills and the MCP server.
+
+## Recommended: Global Setup
+
+The agent skills and MCP server should be installed globally for consistent access across projects.
+
+### 1. Install and Verify Firebase Skills
+Check if the skills are already installed before proceeding:
+
+1. **Check Local skills**: Run `npx skills list --agent github-copilot`. If the output includes `firebase-basics`, the skills are already installed locally.
+2. **Check Global skills**: If not found locally, check the global installation by running:
+   ```bash
+   npx skills list --global --agent github-copilot
+   ```
+   If the output includes `firebase-basics`, the skills are already installed globally.
+3. **Install Skills**: If both checks fail, run the following command to install the Firebase agent skills:
+   ```bash
+   npx skills add firebase/agent-skills --agent github-copilot --skill "*"
+   ```
+   *Note: Omit `--yes` and `--global` to choose the installation location manually. If prompted interactively in the terminal, ensure you send the appropriate user choices via standard input to complete the installation.*
+4. **Verify Installation**: Re-run the checks in steps 1 or 2 to confirm that `firebase-basics` is now available.
+
+### 2. Configure and Verify Firebase MCP Server
+The MCP server allows GitHub Copilot to interact directly with Firebase projects.
+
+1. **Locate `mcp.json`**: Find the configuration file for your environment:
+   - Workspace: `.vscode/mcp.json`
+   - Global: User Settings `mcp.json` file.
+   
+   *Note: If the `.vscode/` directory or `mcp.json` file does not exist, create them and initialize the file with `{ "mcp": { "servers": {} } }` before proceeding.*
+2. **Check Existing Configuration**: Open the `mcp.json` file and check the `mcp.servers` object for a `firebase` entry.
+   - It is already configured if the `command` is `"firebase"` OR if the `command` is `"npx"` with `"firebase-tools"` and `"mcp"` in the `args`.
+   - **Important**: If a valid `firebase` entry is found, the MCP server is already configured. **Skip step 3** and proceed directly to step 4.
+   
+   **Example valid configurations**:
+   ```json
+   "firebase": {
+     "type": "stdio",
+     "command": "npx",
+     "args": ["-y", "firebase-tools@latest", "mcp"]
+   }
+   ```
+   OR
+   ```json
+   "firebase": {
+     "type": "stdio",
+     "command": "firebase",
+     "args": ["mcp"]
+   }
+   ```
+3. **Add or Update Configuration**: If the `firebase` block is missing or incorrect, add it to the `mcp.servers` object:
+   ```json
+   "firebase": {
+     "type": "stdio",
+     "command": "npx",
+     "args": [
+       "-y",
+       "firebase-tools@latest",
+       "mcp"
+     ]
+   }
+   ```
+   *CRITICAL: Merge this configuration into the existing `mcp.json` file under the `mcp.servers` object. You MUST preserve any other existing servers inside `mcp.servers`.*
+4. **Verify Configuration**: Save the file and confirm the `firebase` block is present and properly formatted JSON.
+
+### 3. Restart and Verify Connection
+1. **Restart VS Code**: Instruct the user to restart VS Code. **Stop and wait** for their confirmation before proceeding.
+2. **Confirm Connection**: Check the MCP server list in the VS Code Copilot UI to confirm that the Firebase MCP server is connected.

--- a/.agents/skills/firebase-local-env-setup/references/other_agents.md
+++ b/.agents/skills/firebase-local-env-setup/references/other_agents.md
@@ -1,0 +1,65 @@
+# Other Agents Setup
+
+If you use another agent (like Windsurf, Cline, or Claude Desktop), follow these steps to install the agent skills and the MCP server.
+
+## Recommended: Global Setup
+
+The agent skills and MCP server should be installed globally for consistent access across projects.
+
+### 1. Install and Verify Firebase Skills
+Check if the skills are already installed before proceeding:
+
+1. **Check Local skills**: Run `npx skills list --agent <agent-name>`. If the output includes `firebase-basics`, the skills are already installed locally. Replace `<agent-name>` with the actual agent name, which can be found [here](https://github.com/vercel-labs/skills/blob/main/README.md).
+2. **Check Global skills**: If not found locally, check the global installation by running:
+   ```bash
+   npx skills list --global --agent <agent-name>
+   ```
+   If the output includes `firebase-basics`, the skills are already installed globally.
+3. **Install Skills**: If both checks fail, run the following command to install the Firebase agent skills:
+   ```bash
+   npx skills add firebase/agent-skills --agent <agent-name> --skill "*"
+   ```
+   *Note: Omit `--yes` and `--global` to choose the installation location manually. If prompted interactively in the terminal, ensure you send the appropriate user choices via standard input to complete the installation.*
+4. **Verify Installation**: Re-run the checks in steps 1 or 2 to confirm that `firebase-basics` is now available.
+
+### 2. Configure and Verify Firebase MCP Server
+The MCP server allows the agent to interact directly with Firebase projects.
+
+1. **Locate MCP Configuration**: Find the configuration file for your agent (e.g., `~/.codeium/windsurf/mcp_config.json`, `cline_mcp_settings.json`, or `claude_desktop_config.json`).
+   
+   *Note: If the document or its containing directory does not exist, create them and initialize the file with `{ "mcpServers": {} }` before proceeding.*
+2. **Check Existing Configuration**: Open the configuration file and check the `mcpServers` section for a `firebase` entry.
+   - It is already configured if the `command` is `"firebase"` OR if the `command` is `"npx"` with `"firebase-tools"` and `"mcp"` in the `args`.
+   - **Important**: If a valid `firebase` entry is found, the MCP server is already configured. **Skip step 3** and proceed directly to step 4.
+   
+   **Example valid configurations**:
+   ```json
+   "firebase": {
+     "command": "npx",
+     "args": ["-y", "firebase-tools@latest", "mcp"]
+   }
+   ```
+   OR
+   ```json
+   "firebase": {
+     "command": "firebase",
+     "args": ["mcp"]
+   }
+   ```
+3. **Add or Update Configuration**: If the `firebase` block is missing or incorrect, add it to the `mcpServers` object:
+   ```json
+   "firebase": {
+     "command": "npx",
+     "args": [
+       "-y",
+       "firebase-tools@latest",
+       "mcp"
+     ]
+   }
+   ```
+   *CRITICAL: Merge this configuration into the existing file. You MUST preserve any other existing servers inside the `mcpServers` object.*
+4. **Verify Configuration**: Save the file and confirm the `firebase` block is present and properly formatted JSON.
+
+### 3. Restart and Verify Connection
+1. **Restart Agent**: Instruct the user to restart the agent application. **Stop and wait** for their confirmation before proceeding.
+2. **Confirm Connection**: Check the MCP server list in the agent's UI to confirm that the Firebase MCP server is connected.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,35 @@
+{
+  "version": 1,
+  "skills": {
+    "firebase-ai-logic": {
+      "source": "firebase/agent-skills",
+      "sourceType": "github",
+      "computedHash": "3b3d8994f2ac2e747a1f203488844a7e17b8a25c38e636b221903ae90e3b7c32"
+    },
+    "firebase-auth-basics": {
+      "source": "firebase/agent-skills",
+      "sourceType": "github",
+      "computedHash": "df411eb125374de6086edd38dd739769088b60945052060aec1f57f934be3e27"
+    },
+    "firebase-basics": {
+      "source": "firebase/agent-skills",
+      "sourceType": "github",
+      "computedHash": "dcfb68b53e2a23fc17d0b23a221903d72b475692c23e7018abc99150d740e803"
+    },
+    "firebase-firestore-standard": {
+      "source": "firebase/agent-skills",
+      "sourceType": "github",
+      "computedHash": "433338142338ab05fe004adb37dce8ffbbcbce396303c8bd520ca2cc74f2da78"
+    },
+    "firebase-hosting-basics": {
+      "source": "firebase/agent-skills",
+      "sourceType": "github",
+      "computedHash": "fb86fd4035e8e6379931faeb443557ac6f2e43fde04b397433f287e69b6532a9"
+    },
+    "firebase-local-env-setup": {
+      "source": "firebase/agent-skills",
+      "sourceType": "github",
+      "computedHash": "9a668e12715c38c3041ae9d77bf22fe2c517dd8cc06b88743e9e43f4d39a27de"
+    }
+  }
+}


### PR DESCRIPTION
Closes #179

Adds Firebase agent skills to the project. See the linked issue for full context, install/upgrade commands (pnpm, npm, yarn), and a link to the [Firebase agent skills documentation](https://firebase.google.com/docs/ai-assistance/agent-skills).

Made with [Cursor](https://cursor.com)