### PR TITLE
chore: pin Next for App Hosting CVE gate, disable prod deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,9 @@ jobs:
   deploy-live:
     name: Deploy App Hosting (production)
     needs: lint-and-test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    # Temporarily disabled. Re-enable with:
+    # if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: ${{ false }}
     runs-on: ubuntu-latest
     concurrency:
       group: apphosting-deploy-production

--- a/firebase.json
+++ b/firebase.json
@@ -26,7 +26,8 @@
         ".turbo",
         "**/node_modules",
         "**/.next/cache"
-      ]
+      ],
+      "alwaysDeployFromSource": true
     },
     {
       "backendId": "chronogrove-console-pr",

--- a/hosting/package.json
+++ b/hosting/package.json
@@ -16,7 +16,7 @@
     "hast-util-to-jsx-runtime": "^2.3.6",
     "highlight.js": "^11.11.1",
     "lowlight": "^3.3.0",
-    "next": "^15.5.14",
+    "next": "15.5.14",
     "next-themes": "^0.4.6",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,7 +130,7 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0
       next:
-        specifier: ^15.5.14
+        specifier: 15.5.14
         version: 15.5.14(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: ^0.4.6


### PR DESCRIPTION
## Summary
- Pin `next` to **15.5.14** (exact) so Firebase App Hosting’s `@apphosting/adapter-nextjs` CVE check receives a real semver from `FRAMEWORK_VERSION` (ranges like `^15.5.14` fail `semver.satisfies`).
- Refresh `pnpm-lock.yaml`.
- Set `alwaysDeployFromSource` on `chronogrove-console` in `firebase.json`.
- **Disable** the `deploy-live` GitHub Actions job (`if: ${{ false }}`) until App Hosting CI deploy/IAM is stable; restore the previous `if:` when re-enabling.

## Test plan
- [ ] `pnpm install` / `pnpm run build` (already verified locally)
- [ ] Re-enable deploy job when ready and confirm Firebase deploy

Made with [Cursor](https://cursor.com)