### PR TITLE
feat(functions): Goodreads widget fetch buffer + config tests (v0.25.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Package-specific changes:
 
 ### Changed
 
+- **Functions 0.25.4** — Goodreads widget requests **35** shelf rows (30 display + **5** buffer) so failed lookups are less likely to shrink the grid below 30 titles. See [functions/CHANGELOG.md](functions/CHANGELOG.md).
 - **Functions 0.25.3** — Lazy backend bootstrap in the Firebase entrypoint so deploy-time export discovery no longer reads `STORAGE_FIRESTORE_DATABASE_URL.value()` early; tests updated for first-request initialization. See [functions/CHANGELOG.md](functions/CHANGELOG.md).
 - **Functions 0.25.2** — Goodreads AI summary: prompt allows two or three `<p>` blocks; stored HTML is no longer truncated to two paragraphs (homepage handles “Read more”). See [functions/CHANGELOG.md](functions/CHANGELOG.md).
 - **Hosting 0.6.2** — Overview home cards show Discogs and Goodreads metrics (record-shaped `metrics` and Goodreads fallbacks). See [hosting/CHANGELOG.md](hosting/CHANGELOG.md).

--- a/functions/CHANGELOG.md
+++ b/functions/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.4] - 2026-03-30
+
+### Changed
+
+- **Goodreads widget** — `GOODREADS_BOOKS_TO_FETCH` is **35** (30 displayed titles plus a **five-book** buffer) so ISBN/Google Books misses do not routinely leave the widget short of 30 books. Relationship documented in `goodreads-config.ts`.
+
+### Developer experience
+
+- **Tests** — `goodreads-config.test.ts` asserts fetch vs display and AI shelf caps; `fetch-recently-read-books.test.ts` expects Goodreads `per_page=35`.
+
 ## [0.25.3] - 2026-03-29
 
 ### Fixed
@@ -560,6 +570,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _This changelog was started with v0.8.0._
 
+[0.25.4]: https://github.com/chrisvogt/metrics/compare/v0.25.3...v0.25.4
+[0.25.3]: https://github.com/chrisvogt/metrics/compare/v0.25.2...v0.25.3
 [0.25.2]: https://github.com/chrisvogt/metrics/compare/v0.25.1...v0.25.2
 [0.25.1]: https://github.com/chrisvogt/metrics/compare/v0.25.0...v0.25.1
 [0.25.0]: https://github.com/chrisvogt/metrics/compare/v0.24.0...v0.25.0

--- a/functions/api/goodreads/fetch-recently-read-books.test.ts
+++ b/functions/api/goodreads/fetch-recently-read-books.test.ts
@@ -153,7 +153,7 @@ describe('fetchRecentlyReadBooks', () => {
 
     // Verify Goodreads API was called
     expect(mockGot).toHaveBeenCalledWith(
-      'https://www.goodreads.com/review/list/test-user-id.xml?key=test-api-key&v=2&shelf=read&sort=date_read&per_page=30'
+      'https://www.goodreads.com/review/list/test-user-id.xml?key=test-api-key&v=2&shelf=read&sort=date_read&per_page=35'
     )
 
     // Verify XML parsing was called

--- a/functions/config/goodreads-config.test.ts
+++ b/functions/config/goodreads-config.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  GOODREADS_AI_READ_SHELF_MAX_PAGES,
+  GOODREADS_AI_READ_SHELF_PER_PAGE,
+  GOODREADS_BOOKS_TO_DISPLAY,
+  GOODREADS_BOOKS_TO_FETCH,
+} from './goodreads-config.js'
+
+describe('goodreads-config', () => {
+  it('sizes widget fetch above display so failed lookups can still fill the widget', () => {
+    expect(GOODREADS_BOOKS_TO_DISPLAY).toBe(30)
+    expect(GOODREADS_BOOKS_TO_FETCH).toBe(35)
+    expect(GOODREADS_BOOKS_TO_FETCH).toBeGreaterThan(GOODREADS_BOOKS_TO_DISPLAY)
+  })
+
+  it('exports AI read-shelf pagination caps', () => {
+    expect(GOODREADS_AI_READ_SHELF_PER_PAGE).toBe(200)
+    expect(GOODREADS_AI_READ_SHELF_MAX_PAGES).toBe(10)
+  })
+})

--- a/functions/config/goodreads-config.ts
+++ b/functions/config/goodreads-config.ts
@@ -1,11 +1,17 @@
 /**
  * Goodreads widget configuration.
- * BOOKS_TO_FETCH: Number of books to fetch from Goodreads and process (Google Books API, thumbnails).
- *   Includes buffer for failures—some books may not be found or lack thumbnails.
- * BOOKS_TO_DISPLAY: Number of books to store and display in the widget.
+ * BOOKS_TO_DISPLAY: Number of books to store and show in the widget.
+ * BOOKS_TO_FETCH: Goodreads `per_page` and how many reviews we resolve via Google Books.
+ *   Must be larger than BOOKS_TO_DISPLAY: rows without ISBN, Google Books misses, and
+ *   title-search fallbacks reduce the list before we slice to display count.
  */
-export const GOODREADS_BOOKS_TO_FETCH = 30
 export const GOODREADS_BOOKS_TO_DISPLAY = 30
+
+/** Extra shelf rows beyond display so failures still yield a full widget. */
+const GOODREADS_WIDGET_FETCH_BUFFER = 5
+
+export const GOODREADS_BOOKS_TO_FETCH =
+  GOODREADS_BOOKS_TO_DISPLAY + GOODREADS_WIDGET_FETCH_BUFFER
 
 /**
  * Page size when paginating the entire "read" shelf for the AI summary only.

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics-functions",
-  "version": "0.25.3",
+  "version": "0.25.4",
   "description": "Personal metrics API. A hobby project tracking my online metrics.",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
Request 35 shelf rows (30 display + 5 buffer) so lookups can still fill the grid. Add goodreads-config.test.ts for invariants; bump functions package and changelogs.

Made-with: Cursor