### PR TITLE
feat(sync): manual Flickr sync uses signed-in OAuth integration

### DIFF
--- a/functions/app/create-express-app.route-coverage.test.ts
+++ b/functions/app/create-express-app.route-coverage.test.ts
@@ -350,6 +350,55 @@ describe('createExpressApp route coverage', () => {
     expect(response.end).toHaveBeenCalled()
   })
 
+  it('passes integrationLookupUserId on manual sync SSE when req.user.uid is set', async () => {
+    const { runSyncForProvider } = await import('../services/sync-manual.js')
+    vi.mocked(runSyncForProvider).mockResolvedValueOnce({
+      afterJob: { jobId: 'j1', status: 'completed' },
+      beforeJob: { jobId: 'j1', status: 'queued' },
+      enqueue: { jobId: 'j1', status: 'enqueued' },
+      worker: { jobId: 'j1', result: 'SUCCESS' },
+    })
+
+    const { createExpressApp } = await import('./create-express-app.js')
+    const app = createExpressApp({
+      authService,
+      documentStore,
+      ensureRuntimeConfigApplied,
+      getClientAuthConfig,
+      logger,
+      resolveMediaStore: () => new LocalDiskMediaStore('/tmp/metrics-unused-route-coverage'),
+      syncJobQueue,
+    })
+
+    const streamHandler = findRouteHandler(app, 'get', '/api/widgets/sync/:provider/stream')
+    const response = {
+      setHeader: vi.fn(),
+      write: vi.fn(),
+      end: vi.fn(),
+    }
+
+    const reqUser = {
+      email: 'ops@chrisvogt.me',
+      emailVerified: true,
+      uid: 'sse-signed-in-uid',
+    }
+
+    await streamHandler(
+      { params: { provider: 'flickr' }, user: reqUser },
+      response
+    )
+
+    expect(runSyncForProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        documentStore,
+        integrationLookupUserId: 'sse-signed-in-uid',
+        provider: 'flickr',
+        syncJobQueue,
+        onProgress: expect.any(Function),
+      }),
+    )
+  })
+
   it('returns 400 for manual sync stream when provider param is not a string', async () => {
     const { createExpressApp } = await import('./create-express-app.js')
     const app = createExpressApp({

--- a/functions/app/create-express-app.test.ts
+++ b/functions/app/create-express-app.test.ts
@@ -497,6 +497,7 @@ describe('createExpressApp auth and session branches', () => {
 
     expect(runSyncForProvider).toHaveBeenCalledWith({
       documentStore,
+      integrationLookupUserId: 'test-uid',
       provider,
       syncJobQueue,
     })

--- a/functions/app/create-express-app.ts
+++ b/functions/app/create-express-app.ts
@@ -364,11 +364,13 @@ export function createExpressApp({
   })
 
   const runSyncHandler = async (
-    provider: SyncProviderId
+    provider: SyncProviderId,
+    integrationLookupUserId?: string
   ): Promise<ManualSyncResult> => runSyncForProvider({
     documentStore,
     provider,
     syncJobQueue,
+    ...(integrationLookupUserId ? { integrationLookupUserId } : {}),
   })
 
   expressApp.get(
@@ -445,6 +447,7 @@ export function createExpressApp({
           documentStore,
           provider,
           syncJobQueue,
+          ...(req.user?.uid ? { integrationLookupUserId: req.user.uid } : {}),
           onProgress: (event) => writeEvent({ type: 'progress', ...event }),
         })
         writeEvent({ type: 'done', result })
@@ -475,7 +478,7 @@ export function createExpressApp({
       }
 
       try {
-        const result = await runSyncHandler(provider)
+        const result = await runSyncHandler(provider, req.user?.uid)
         res.status(200).send(result)
       } catch (err) {
         logger.error(`Error syncing ${provider} data.`, err)

--- a/functions/index.test.ts
+++ b/functions/index.test.ts
@@ -301,6 +301,7 @@ describe('index.js', () => {
           .expect(200)
 
         expect(runSyncForProvider).toHaveBeenCalledWith(expect.objectContaining({
+          integrationLookupUserId: 'sync-test-uid',
           provider: 'spotify',
         }))
         expect(response.body.enqueue.status).toBe('enqueued')
@@ -317,6 +318,7 @@ describe('index.js', () => {
 
         expect(response.body.worker.result).toBe('SUCCESS')
         expect(runSyncForProvider).toHaveBeenCalledWith(expect.objectContaining({
+          integrationLookupUserId: 'sync-test-uid',
           provider: 'flickr',
         }))
       })

--- a/functions/jobs/sync-flickr-data.boundary.test.ts
+++ b/functions/jobs/sync-flickr-data.boundary.test.ts
@@ -20,6 +20,7 @@ describe('syncFlickrData boundary wiring', () => {
     const { default: syncFlickrData } = await import('./sync-flickr-data.js')
 
     await expect(syncFlickrData(injectedStore)).resolves.toEqual({
+      flickrAuthMode: 'env',
       result: 'SUCCESS',
       widgetContent: expect.any(Object),
     })

--- a/functions/jobs/sync-flickr-data.test.ts
+++ b/functions/jobs/sync-flickr-data.test.ts
@@ -39,6 +39,40 @@ describe('syncFlickrData', () => {
     delete process.env.FLICKR_USER_ID
   })
 
+  it('reports OAuth vs legacy in flickr.auth progress messages', async () => {
+    const onProgress = vi.fn()
+    vi.mocked(fetchPhotos).mockResolvedValue({ total: 0, photos: [] })
+
+    await syncFlickrData(documentStore, { onProgress })
+
+    expect(onProgress).toHaveBeenCalledWith(
+      expect.objectContaining({
+        phase: 'flickr.auth',
+        message: expect.stringContaining('legacy'),
+      })
+    )
+
+    onProgress.mockClear()
+    vi.mocked(loadFlickrAuthForUser).mockResolvedValue({
+      mode: 'oauth',
+      consumerKey: 'ck',
+      consumerSecret: 'cs',
+      userNsid: 'nsid-99',
+      oauthToken: 'ot',
+      oauthTokenSecret: 'os',
+      flickrUsername: 'bert',
+    })
+
+    await syncFlickrData(documentStore, { onProgress })
+
+    expect(onProgress).toHaveBeenCalledWith(
+      expect.objectContaining({
+        phase: 'flickr.auth',
+        message: expect.stringContaining('OAuth'),
+      })
+    )
+  })
+
   it('uses OAuth profile and fetchPhotos({ oauth }) when integration is connected', async () => {
     const oauth = {
       mode: 'oauth' as const,
@@ -58,7 +92,9 @@ describe('syncFlickrData', () => {
 
     const result = await syncFlickrData(documentStore)
 
+    expect(loadFlickrAuthForUser).toHaveBeenCalledWith(documentStore, 'chrisvogt')
     expect(fetchPhotos).toHaveBeenCalledWith({ oauth })
+    expect(result).toMatchObject({ flickrAuthMode: 'oauth', result: 'SUCCESS' })
     expect(result.widgetContent.profile).toEqual({
       displayName: 'ernie',
       profileURL: 'https://www.flickr.com/photos/ernie/',
@@ -131,6 +167,7 @@ describe('syncFlickrData', () => {
     )
 
     expect(result).toEqual({
+      flickrAuthMode: 'env',
       result: 'SUCCESS',
       widgetContent: {
         collections: {
@@ -157,6 +194,7 @@ describe('syncFlickrData', () => {
       totalPhotos: 2,
       photosFetched: 2,
       userId: 'chrisvogt',
+      integrationLookupUserId: 'chrisvogt',
       authMode: 'env',
     })
   })
@@ -175,6 +213,7 @@ describe('syncFlickrData', () => {
       totalPhotos: 0,
       photosFetched: 0,
       userId: 'chrisvogt',
+      integrationLookupUserId: 'chrisvogt',
       authMode: 'env',
     })
   })
@@ -317,6 +356,41 @@ describe('syncFlickrData', () => {
       userId: 'chrisvogt',
     })
 
+    expect(documentStore.setDocument).toHaveBeenNthCalledWith(
+      1,
+      'users/chrisvogt/flickr/last-response',
+      expect.any(Object)
+    )
+    expect(documentStore.setDocument).toHaveBeenNthCalledWith(
+      2,
+      'users/chrisvogt/flickr/widget-content',
+      expect.any(Object)
+    )
+  })
+
+  it('loads OAuth via integrationLookupUserId but writes widget paths for userId', async () => {
+    const oauth = {
+      mode: 'oauth' as const,
+      consumerKey: 'ck',
+      consumerSecret: 'cs',
+      userNsid: 'nsid-firebase',
+      oauthToken: 'ot',
+      oauthTokenSecret: 'os',
+      flickrUsername: 'from-oauth',
+    }
+    vi.mocked(loadFlickrAuthForUser).mockImplementation(async (_store, uid) =>
+      uid === 'firebase-abc' ? oauth : null
+    )
+    vi.mocked(fetchPhotos).mockResolvedValue({ total: 0, photos: [] })
+
+    const result = await syncFlickrData(documentStore, {
+      userId: 'chrisvogt',
+      integrationLookupUserId: 'firebase-abc',
+    })
+
+    expect(loadFlickrAuthForUser).toHaveBeenCalledWith(documentStore, 'firebase-abc')
+    expect(fetchPhotos).toHaveBeenCalledWith({ oauth })
+    expect(result).toMatchObject({ flickrAuthMode: 'oauth' })
     expect(documentStore.setDocument).toHaveBeenNthCalledWith(
       1,
       'users/chrisvogt/flickr/last-response',

--- a/functions/jobs/sync-flickr-data.ts
+++ b/functions/jobs/sync-flickr-data.ts
@@ -21,14 +21,25 @@ const syncFlickrData = async (
 ) => {
   const logger = getLogger()
   const { onProgress } = options
-  const userId = options.userId ?? getDefaultWidgetUserId()
+  const storageUserId = options.userId ?? getDefaultWidgetUserId()
+  const integrationLookupUserId = options.integrationLookupUserId ?? storageUserId
 
   const envConfig = getFlickrConfig()
   let displayName: string | undefined = envConfig.userId ?? undefined
   let profilePathSegment = envConfig.userId ?? ''
 
   try {
-    const oauth = await loadFlickrAuthForUser(documentStore, userId)
+    const oauth = await loadFlickrAuthForUser(documentStore, integrationLookupUserId)
+    const flickrAuthMode = oauth ? 'oauth' : 'env'
+
+    onProgress?.({
+      phase: 'flickr.auth',
+      message:
+        flickrAuthMode === 'oauth'
+          ? 'Using your connected Flickr account (OAuth).'
+          : 'Using server Flickr API credentials (legacy).',
+    })
+
     if (oauth) {
       displayName = oauth.flickrUsername || oauth.userNsid
       profilePathSegment = oauth.flickrUsername || oauth.userNsid
@@ -46,7 +57,7 @@ const syncFlickrData = async (
       phase: 'flickr.persist',
       message: 'Reticulating splines.',
     })
-    await documentStore.setDocument(toFlickrLastResponsePath(options), {
+    await documentStore.setDocument(toFlickrLastResponsePath({ ...options, userId: storageUserId }), {
       response: photosResponse,
       fetchedAt: toStoredDateTime(),
     })
@@ -78,16 +89,18 @@ const syncFlickrData = async (
       },
     }
 
-    await documentStore.setDocument(toFlickrWidgetContentPath(options), widgetContent)
+    await documentStore.setDocument(toFlickrWidgetContentPath({ ...options, userId: storageUserId }), widgetContent)
 
     logger.info('Flickr data sync completed successfully', {
       totalPhotos: photoCount,
       photosFetched: photos.length,
-      userId,
-      authMode: oauth ? 'oauth' : 'env',
+      userId: storageUserId,
+      integrationLookupUserId,
+      authMode: flickrAuthMode,
     })
 
     return {
+      flickrAuthMode,
       result: 'SUCCESS',
       widgetContent,
     }

--- a/functions/services/sync-manual.test.ts
+++ b/functions/services/sync-manual.test.ts
@@ -86,6 +86,33 @@ describe('runSyncForProvider', () => {
     expect(processSyncJob).toHaveBeenCalled()
   })
 
+  it('passes integrationLookupUserId through to enqueue when provided', async () => {
+    vi.mocked(syncJobQueue.enqueue).mockResolvedValueOnce({
+      jobId: 'sync-chrisvogt-flickr',
+      status: 'enqueued',
+    })
+    vi.mocked(syncJobQueue.claimJob).mockResolvedValueOnce(null)
+    vi.mocked(syncJobQueue.getJob).mockResolvedValue({
+      jobId: 'sync-chrisvogt-flickr',
+      status: 'queued',
+    })
+
+    await runSyncForProvider({
+      documentStore,
+      provider: 'flickr',
+      syncJobQueue,
+      userId: 'chrisvogt',
+      integrationLookupUserId: 'firebase-uid-1',
+    })
+
+    expect(syncJobQueue.enqueue).toHaveBeenCalledWith({
+      mode: 'sync',
+      provider: 'flickr',
+      userId: 'chrisvogt',
+      integrationLookupUserId: 'firebase-uid-1',
+    })
+  })
+
   it('returns NOOP worker status when the job cannot be claimed', async () => {
     vi.mocked(syncJobQueue.claimJob).mockResolvedValueOnce(null)
 

--- a/functions/services/sync-manual.ts
+++ b/functions/services/sync-manual.ts
@@ -22,18 +22,21 @@ export const runSyncForProvider = async ({
   provider,
   syncJobQueue,
   userId = getDefaultWidgetUserId(),
+  integrationLookupUserId,
   onProgress,
 }: {
   documentStore: DocumentStore
   provider: SyncProviderId
   syncJobQueue: SyncJobQueue
   userId?: string
+  integrationLookupUserId?: string
   onProgress?: SyncProgressReporter
 }): Promise<ManualSyncResult> => {
   const enqueue = await syncJobQueue.enqueue({
     mode: 'sync',
     provider,
     userId,
+    ...(integrationLookupUserId ? { integrationLookupUserId } : {}),
   })
 
   const beforeJob = await syncJobQueue.getJob(enqueue.jobId)

--- a/functions/services/sync-worker.test.ts
+++ b/functions/services/sync-worker.test.ts
@@ -343,6 +343,57 @@ describe('runNextSyncJob', () => {
     })
   })
 
+  it('passes integrationLookupUserId into Flickr jobs without onProgress', async () => {
+    vi.mocked(syncFlickrData).mockResolvedValue({ flickrAuthMode: 'oauth', result: 'SUCCESS' })
+
+    await processSyncJob({
+      documentStore,
+      job: {
+        runCount: 1,
+        enqueuedAt: '2026-03-21T02:00:00.000Z',
+        jobId: 'sync-chrisvogt-flickr',
+        integrationLookupUserId: 'firebase-integration-uid',
+        mode: 'sync',
+        provider: 'flickr',
+        status: 'processing',
+        updatedAt: '2026-03-21T02:00:00.000Z',
+        userId: 'chrisvogt',
+      },
+      syncJobQueue,
+    })
+
+    expect(syncFlickrData).toHaveBeenCalledWith(documentStore, {
+      integrationLookupUserId: 'firebase-integration-uid',
+      userId: 'chrisvogt',
+    })
+  })
+
+  it('returns flickrAuthMode on successful Flickr sync', async () => {
+    vi.mocked(syncFlickrData).mockResolvedValue({
+      flickrAuthMode: 'env',
+      result: 'SUCCESS',
+    })
+
+    await expect(processSyncJob({
+      documentStore,
+      job: {
+        runCount: 1,
+        enqueuedAt: '2026-03-21T02:00:00.000Z',
+        jobId: 'sync-chrisvogt-flickr',
+        mode: 'sync',
+        provider: 'flickr',
+        status: 'processing',
+        updatedAt: '2026-03-21T02:00:00.000Z',
+        userId: 'chrisvogt',
+      },
+      syncJobQueue,
+    })).resolves.toEqual({
+      flickrAuthMode: 'env',
+      jobId: 'sync-chrisvogt-flickr',
+      result: 'SUCCESS',
+    })
+  })
+
   it('fails with a helpful error when the provider is not implemented', async () => {
     await expect(processSyncJob({
       documentStore,

--- a/functions/services/sync-worker.ts
+++ b/functions/services/sync-worker.ts
@@ -21,6 +21,7 @@ import type { SyncProviderId } from '../types/widget-content.js'
 interface SyncExecutionResult {
   data?: unknown
   error?: unknown
+  flickrAuthMode?: 'env' | 'oauth'
   metrics?: Record<string, number>
   result: 'FAILURE' | 'SUCCESS'
 }
@@ -60,10 +61,15 @@ const buildSummary = (
   }
 }
 
-const jobExecOpts = (job: QueuedSyncJob, onProgress?: SyncProgressReporter) =>
-  onProgress
+const jobExecOpts = (job: QueuedSyncJob, onProgress?: SyncProgressReporter) => {
+  const opts = onProgress
     ? { userId: job.userId, onProgress }
     : { userId: job.userId }
+  if (job.integrationLookupUserId) {
+    return { ...opts, integrationLookupUserId: job.integrationLookupUserId }
+  }
+  return opts
+}
 
 const runSyncJob = async (
   job: QueuedSyncJob,
@@ -94,6 +100,8 @@ const runSyncJob = async (
 
 export interface SyncWorkerResult {
   jobId?: string
+  /** Present after a successful Flickr sync (manual or scheduled). */
+  flickrAuthMode?: 'env' | 'oauth'
   result: 'FAILURE' | 'NOOP' | 'SUCCESS'
 }
 
@@ -123,9 +131,11 @@ export const processSyncJob = async ({
         provider: job.provider,
         userId: job.userId,
       })
+      const flickrAuthMode = result.flickrAuthMode
       return {
         jobId: job.jobId,
         result: 'SUCCESS',
+        ...(flickrAuthMode ? { flickrAuthMode } : {}),
       }
     }
 

--- a/functions/types/sync-pipeline.ts
+++ b/functions/types/sync-pipeline.ts
@@ -8,6 +8,12 @@ export interface QueuedSyncJobDescriptor {
   mode: 'sync'
   provider: SyncProviderId
   userId: string
+  /**
+   * When set (manual sync with a signed-in user), Flickr OAuth credentials are
+   * loaded from `users/{integrationLookupUserId}/integrations/flickr` while
+   * widget documents still use `userId` (default widget owner id).
+   */
+  integrationLookupUserId?: string
 }
 
 /** Streamed to the browser during manual sync (SSE); ignored by scheduled worker. */
@@ -21,6 +27,8 @@ export type SyncProgressReporter = (event: SyncProgressEvent) => void
 
 export interface SyncJobExecutionOptions {
   userId?: string
+  /** See {@link QueuedSyncJobDescriptor.integrationLookupUserId}. */
+  integrationLookupUserId?: string
   onProgress?: SyncProgressReporter
 }
 

--- a/hosting/src/lib/readFlickrAuthModeFromSyncPayload.test.ts
+++ b/hosting/src/lib/readFlickrAuthModeFromSyncPayload.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { readFlickrAuthModeFromSyncPayload } from './readFlickrAuthModeFromSyncPayload.js'
+
+describe('readFlickrAuthModeFromSyncPayload', () => {
+  it('returns oauth when worker.flickrAuthMode is oauth', () => {
+    expect(
+      readFlickrAuthModeFromSyncPayload({
+        worker: { flickrAuthMode: 'oauth' },
+      })
+    ).toBe('oauth')
+  })
+
+  it('returns env when worker.flickrAuthMode is env', () => {
+    expect(
+      readFlickrAuthModeFromSyncPayload({
+        worker: { flickrAuthMode: 'env' },
+      })
+    ).toBe('env')
+  })
+
+  it('returns undefined for invalid or missing modes', () => {
+    expect(readFlickrAuthModeFromSyncPayload(null)).toBeUndefined()
+    expect(readFlickrAuthModeFromSyncPayload(undefined)).toBeUndefined()
+    expect(readFlickrAuthModeFromSyncPayload('')).toBeUndefined()
+    expect(readFlickrAuthModeFromSyncPayload({})).toBeUndefined()
+    expect(readFlickrAuthModeFromSyncPayload({ worker: {} })).toBeUndefined()
+    expect(
+      readFlickrAuthModeFromSyncPayload({ worker: { flickrAuthMode: 'other' } })
+    ).toBeUndefined()
+  })
+})

--- a/hosting/src/lib/readFlickrAuthModeFromSyncPayload.ts
+++ b/hosting/src/lib/readFlickrAuthModeFromSyncPayload.ts
@@ -1,0 +1,8 @@
+export type FlickrAuthMode = 'env' | 'oauth'
+
+export function readFlickrAuthModeFromSyncPayload(data: unknown): FlickrAuthMode | undefined {
+  if (!data || typeof data !== 'object') return undefined
+  const worker = (data as { worker?: { flickrAuthMode?: unknown } }).worker
+  const mode = worker?.flickrAuthMode
+  return mode === 'oauth' || mode === 'env' ? mode : undefined
+}

--- a/hosting/src/sections/ApiTestingSection.module.css
+++ b/hosting/src/sections/ApiTestingSection.module.css
@@ -171,6 +171,30 @@
   word-break: break-word;
 }
 
+.flickrAuthBadge {
+  margin-top: 0.75rem;
+  padding: 0.45rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border: 1px solid var(--border-strong);
+  background: color-mix(in srgb, var(--surface) 92%, var(--accent) 8%);
+  color: var(--text);
+}
+
+.flickrAuthBadgeOAuth {
+  border-color: color-mix(in srgb, var(--success) 45%, var(--border) 55%);
+  background: color-mix(in srgb, var(--success) 12%, var(--surface) 88%);
+}
+
+.flickrAuthBadgeLegacy {
+  border-color: color-mix(in srgb, var(--text-muted) 35%, var(--border) 65%);
+  background: color-mix(in srgb, var(--text-muted) 8%, var(--surface) 92%);
+}
+
 .inlineCode {
   font-family: var(--font-mono);
   font-size: 0.88em;

--- a/hosting/src/sections/ApiTestingSection.tsx
+++ b/hosting/src/sections/ApiTestingSection.tsx
@@ -5,6 +5,7 @@ import type { SectionId } from '../layout/Layout'
 import { useAuth } from '../auth/AuthContext'
 import { ApiClient } from '../auth/apiClient'
 import { getAppBaseUrl, getManualSyncStreamUrl } from '../lib/baseUrl'
+import { readFlickrAuthModeFromSyncPayload } from '../lib/readFlickrAuthModeFromSyncPayload'
 import styles from './ApiTestingSection.module.css'
 
 const WIDGET_PROVIDERS = ['discogs', 'flickr', 'github', 'goodreads', 'instagram', 'spotify', 'steam'] as const
@@ -66,6 +67,10 @@ export function ApiTestingSection({ activeSection }: ApiTestingSectionProps) {
 
   const showApi = activeSection === 'api'
   const showSync = activeSection === 'sync'
+  const syncFlickrAuthMode =
+    showSync && syncProvider === 'flickr' && syncResult?.ok
+      ? readFlickrAuthModeFromSyncPayload(syncResult.data)
+      : undefined
 
   const fetchToken = async () => {
     if (!user) return
@@ -319,6 +324,9 @@ export function ApiTestingSection({ activeSection }: ApiTestingSectionProps) {
               Run the queue-backed sync via{' '}
               <code className={styles.inlineCode}>GET /api/widgets/sync/&#123;provider&#125;/stream</code>{' '}
               so you can watch live steps and inspect the same final payload returned by the JSON endpoint.
+              {syncProvider === 'flickr'
+                ? ' Flickr manual sync loads OAuth from your signed-in user when you have connected Flickr; widget data still updates the default site owner path.'
+                : ''}
             </p>
             <div className={styles.endpoint}>
               <span className={styles.methodGet}>GET</span>
@@ -359,6 +367,20 @@ export function ApiTestingSection({ activeSection }: ApiTestingSectionProps) {
                     {syncThinkingLine}
                   </p>
                 </div>
+              ) : null}
+              {syncFlickrAuthMode ? (
+                <p
+                  className={`${styles.flickrAuthBadge} ${
+                    syncFlickrAuthMode === 'oauth'
+                      ? styles.flickrAuthBadgeOAuth
+                      : styles.flickrAuthBadgeLegacy
+                  }`}
+                  role="status"
+                >
+                  {syncFlickrAuthMode === 'oauth'
+                    ? 'Flickr credentials: OAuth (connected account)'
+                    : 'Flickr credentials: legacy (server API key)'}
+                </p>
               ) : null}
               {syncResult && <ResultBox result={syncResult} />}
             </div>

--- a/hosting/vitest.config.ts
+++ b/hosting/vitest.config.ts
@@ -7,7 +7,12 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],
-      include: ['src/lib/baseUrl.ts', 'src/lib/buildSha.ts', 'src/lib/overviewMetrics.ts'],
+      include: [
+        'src/lib/baseUrl.ts',
+        'src/lib/buildSha.ts',
+        'src/lib/overviewMetrics.ts',
+        'src/lib/readFlickrAuthModeFromSyncPayload.ts',
+      ],
       all: true,
       thresholds: {
         perFile: true,


### PR DESCRIPTION
## Summary

Manual widget sync (JSON and SSE) now passes the authenticated user\u2019s Firebase Auth uid as `integrationLookupUserId` on the sync job. The Flickr job loads OAuth credentials from `users/{uid}/integrations/flickr` while continuing to write widget documents under the default site owner id, so scheduled planner/worker behavior is unchanged.

## UX

- Sync page: progress includes a `flickr.auth` step (OAuth vs legacy copy).
- After a successful Flickr sync, the UI shows whether **OAuth (connected account)** or **legacy (server API key)** was used (`worker.flickrAuthMode`).
- Flickr sync help text on the Sync page explains the signed-in vs site-owner path split.

## Tests

- Route coverage for SSE with `req.user`, `sync-worker` integration + `flickrAuthMode`, Flickr progress messaging, and a small hosted lib helper (`readFlickrAuthModeFromSyncPayload`) under full Vitest coverage thresholds for included files.

Made with [Cursor](https://cursor.com)