### PR TITLE
feat: block PHP scanner paths in Next.js middleware

### DIFF
--- a/hosting/src/middleware.ts
+++ b/hosting/src/middleware.ts
@@ -40,8 +40,12 @@ const SCANNER_PATTERN = new RegExp(
   'i'
 )
 
+/** Root / nested PHP probes (e.g. /admin.php); real app has no .php routes. */
+const PHP_PROBE = /\.php$/i
+
 export function middleware(request: NextRequest) {
-  if (SCANNER_PATTERN.test(request.nextUrl.pathname)) {
+  const path = request.nextUrl.pathname
+  if (SCANNER_PATTERN.test(path) || PHP_PROBE.test(path)) {
     return new NextResponse(null, { status: 403 })
   }
 


### PR DESCRIPTION
## Summary
Extends the existing scanner middleware to return **403** for any path whose pathname ends in `.php`, in addition to the prefix-based list (wp-admin, .env, etc.).

Root-level probes like `/admin.php` or `/aa.php` were not matched by `/wp-*` prefixes.

## Notes
- The app has no `.php` routes; this only affects automated probes.
- `/_next/static` remains excluded from the matcher so real assets are unchanged.

Made with [Cursor](https://cursor.com)