### PR TITLE
Increase Goodreads widget display from 24 to 30 books

### DIFF
--- a/functions/config/goodreads-config.ts
+++ b/functions/config/goodreads-config.ts
@@ -5,7 +5,7 @@
  * BOOKS_TO_DISPLAY: Number of books to store and display in the widget.
  */
 export const GOODREADS_BOOKS_TO_FETCH = 30
-export const GOODREADS_BOOKS_TO_DISPLAY = 24
+export const GOODREADS_BOOKS_TO_DISPLAY = 30
 
 /**
  * Page size when paginating the entire "read" shelf for the AI summary only.


### PR DESCRIPTION
Updates `GOODREADS_BOOKS_TO_DISPLAY` from 24 to 30 in `functions/config/goodreads-config.ts`. `GOODREADS_BOOKS_TO_FETCH` was already 30, so no other changes were required.

Made with [Cursor](https://cursor.com)