### PR TITLE
feat(functions): switch widget API to revalidation-first caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Package-specific changes:
 
 ### Changed
 
+- **Functions 0.25.6** — Widget API caching now favors revalidation across all providers: browser responses revalidate (`max-age=0, must-revalidate`) while shared caches keep a short TTL (`s-maxage=300`, `stale-while-revalidate=60`) to reduce stale widget payloads after sync. See [functions/CHANGELOG.md](functions/CHANGELOG.md).
 - **Functions 0.25.5** — Removed `requestretry` from Spotify profile/top-tracks requests, standardized on a shared `got` Spotify client (retry + JSON defaults), and added unit coverage for that shared client. See [functions/CHANGELOG.md](functions/CHANGELOG.md).
 - **Functions 0.25.4** — Goodreads widget requests **35** shelf rows (30 display + **5** buffer) so failed lookups are less likely to shrink the grid below 30 titles. See [functions/CHANGELOG.md](functions/CHANGELOG.md).
 - **Functions 0.25.3** — Lazy backend bootstrap in the Firebase entrypoint so deploy-time export discovery no longer reads `STORAGE_FIRESTORE_DATABASE_URL.value()` early; tests updated for first-request initialization. See [functions/CHANGELOG.md](functions/CHANGELOG.md).

--- a/functions/CHANGELOG.md
+++ b/functions/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.6] - 2026-03-31
+
+### Changed
+
+- **Widget API caching** — `GET /api/widgets/:provider` now uses revalidation-first caching (`max-age=0, must-revalidate`) with short shared-cache freshness (`s-maxage=300`, `stale-while-revalidate=60`) so synced widget data is refreshed quickly across providers without long-lived stale responses.
+
 ## [0.25.5] - 2026-03-30
 
 ### Changed

--- a/functions/app/create-express-app.ts
+++ b/functions/app/create-express-app.ts
@@ -437,7 +437,11 @@ export function createExpressApp({
       const widgetContent: WidgetContentUnion =
         await getWidgetContent(provider, userId, documentStore)
       const response = buildSuccessResponse(widgetContent)
-      res.set('Cache-Control', 'public, max-age=3600, s-maxage=7200')
+      // Always revalidate at the client, while allowing short shared-cache freshness.
+      res.set(
+        'Cache-Control',
+        'public, max-age=0, s-maxage=300, must-revalidate, stale-while-revalidate=60',
+      )
       res.status(200).send(response)
     } catch (err) {
       logger.error('Error loading widget content', {

--- a/functions/index.test.ts
+++ b/functions/index.test.ts
@@ -186,7 +186,9 @@ describe('index.js', () => {
           ok: true,
           payload: { mock: 'widget-content' }
         })
-        expect(response.headers['cache-control']).toBe('public, max-age=3600, s-maxage=7200')
+        expect(response.headers['cache-control']).toBe(
+          'public, max-age=0, s-maxage=300, must-revalidate, stale-while-revalidate=60'
+        )
         expect(response.headers['set-cookie']).toBeUndefined()
       })
 

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "metrics-functions",
-  "version": "0.25.5",
+  "version": "0.25.6",
   "description": "Personal metrics API. A hobby project tracking my online metrics.",
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## Summary
- switch `GET /api/widgets/:provider` to a revalidation-first cache policy across all providers: `public, max-age=0, s-maxage=300, must-revalidate, stale-while-revalidate=60`
- update the widget API cache-header assertion in `functions/index.test.ts`
- bump Functions package to `0.25.6` and document the release in `functions/CHANGELOG.md` and root `CHANGELOG.md`

## Test plan
- [x] `pnpm -C functions test`
- [x] `pnpm -C functions lint` (passes with one unrelated pre-existing warning)

Made with [Cursor](https://cursor.com)