### PR TITLE
fix(hosting): Firebase Hosting cache headers for static export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Package-specific changes:
 
 ### Fixed
 
+- **Hosting 0.6.3** — Firebase Hosting `Cache-Control` headers for the static export (revalidate HTML/shell, immutable `/_next/static` chunks) to avoid stale shells and post-deploy `ChunkLoadError`. See [hosting/CHANGELOG.md](hosting/CHANGELOG.md).
 - **Widget API (functions)** – Public `GET /api/widgets/:provider` responses no longer emit CSRF cookies, so Firebase Hosting / CDN can cache them per `Cache-Control` again. See [functions/CHANGELOG.md](functions/CHANGELOG.md) **0.22.17**.
 - **Auth routes (functions)** – `POST /api/auth/session` and `POST /api/auth/logout` are now rate-limited so all authorization routes satisfy CodeQL; session allows 20 req/15 min, logout 30 req/15 min.
 

--- a/firebase.json
+++ b/firebase.json
@@ -20,6 +20,26 @@
         "source": "/api/**",
         "function": "app"
       }
+    ],
+    "headers": [
+      {
+        "source": "**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=0, must-revalidate"
+          }
+        ]
+      },
+      {
+        "source": "/_next/static/**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=31536000, immutable"
+          }
+        ]
+      }
     ]
   },
   "emulators": {

--- a/hosting/CHANGELOG.md
+++ b/hosting/CHANGELOG.md
@@ -7,6 +7,12 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3] - 2026-03-28
+
+### Fixed
+
+- **Firebase Hosting** — `firebase.json` sets `Cache-Control` so HTML and other documents revalidate (`public, max-age=0, must-revalidate`) while `/_next/static/**` remains long-lived (`immutable`), reducing post-deploy `ChunkLoadError` and odd client-side navigation when the CDN or browser kept an older shell.
+
 ## [0.6.2] - 2026-03-28
 
 ### Fixed

--- a/hosting/package.json
+++ b/hosting/package.json
@@ -1,7 +1,7 @@
 {
   "name": "metrics-hosting",
   "private": true,
-  "version": "0.6.2",
+  "version": "0.6.3",
   "scripts": {
     "dev": "next dev --port 5173",
     "build": "next build",


### PR DESCRIPTION
## Summary

Adds explicit `Cache-Control` rules in `firebase.json` so HTML/shell responses revalidate while `/_next/static/**` hashed assets stay long-lived and immutable. This reduces post-deploy `ChunkLoadError` and odd client-side navigation when the CDN or browser cached an older document that referenced removed chunk URLs.

## Changes

- `firebase.json`: `hosting.headers` — `**` → `max-age=0, must-revalidate`; `/_next/static/**` → `max-age=31536000, immutable` (last rule wins for overlapping paths).
- **metrics-hosting 0.6.3** — `hosting/package.json` and changelogs.

## Testing

- `firebase deploy --only hosting --dry-run` succeeded locally before commit.

Made with [Cursor](https://cursor.com)