### PR TITLE
fix(functions): CORS preflight for cross-origin sync SSE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Package-specific changes:
 
 ### Changed
 
+- **Functions 0.25.1** — Global `/api` CORS (before CSRF) so OPTIONS preflight works for cross-origin sync SSE to Cloud Functions. See [functions/CHANGELOG.md](functions/CHANGELOG.md).
 - **Hosting 0.6.1** — Manual sync SSE requests use the Cloud Functions URL so streams are not buffered by Firebase Hosting; Vitest coverage for `baseUrl` helpers. See [hosting/CHANGELOG.md](hosting/CHANGELOG.md).
 - **Hosting** – Admin UI migrated from Vite to **Next.js 15** (App Router, static export to `hosting/out`); docs and changelogs updated. Firebase Hosting no longer uses an SPA catch-all rewrite (unknown URLs → `404.html`). See [hosting/CHANGELOG.md](hosting/CHANGELOG.md).
 - **Hosting 0.5.0** – Schema documents manual sync **SSE** (`/stream`); JsonCodeBlock examples; Sync page streams progress. See [hosting/CHANGELOG.md](hosting/CHANGELOG.md).

--- a/functions/CHANGELOG.md
+++ b/functions/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.1] - 2026-03-28
+
+### Fixed
+
+- **CORS** – Apply `cors` once for all `/api` routes **before** CSRF so **OPTIONS** preflight succeeds. Cross-origin `fetch` to `*.cloudfunctions.net` with `Authorization` (manual sync SSE from Firebase Hosting) only runs `cors()` on `app.get()`, so preflight previously missed CORS and the browser blocked the stream.
+
+### Developer experience
+
+- **Tests** – Supertest `OPTIONS` preflight for `GET /api/widgets/sync/:provider/stream`.
+
 ## [0.25.0] - 2026-03-27
 
 ### Added

--- a/functions/app/create-express-app.test.ts
+++ b/functions/app/create-express-app.test.ts
@@ -508,6 +508,19 @@ describe('createExpressApp auth and session branches', () => {
     expect(response.text).toBe('Unrecognized or unsupported provider.')
   })
 
