### PR TITLE
feat(functions): keep full Goodreads AI summary paragraphs (v0.25.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Package-specific changes:
 
 ### Changed
 
+- **Functions 0.25.2** — Goodreads AI summary: prompt allows two or three `<p>` blocks; stored HTML is no longer truncated to two paragraphs (homepage handles “Read more”). See [functions/CHANGELOG.md](functions/CHANGELOG.md).
 - **Hosting 0.6.2** — Overview home cards show Discogs and Goodreads metrics (record-shaped `metrics` and Goodreads fallbacks). See [hosting/CHANGELOG.md](hosting/CHANGELOG.md).
 - **Functions 0.25.1** — Global `/api` CORS (before CSRF) so OPTIONS preflight works for cross-origin sync SSE to Cloud Functions. See [functions/CHANGELOG.md](functions/CHANGELOG.md).
 - **Hosting 0.6.1** — Manual sync SSE requests use the Cloud Functions URL so streams are not buffered by Firebase Hosting; Vitest coverage for `baseUrl` helpers. See [hosting/CHANGELOG.md](hosting/CHANGELOG.md).

--- a/functions/CHANGELOG.md
+++ b/functions/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.2] - 2026-03-28
+
+### Changed
+
+- **Goodreads AI summary** – Gemini prompt asks for **two or three** `<p>` paragraphs (replacing “exactly two”). `normalizeParagraphSummary` keeps **all** returned `<p>` blocks; the homepage UI collapses extra paragraphs behind “Read more,” so the backend no longer truncates a third paragraph.
+
+### Developer experience
+
+- **Tests** – `generate-goodreads-summary` asserts full multi-paragraph HTML and updated prompt copy.
+
 ## [0.25.1] - 2026-03-28
 
 ### Fixed
@@ -540,6 +550,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _This changelog was started with v0.8.0._
 
+[0.25.2]: https://github.com/chrisvogt/metrics/compare/v0.25.1...v0.25.2
+[0.25.1]: https://github.com/chrisvogt/metrics/compare/v0.25.0...v0.25.1
 [0.25.0]: https://github.com/chrisvogt/metrics/compare/v0.24.0...v0.25.0
 [0.24.0]: https://github.com/chrisvogt/metrics/compare/v0.23.0...v0.24.0
 [0.23.0]: https://github.com/chrisvogt/metrics/compare/v0.22.0...v0.23.0

--- a/functions/api/goodreads/generate-goodreads-summary.test.ts
+++ b/functions/api/goodreads/generate-goodreads-summary.test.ts
@@ -340,7 +340,7 @@ describe('generateGoodreadsSummary', () => {
     
     // Verify prompt contains instructions
     expect(promptCall).toContain('chrisvogt.me')
-    expect(promptCall).toContain('Exactly two')
+    expect(promptCall).toContain('Two or three')
     expect(promptCall).toContain('Third person')
   })
 
@@ -361,7 +361,7 @@ describe('generateGoodreadsSummary', () => {
     expect(result).toBe('Plain fallback copy.')
   })
 
-  it('keeps only the first two <p> elements when the model returns extra paragraphs', async () => {
+  it('keeps all <p> elements when the model returns two or three paragraphs', async () => {
     process.env.GEMINI_API_KEY = 'test-api-key'
 
     mockGenerateContent.mockResolvedValue({
@@ -381,7 +381,9 @@ describe('generateGoodreadsSummary', () => {
       profile: { displayName: 'Chris Vogt' },
     })
 
-    expect(result).toBe('<p>First graph.</p><p>Second graph.</p>')
+    expect(result).toBe(
+      '<p>First graph.</p><p>Second graph.</p><p>Third graph.</p>',
+    )
   })
 
   it('maps sparse widget books into completeReadShelf and omits categories when absent', async () => {

--- a/functions/api/goodreads/generate-goodreads-summary.ts
+++ b/functions/api/goodreads/generate-goodreads-summary.ts
@@ -17,26 +17,22 @@ type GeminiGoodreadsSummaryJson = {
   debug?: Record<string, unknown>
 }
 
-/** UI on chrisvogt.me expects exactly two <p> blocks side by side with the book list */
+/** Extract top-level <p> blocks; the homepage UI collapses extra paragraphs behind “Read more”. */
 const extractParagraphTags = (html: string): string[] => {
   const re = /<p\b[^>]*>[\s\S]*?<\/p>/gi
   return html.match(re) ?? []
 }
 
-const ensureTwoParagraphSummary = (html: string): string => {
+const normalizeParagraphSummary = (html: string): string => {
   const paras = extractParagraphTags(html)
   if (paras.length === 0) {
     return html.trim()
   }
   if (paras.length === 1) {
-    logger.warn('Goodreads AI summary contained only one <p>; homepage layout expects two.')
+    logger.warn('Goodreads AI summary contained only one <p>.')
     return paras[0]
   }
-  if (paras.length > 2) {
-    logger.info(`Goodreads AI summary had ${paras.length} <p> tags; using the first two for the widget.`)
-    return paras[0] + paras[1]
-  }
-  return paras[0] + paras[1]
+  return paras.join('')
 }
 
 /**
@@ -76,7 +72,7 @@ You are writing a short, reader-facing “AI reading summary” for Chris Vogt�
 
 Return **valid JSON only** (no markdown fences, no commentary) using this shape:
 {
-  "response": "<string: exactly two HTML paragraphs, see rules below>",
+  "response": "<string: two or three HTML paragraphs, see rules below>",
   "debug": {
     "recentlyReadBooks": [...],
     "readingPatterns": [...]
@@ -84,7 +80,7 @@ Return **valid JSON only** (no markdown fences, no commentary) using this shape:
 }
 
 Rules for the "response" string (strict — the UI is built for this):
-- **Exactly two** <p>...</p> elements, back-to-back, with nothing before, between, or after them (no wrapper <div>, no line breaks outside the tags).
+- **Two or three** <p>...</p> elements, back-to-back, with nothing before, between, or after them (no wrapper <div>, no line breaks outside the tags).
 - **Third person** only, referring to him as **Chris** (e.g. “Chris tends to…”, “He often…”). Never “I”, “you”, or “the reader”.
 - Tone: calm, specific, a little editorial — like a sharp one-column blurb in a magazine, not marketing fluff. Avoid generic openers (“Chris loves books”, “As an avid reader”).
 - **Do not** repeat or enumerate the book list; at most **one** quick nod to a title or theme if it sharpens a point. Ratings are visible elsewhere — mention them only if unusual or telling.
@@ -115,7 +111,7 @@ Goodreads Profile: ${profile?.name || profile?.username || 'Chris Vogt'}
       throw new Error('Gemini response was not valid JSON (no markdown block or raw JSON)')
     }
     const { response: sanitizedResponse = '' } = parsed
-    return ensureTwoParagraphSummary(sanitizedResponse)
+    return normalizeParagraphSummary(sanitizedResponse)
   } catch (error) {
     logger.error('Error generating Goodreads summary with Gemini:', error)
     throw new Error(`Failed to generate AI summary: ${error.message}`, { cause: error })

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics-functions",
-  "version": "0.25.1",
+  "version": "0.25.2",
   "description": "Personal metrics API. A hobby project tracking my online metrics.",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
- Replace ensureTwoParagraphSummary with normalizeParagraphSummary; join all <p> blocks instead of truncating after two.
- Prompt: two or three paragraphs to match homepage Read more UI.
- Changelog (root + functions) and metrics-functions version 0.25.2.

Made-with: Cursor