### PR TITLE
fix(ci): bust Turbo cache for hosting build so Git SHA matches deploy

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -5,6 +5,15 @@
       "outputs": ["dist", "lib", "out"],
       "dependsOn": []
     },
+    /**
+     * `NEXT_PUBLIC_GIT_SHA` is baked into the static export in `hosting/next.config.ts`.
+     * Without this, Turbo can restore a cached `hosting/out` whenever only other packages
+     * (e.g. `functions/`) or repo-root files like `firebase.json` change — so Hosting
+     * deploys would ship an old UI while still showing an outdated commit in the sidebar.
+     */
+    "metrics-hosting#build": {
+      "env": ["GITHUB_SHA"]
+    },
     "dev": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
## Summary

Turborepo was restoring a cached `hosting/out` when only `functions/` or repo-root files (e.g. `firebase.json`) changed. Firebase Hosting then deployed stale static assets while Functions and Hosting config updated, so the sidebar still showed an old `NEXT_PUBLIC_GIT_SHA`.

## Change

- Add `GITHUB_SHA` to the `metrics-hosting#build` task `env` in `turbo.json` so each CI commit gets a fresh Next static export and the displayed commit matches what was built.

## Verify

After merge, the next push to `main` should show the current short SHA in the Chronogrove sidebar on metrics.chrisvogt.me.

Made with [Cursor](https://cursor.com)