+  it('answers CORS preflight OPTIONS for sync stream (Authorization triggers preflight cross-origin)', async () => {
+    const app = await buildApp()
+
+    const response = await request(app)
+      .options('/api/widgets/sync/spotify/stream')
+      .set('Origin', 'https://metrics.chrisvogt.me')
+      .set('Access-Control-Request-Method', 'GET')
+      .set('Access-Control-Request-Headers', 'authorization')
+
+    expect(response.status).toBe(204)
+    expect(response.headers['access-control-allow-origin']).toBe('https://metrics.chrisvogt.me')
+    expect(response.headers['access-control-allow-credentials']).toBe('true')
+  })
 
   it('treats array sync provider params as unsupported', async () => {
     const app = await buildApp()

--- a/functions/app/create-express-app.ts
+++ b/functions/app/create-express-app.ts
@@ -262,6 +262,31 @@ export function createExpressApp({
     })
   )
   expressApp.use(cookieParser())
+
+  const corsAllowList: RegExp[] = [
+    /https?:\/\/([a-z0-9]+[.])*chrisvogt[.]me$/,
+    /https?:\/\/([a-z0-9]+[.])*dev-chrisvogt[.]me:?(.*)$/,
+    /^https?:\/\/([a-z0-9-]+--)?chrisvogt\.netlify\.app$/,
+    /https?:\/\/([a-z0-9]+[.])*chronogrove[.]com$/,
+    /https?:\/\/([a-z0-9]+[.])*dev-chronogrove[.]com$/,
+  ]
+
+  if (!isProductionEnvironment()) {
+    corsAllowList.push(/localhost:?(\d+)?$/)
+  }
+
+  const corsOptions = {
+    origin: corsAllowList,
+    credentials: true,
+  }
+
+  /**
+   * Run before CSRF so OPTIONS preflight for `/api` is answered here (cors ends the response).
+   * Per-route `cors()` on `app.get()` only does not run for OPTIONS, so cross-origin fetches with
+   * `Authorization` (e.g. sync SSE to `*.cloudfunctions.net`) would otherwise fail CORS.
+   */
+  expressApp.use('/api', cors(corsOptions))
+
   expressApp.use(
     lusca.csrf({
       angular: true,
@@ -282,23 +307,6 @@ export function createExpressApp({
     })
   )
 
-  const corsAllowList: RegExp[] = [
-    /https?:\/\/([a-z0-9]+[.])*chrisvogt[.]me$/,
-    /https?:\/\/([a-z0-9]+[.])*dev-chrisvogt[.]me:?(.*)$/,
-    /^https?:\/\/([a-z0-9-]+--)?chrisvogt\.netlify\.app$/,
-    /https?:\/\/([a-z0-9]+[.])*chronogrove[.]com$/,
-    /https?:\/\/([a-z0-9]+[.])*dev-chronogrove[.]com$/,
-  ]
-
-  if (!isProductionEnvironment()) {
-    corsAllowList.push(/localhost:?(\d+)?$/)
-  }
-
-  const corsOptions = {
-    origin: corsAllowList,
-    credentials: true,
-  }
-
   const runSyncHandler = async (
     provider: SyncProviderId
   ): Promise<ManualSyncResult> => runSyncForProvider({
@@ -309,7 +317,6 @@ export function createExpressApp({
 
   expressApp.get(
     '/api/media/{*mediaPath}',
-    cors(corsOptions),
     createRateLimiter(15 * 60 * 1000, 100),
     async (req, res) => {
       const mediaStore = resolveMediaStore()
@@ -352,7 +359,6 @@ export function createExpressApp({
 
   expressApp.get(
     '/api/widgets/sync/:provider/stream',
-    cors(corsOptions),
     createRateLimiter(15 * 60 * 1000, 10),
     async (req, res) => {
       const providerParam = req.params.provider
@@ -399,7 +405,6 @@ export function createExpressApp({
 
   expressApp.get(
     '/api/widgets/sync/:provider',
-    cors(corsOptions),
     createRateLimiter(15 * 60 * 1000, 10),
     async (req, res) => {
       const providerParam = req.params.provider
@@ -421,7 +426,7 @@ export function createExpressApp({
     }
   )
 
-  expressApp.get('/api/widgets/:provider', cors(corsOptions), async (req, res) => {
+  expressApp.get('/api/widgets/:provider', async (req, res) => {
     const provider = req.params.provider
 
     if (!provider || !isWidgetId(provider)) {
@@ -457,7 +462,6 @@ export function createExpressApp({
 
   expressApp.get(
     '/api/user/profile',
-    cors(corsOptions),
     createRateLimiter(15 * 60 * 1000, 50),
     authenticateUser,
     async (req, res) => {
@@ -475,7 +479,6 @@ export function createExpressApp({
 
   expressApp.delete(
     '/api/user/account',
-    cors(corsOptions),
     createRateLimiter(15 * 60 * 1000, 5),
     authenticateUser,
     async (req, res) => {
@@ -501,7 +504,6 @@ export function createExpressApp({
 
   expressApp.post(
     '/api/auth/session',
-    cors(corsOptions),
     createRateLimiter(15 * 60 * 1000, 20),
     async (req, res) => {
       try {
@@ -563,7 +565,6 @@ export function createExpressApp({
 
   expressApp.get(
     '/api/client-auth-config',
-    cors(corsOptions),
     createRateLimiter(15 * 60 * 1000, 20),
     async (_req, res) => {
       await sendClientAuthConfig(res)
@@ -572,14 +573,13 @@ export function createExpressApp({
 
   expressApp.get(
     '/api/firebase-config',
-    cors(corsOptions),
     createRateLimiter(15 * 60 * 1000, 20),
     async (_req, res) => {
       await sendClientAuthConfig(res)
     }
   )
 
-  expressApp.get('/api/csrf-token', cors(corsOptions), (req, res) => {
+  expressApp.get('/api/csrf-token', (req, res) => {
     const csrfToken = typeof req.csrfToken === 'function' ? req.csrfToken() : res.locals._csrf
 
     res.json({
@@ -590,7 +590,6 @@ export function createExpressApp({
 
   expressApp.post(
     '/api/auth/logout',
-    cors(corsOptions),
     createRateLimiter(15 * 60 * 1000, 30),
     authenticateUser,
     async (req, res) => {

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics-functions",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "Personal metrics API. A hobby project tracking my online metrics.",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## Problem

Manual sync SSE calls `*.cloudfunctions.net` from `metrics.chrisvogt.me`. Cross-origin `fetch` with `Authorization` triggers an **OPTIONS** preflight. `cors()` was only attached to `app.get(...)`, so **OPTIONS never hit CORS** and the browser blocked the stream.

## Solution

- `expressApp.use('/api', cors(corsOptions))` **before** CSRF so preflight is answered without a CSRF token.
- Remove per-route `cors(corsOptions)` from API handlers (single global application).

## Release

- **metrics-functions 0.25.1** — see `functions/CHANGELOG.md`.

## Verify

- `pnpm -C functions run test`
- After deploy: manual sync from production UI; Network tab should show successful OPTIONS then GET to the function URL.

Made with [Cursor](https://cursor.com)