### PR TITLE
fix(hosting): restore CDN cache headers for widget API paths

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -39,6 +39,24 @@
             "value": "public, max-age=31536000, immutable"
           }
         ]
+      },
+      {
+        "source": "/api/widgets/**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=3600, s-maxage=7200"
+          }
+        ]
+      },
+      {
+        "source": "/api/widgets/sync/**",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache, no-transform"
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
## Summary

The global `**` `Cache-Control` rule in `firebase.json` was overriding Express widget GET responses. Responses showed `public, max-age=0, must-revalidate` and `x-cache: MISS`, so the CDN stopped caching widget JSON and latency jumped (edge hits vs origin).

## Changes

- Add explicit `/api/widgets/**` headers matching the handler: `public, max-age=3600, s-maxage=7200`.
- Add `/api/widgets/sync/**` with `no-cache, no-transform` after the broad rule so sync/SSE routes are not long-cached.

## Verify

After deploy, `GET /api/widgets/:provider` should show the long `Cache-Control` and move toward `x-cache: HIT` on repeat requests.

Made with [Cursor](https://cursor.com)