### PR TITLE
feat(auth,console): session alignment, onboarding gate, dashboard polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Package-specific changes:
 
 ### Changed
 
+- **Workspace** — **Console 0.6.22** and **Functions 0.30.1**: account-switching session handling (stale HttpOnly **`session`** vs Firebase ID token), **`POST /api/auth/clear-session-cookie`**, onboarding redirect until a public **username** is chosen, **`getIdToken(true)`** for session cookie minting, dashboard hero hostname resolution (**`resolveDashboardTenantHostname`**), and overview **quick links** (**`buildOverviewQuickLinks`**) with Vitest coverage for the new helpers. See [functions/CHANGELOG.md](functions/CHANGELOG.md) and [apps/console/CHANGELOG.md](apps/console/CHANGELOG.md).
+
 - **Workspace** — **Console 0.6.20** and **Functions 0.30.0**: public tenant API and status routing ([GitHub #256](https://github.com/chrisvogt/chronogrove/issues/256)): optional widget **`uid`** / **`username`** query params; removed default **`api.chronogrove.com → chronogrove`** hostname map; console **`/u/[username]`**, **`/widgets/*`** rewrite, **`src/proxy.ts`** **`/`** → **`/u/{slug}`**, **`apps/console/.env.template`**, dev SSR widget fetches via **`127.0.0.1:5001`** emulator. See [functions/CHANGELOG.md](functions/CHANGELOG.md), [apps/console/CHANGELOG.md](apps/console/CHANGELOG.md), [docs/APP_HOSTING.md](docs/APP_HOSTING.md).
 
 - **Workspace** — **Console 0.6.19**: **Next.js 16.2.x** (from 15.5.x), **`next.config.mjs`**, **`src/proxy.ts`** (replaces deprecated middleware convention), **`tsconfig`** updates from Next; Vitest mock fix for Strict Mode in settings username check. See [apps/console/CHANGELOG.md](apps/console/CHANGELOG.md).

--- a/apps/console/.env.template
+++ b/apps/console/.env.template
@@ -13,6 +13,9 @@
 # Public hostname for this deployment (overview hero, headers). No protocol.
 # NEXT_PUBLIC_TENANT_DISPLAY_HOST=www.chrisvogt.me
 
+# Shared public API hostname for the dashboard hero when the user has a username but no custom domain (default: api.chronogrove.com).
+# NEXT_PUBLIC_DEFAULT_PUBLIC_API_HOST=api.chronogrove.com
+
 # Hostname shown as the CNAME target in onboarding / DNS copy.
 # NEXT_PUBLIC_ONBOARDING_CNAME_TARGET=personal-stats-chrisvogt.web.app
 

--- a/apps/console/CHANGELOG.md
+++ b/apps/console/CHANGELOG.md
@@ -7,6 +7,23 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.22] - 2026-04-10
+
+### Added
+
+- **Onboarding username gate** — Verified users who have not chosen a public slug (no persisted **`username`** and **`username`** not in **`completedSteps`**) are redirected to **`/onboarding/`** after the API session is ready. Marketing and auth routes are excluded (**`/about`**, **`/docs`**, **`/privacy`**, **`/verify-email`**, **`/signup`**, **`/auth`**, public **`/u/*`**).
+- **Tests** — **`src/lib/overviewQuickLinks.test.ts`** (dashboard quick-link URLs for signed-in vs signed-out); **`src/lib/tenantDisplay.test.ts`** (**`resolveDashboardTenantHostname`**); **`src/lib/onboardingUsernameCompletion.test.ts`** (**`hasCompletedUsernameSelection`**).
+
+### Changed
+
+- **Auth / session** — Clear stale HttpOnly **`session`** cookies when switching Firebase accounts (**`POST /api/auth/clear-session-cookie`**, **`apiClient.clearStaleSessionCookie`**, **`AuthContext`** on uid change and before email sign-up). Session creation uses a **force-refreshed** ID token (**`getIdToken(true)`**) so **`email_verified`** matches the server after verification links.
+- **Dashboard quick links** — Overview card links are **Settings**, **Docs**, **Public status page** (when a public **username** exists) or **Account setup**, and **GitHub**; signed-out visitors see **Docs**, **About**, and **Sign in**. Implemented as **`buildOverviewQuickLinks`** in **`src/lib/overviewQuickLinks.ts`** (used by **`OverviewSection`**).
+
+### Fixed
+
+- **Dashboard hero** — Headline uses **`GET /api/onboarding/progress`**: configured **`customDomain`** (tenant API host) when set, else **`NEXT_PUBLIC_DEFAULT_PUBLIC_API_HOST`** (default **`api.chronogrove.com`**) when a public **username** exists, else **`NEXT_PUBLIC_TENANT_DISPLAY_HOST`**. **`resolveDashboardTenantHostname`** in **`src/lib/tenantDisplay.ts`**.
+- **Dashboard hero typography** — Relaxed **`line-height`**, added slight **`padding-bottom`**, and set the hero to **`overflow: visible`** so gradient headline text does not clip descenders (e.g. “g”).
+
 ## [0.6.21] - 2026-04-08
 
 ### Changed

--- a/apps/console/next.config.mjs
+++ b/apps/console/next.config.mjs
@@ -53,6 +53,8 @@ const nextConfig = {
     NEXT_PUBLIC_CLOUD_FUNCTIONS_APP_ORIGIN: cloudFunctionsAppOrigin,
     NEXT_PUBLIC_ONBOARDING_CNAME_TARGET:
       process.env.NEXT_PUBLIC_ONBOARDING_CNAME_TARGET ?? 'personal-stats-chrisvogt.web.app',
+    NEXT_PUBLIC_DEFAULT_PUBLIC_API_HOST:
+      process.env.NEXT_PUBLIC_DEFAULT_PUBLIC_API_HOST ?? '',
   },
   async rewrites() {
     const apiRewrite =

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "license": "Apache-2.0",
   "description": "Chronogrove operator console: Next.js admin UI (SSR on Firebase App Hosting) for schema, status, sync, and onboarding.",
-  "version": "0.6.21",
+  "version": "0.6.22",
   "engines": {
     "node": ">=24"
   },

--- a/apps/console/src/app/providers.tsx
+++ b/apps/console/src/app/providers.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from 'react'
 import { ThemeProvider } from 'next-themes'
 import { AuthProvider } from '@/auth/AuthContext'
+import { OnboardingUsernameGate } from '@/components/OnboardingUsernameGate'
 import { ThemeSync } from '@/theme/ThemeSync'
 import {
   CHRONOGROVE_THEME_STORAGE_KEY,
@@ -21,6 +22,7 @@ export function Providers({ children }: { children: ReactNode }) {
       disableTransitionOnChange
     >
       <AuthProvider>
+        <OnboardingUsernameGate />
         <ThemeSync>{children}</ThemeSync>
       </AuthProvider>
     </ThemeProvider>

--- a/apps/console/src/auth/AuthContext.tsx
+++ b/apps/console/src/auth/AuthContext.tsx
@@ -58,6 +58,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const [auth, setAuth] = useState<Auth | null>(null)
   const [error, setError] = useState<string | null>(null)
   const lastEmailVerifiedRef = useRef<boolean | null>(null)
+  const previousAuthUidRef = useRef<string | null>(null)
 
   useEffect(() => {
     let cancelled = false
@@ -84,6 +85,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
           if (cancelled) return
           if (!u) {
             lastEmailVerifiedRef.current = null
+            previousAuthUidRef.current = null
             resetSessionEstablishmentTracking()
             apiClient.clearSession()
             setUser(null)
@@ -91,6 +93,15 @@ export function AuthProvider({ children }: AuthProviderProps) {
             setLoading(false)
             return
           }
+
+          if (
+            previousAuthUidRef.current !== null &&
+            previousAuthUidRef.current !== u.uid
+          ) {
+            await apiClient.clearStaleSessionCookie()
+            resetSessionEstablishmentTracking()
+          }
+          previousAuthUidRef.current = u.uid
 
           if (
             lastEmailVerifiedRef.current !== null &&
@@ -148,6 +159,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     if (!auth) return
     setError(null)
     try {
+      await apiClient.clearStaleSessionCookie()
       const cred = await createUserWithEmailAndPassword(auth, email, password)
       await sendEmailVerification(cred.user)
       await establishApiSessionCoalesced(cred.user)

--- a/apps/console/src/auth/apiClient.ts
+++ b/apps/console/src/auth/apiClient.ts
@@ -77,6 +77,25 @@ export class ApiClient {
     return this.getCookieValue('XSRF-TOKEN') ?? payload.csrfToken ?? null
   }
 
+  /**
+   * Server-side clear of the HttpOnly `session` cookie (client JS cannot remove it).
+   * Call when switching Firebase accounts so API requests match the current user.
+   */
+  async clearStaleSessionCookie(): Promise<void> {
+    try {
+      const csrfToken = await this.getCsrfToken(true)
+      await fetch(`${this.baseUrl}/api/auth/clear-session-cookie`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          ...(csrfToken ? { 'X-XSRF-TOKEN': csrfToken } : {}),
+        },
+      })
+    } catch {
+      /* best-effort */
+    }
+  }
+
   async createSession(token: string): Promise<{ ok: boolean; message?: string }> {
     const csrfToken = await this.getCsrfToken()
     const res = await fetch(`${this.baseUrl}/api/auth/session`, {

--- a/apps/console/src/auth/establishApiSession.ts
+++ b/apps/console/src/auth/establishApiSession.ts
@@ -23,7 +23,7 @@ export function isApiSessionEstablishedForUid(uid: string): boolean {
  */
 export async function establishApiSession(u: User): Promise<boolean> {
   try {
-    const token = await u.getIdToken()
+    const token = await u.getIdToken(true)
     await apiClient.createSession(token)
     return true
   } catch (e) {

--- a/apps/console/src/components/OnboardingUsernameGate.tsx
+++ b/apps/console/src/components/OnboardingUsernameGate.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useEffect } from 'react'
+import { usePathname, useRouter } from 'next/navigation'
+import { useAuth } from '@/auth/AuthContext'
+import { apiClient } from '@/auth/apiClient'
+import { mustVerifyEmailBeforeConsole } from '@/lib/emailVerificationGate'
+import { hasCompletedUsernameSelection } from '@/lib/onboardingUsernameCompletion'
+
+function shouldSkipOnboardingRedirect(pathname: string): boolean {
+  const base = pathname.replace(/\/$/, '') || '/'
+  if (base === '/onboarding') return true
+  if (base.startsWith('/verify-email')) return true
+  if (base === '/signup' || base.startsWith('/signup/')) return true
+  if (base === '/auth' || base.startsWith('/auth/')) return true
+  if (base.startsWith('/u/')) return true
+  if (base === '/about' || base === '/docs' || base === '/privacy') return true
+  return false
+}
+
+/**
+ * Sends verified users who have not chosen a public username to `/onboarding/` (username step).
+ * Other wizard steps and providers can be finished from Settings / dashboard.
+ */
+export function OnboardingUsernameGate() {
+  const pathname = usePathname() ?? '/'
+  const router = useRouter()
+  const { user, loading, apiSessionReady } = useAuth()
+
+  useEffect(() => {
+    if (loading || !user || !apiSessionReady) return
+    if (mustVerifyEmailBeforeConsole(user)) return
+    if (shouldSkipOnboardingRedirect(pathname)) return
+
+    let cancelled = false
+
+    void (async () => {
+      try {
+        const idToken = await user.getIdToken()
+        const res = await apiClient.getJson('/api/onboarding/progress', { idToken })
+        if (cancelled || !res.ok) return
+        const data = (await res.json().catch(() => ({}))) as {
+          payload?: { username: string | null; completedSteps: string[] }
+        }
+        const p = data.payload
+        if (cancelled || !p) return
+        if (hasCompletedUsernameSelection(p)) return
+        router.replace('/onboarding/')
+      } catch {
+        /* ignore — onboarding page can still load */
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [user, loading, apiSessionReady, pathname, router])
+
+  return null
+}

--- a/apps/console/src/components/user-settings/SettingsProfileIdentity.test.tsx
+++ b/apps/console/src/components/user-settings/SettingsProfileIdentity.test.tsx
@@ -354,10 +354,15 @@ describe('SettingsProfileIdentity', () => {
     render(<SettingsProfileIdentity user={mockUser()} apiSessionReady />)
     await waitFor(() => screen.getByPlaceholderText('your-username'))
 
-    fireEvent.change(screen.getByPlaceholderText('your-username'), {
-      target: { value: 'abcuser' },
-    })
-    await afterUsernameDebounce()
+    const input = screen.getByPlaceholderText('your-username')
+    fireEvent.change(input, { target: { value: 'abcuser' } })
+    await waitFor(() => expect(input).toHaveValue('abcuser'))
+    await waitFor(() =>
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/onboarding/check-username?username=abcuser'),
+        expect.anything(),
+      ),
+    )
 
     await waitFor(() => {
       expect(
@@ -434,10 +439,15 @@ describe('SettingsProfileIdentity', () => {
     render(<SettingsProfileIdentity user={mockUser()} apiSessionReady />)
     await waitFor(() => screen.getByPlaceholderText('your-username'))
 
-    fireEvent.change(screen.getByPlaceholderText('your-username'), {
-      target: { value: 'httpfail' },
-    })
-    await afterUsernameDebounce()
+    const input = screen.getByPlaceholderText('your-username')
+    fireEvent.change(input, { target: { value: 'httpfail' } })
+    await waitFor(() => expect(input).toHaveValue('httpfail'))
+    await waitFor(() =>
+      expect(globalThis.fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/onboarding/check-username?username=httpfail'),
+        expect.anything(),
+      ),
+    )
 
     await waitFor(() => {
       expect(screen.getByText(/could not check availability/i)).toBeInTheDocument()

--- a/apps/console/src/lib/onboardingUsernameCompletion.test.ts
+++ b/apps/console/src/lib/onboardingUsernameCompletion.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { hasCompletedUsernameSelection } from './onboardingUsernameCompletion'
+
+describe('hasCompletedUsernameSelection', () => {
+  it('is true when username step is in completedSteps', () => {
+    expect(
+      hasCompletedUsernameSelection({
+        username: null,
+        completedSteps: ['username'],
+      })
+    ).toBe(true)
+  })
+
+  it('is true when username slug is persisted', () => {
+    expect(
+      hasCompletedUsernameSelection({
+        username: 'my-slug',
+        completedSteps: [],
+      })
+    ).toBe(true)
+  })
+
+  it('is false for a brand-new payload', () => {
+    expect(
+      hasCompletedUsernameSelection({
+        username: null,
+        completedSteps: [],
+      })
+    ).toBe(false)
+  })
+})

--- a/apps/console/src/lib/onboardingUsernameCompletion.ts
+++ b/apps/console/src/lib/onboardingUsernameCompletion.ts
@@ -1,0 +1,12 @@
+/**
+ * Whether the operator has finished the username step (public slug), either recorded in
+ * `completedSteps` or persisted on the user doc as `username` (includes users who set it in Settings).
+ */
+export function hasCompletedUsernameSelection(payload: {
+  username: string | null
+  completedSteps: string[]
+}): boolean {
+  if (payload.completedSteps.includes('username')) return true
+  if (payload.username != null && payload.username.trim().length > 0) return true
+  return false
+}

--- a/apps/console/src/lib/overviewQuickLinks.test.ts
+++ b/apps/console/src/lib/overviewQuickLinks.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { CHRONOGROVE_GITHUB_REPO } from '@/lib/chronogroveRepo'
+
+import { buildOverviewQuickLinks } from './overviewQuickLinks'
+
+describe('buildOverviewQuickLinks', () => {
+  it('returns docs, about, and sign-in when signed out', () => {
+    expect(buildOverviewQuickLinks({ user: null, publicUsername: null })).toEqual([
+      { href: '/docs/', label: 'Docs' },
+      { href: '/about/', label: 'About' },
+      { href: '/auth/', label: 'Sign in' },
+    ])
+  })
+
+  it('includes settings, docs, public status, and GitHub when signed in with a username', () => {
+    expect(
+      buildOverviewQuickLinks({ user: { uid: 'x' }, publicUsername: 'alice_bob' })
+    ).toEqual([
+      { href: '/user-settings/', label: 'Settings' },
+      { href: '/docs/', label: 'Docs' },
+      { href: '/u/alice_bob/', label: 'Public status page' },
+      { href: CHRONOGROVE_GITHUB_REPO, label: 'GitHub', external: true },
+    ])
+  })
+
+  it('encodes reserved characters in the public status path', () => {
+    const links = buildOverviewQuickLinks({ user: { uid: 'x' }, publicUsername: 'a/b' })
+    expect(links[2]).toEqual({
+      href: '/u/a%2Fb/',
+      label: 'Public status page',
+    })
+  })
+
+  it('uses account setup instead of public page when there is no username', () => {
+    expect(buildOverviewQuickLinks({ user: { uid: 'x' }, publicUsername: null })).toEqual([
+      { href: '/user-settings/', label: 'Settings' },
+      { href: '/docs/', label: 'Docs' },
+      { href: '/onboarding/', label: 'Account setup' },
+      { href: CHRONOGROVE_GITHUB_REPO, label: 'GitHub', external: true },
+    ])
+  })
+})

--- a/apps/console/src/lib/overviewQuickLinks.ts
+++ b/apps/console/src/lib/overviewQuickLinks.ts
@@ -1,0 +1,33 @@
+import { CHRONOGROVE_GITHUB_REPO } from '@/lib/chronogroveRepo'
+
+export type OverviewQuickLink = { href: string; label: string; external?: boolean }
+
+/**
+ * Dashboard hero “quick links”: routes that complement the main nav (not Schema / Status / Try API / Sync).
+ */
+export function buildOverviewQuickLinks(input: {
+  user: unknown | null
+  publicUsername: string | null
+}): OverviewQuickLink[] {
+  if (!input.user) {
+    return [
+      { href: '/docs/', label: 'Docs' },
+      { href: '/about/', label: 'About' },
+      { href: '/auth/', label: 'Sign in' },
+    ]
+  }
+  const links: OverviewQuickLink[] = [
+    { href: '/user-settings/', label: 'Settings' },
+    { href: '/docs/', label: 'Docs' },
+  ]
+  if (input.publicUsername) {
+    links.push({
+      href: `/u/${encodeURIComponent(input.publicUsername)}/`,
+      label: 'Public status page',
+    })
+  } else {
+    links.push({ href: '/onboarding/', label: 'Account setup' })
+  }
+  links.push({ href: CHRONOGROVE_GITHUB_REPO, label: 'GitHub', external: true })
+  return links
+}

--- a/apps/console/src/lib/tenantDisplay.test.ts
+++ b/apps/console/src/lib/tenantDisplay.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { resolveDashboardTenantHostname } from './tenantDisplay'
+
+describe('resolveDashboardTenantHostname', () => {
+  beforeEach(() => {
+    vi.stubEnv('NEXT_PUBLIC_TENANT_DISPLAY_HOST', 'www.chrisvogt.me')
+    vi.stubEnv('NEXT_PUBLIC_DEFAULT_PUBLIC_API_HOST', '')
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('uses customDomain when set', () => {
+    expect(
+      resolveDashboardTenantHostname({
+        customDomain: 'https://api.customer.example',
+        username: 'alice',
+      })
+    ).toBe('api.customer.example')
+  })
+
+  it('uses default public API host when username exists but no custom domain', () => {
+    expect(
+      resolveDashboardTenantHostname({
+        customDomain: null,
+        username: 'bob',
+      })
+    ).toBe('api.chronogrove.com')
+  })
+
+  it('respects NEXT_PUBLIC_DEFAULT_PUBLIC_API_HOST when username exists', () => {
+    vi.stubEnv('NEXT_PUBLIC_DEFAULT_PUBLIC_API_HOST', 'api.example.org')
+    expect(
+      resolveDashboardTenantHostname({
+        customDomain: null,
+        username: 'bob',
+      })
+    ).toBe('api.example.org')
+  })
+
+  it('falls back to getTenantDisplayHost when no slug or domain', () => {
+    expect(
+      resolveDashboardTenantHostname({
+        customDomain: null,
+        username: null,
+      })
+    ).toBe('www.chrisvogt.me')
+  })
+})

--- a/apps/console/src/lib/tenantDisplay.ts
+++ b/apps/console/src/lib/tenantDisplay.ts
@@ -27,3 +27,34 @@ export function getTenantDisplayHost(): string {
   const raw = process.env.NEXT_PUBLIC_TENANT_DISPLAY_HOST ?? ''
   return normalizeTenantDisplayHost(raw)
 }
+
+/** Default shared widget API host when the operator has a username but no custom domain (product default). */
+const DEFAULT_PUBLIC_API_HOST = 'api.chronogrove.com'
+
+/**
+ * Dashboard hero: prefer the tenant’s configured API hostname (`customDomain` / Firestore
+ * `tenantHostname`), then the shared public API host when a username exists, else the build-time
+ * display host for single-tenant / signed-out copy.
+ */
+export function resolveDashboardTenantHostname(input: {
+  customDomain: string | null
+  username: string | null
+}): string {
+  const fromCustom = input.customDomain ? normalizeTenantDisplayHost(input.customDomain) : ''
+  if (fromCustom) return fromCustom
+
+  const slug =
+    input.username != null && input.username.trim().length > 0
+      ? input.username.trim().toLowerCase()
+      : ''
+  if (slug) {
+    const raw =
+      typeof process !== 'undefined'
+        ? process.env.NEXT_PUBLIC_DEFAULT_PUBLIC_API_HOST?.trim()
+        : ''
+    const host = normalizeTenantDisplayHost(raw || DEFAULT_PUBLIC_API_HOST)
+    return host || DEFAULT_PUBLIC_API_HOST
+  }
+
+  return getTenantDisplayHost()
+}

--- a/apps/console/src/sections/OverviewSection.module.css
+++ b/apps/console/src/sections/OverviewSection.module.css
@@ -47,7 +47,8 @@
     radial-gradient(circle at 72% 35%, var(--surface-soft), transparent 55%);
   box-shadow: var(--shadow-lg);
   position: relative;
-  overflow: hidden;
+  /* Allow descenders on the headline (e.g. g, y); inner gradient still fits border-radius. */
+  overflow: visible;
   animation: slideUp 0.4s ease both;
 }
 
@@ -81,7 +82,8 @@
   font-size: clamp(2.1rem, 4.5vw, 3.2rem);
   font-weight: 800;
   letter-spacing: -0.05em;
-  line-height: 1;
+  line-height: 1.18;
+  padding-bottom: 0.06em;
   background: linear-gradient(130deg, var(--text) 25%, var(--accent-strong) 100%);
   -webkit-background-clip: text;
   background-clip: text;

--- a/apps/console/src/sections/OverviewSection.tsx
+++ b/apps/console/src/sections/OverviewSection.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import Link from 'next/link'
 import { useAuth } from '@/auth/AuthContext'
+import { apiClient } from '@/auth/apiClient'
 import { getAppBaseUrl } from '../lib/baseUrl'
 import { AddProvidersFlyout } from '@/components/onboarding/AddProvidersFlyout'
 import {
@@ -10,7 +11,8 @@ import {
   extractOverviewMetrics,
   type MetricItem,
 } from '../lib/overviewMetrics'
-import { getTenantDisplayHost } from '../lib/tenantDisplay'
+import { buildOverviewQuickLinks } from '@/lib/overviewQuickLinks'
+import { getTenantDisplayHost, resolveDashboardTenantHostname } from '../lib/tenantDisplay'
 import styles from './OverviewSection.module.css'
 
 interface ProviderConfig {
@@ -27,13 +29,6 @@ const PROVIDERS: ProviderConfig[] = [
   { id: 'steam', label: 'Steam', accent: '#67d9ff' },
   { id: 'discogs', label: 'Discogs', accent: '#c5ceff' },
   { id: 'flickr', label: 'Flickr', accent: '#ff0084' },
-]
-
-const QUICK_LINKS = [
-  { href: '/schema/', label: 'Schema' },
-  { href: '/status/', label: 'Status' },
-  { href: '/sync/', label: 'Sync' },
-  { href: '/auth/', label: 'Sign in' },
 ]
 
 interface ProviderState {
@@ -72,10 +67,49 @@ export function OverviewSection() {
   const baseUrl = getAppBaseUrl()
   const [states, setStates] = useState<Record<string, ProviderState>>({})
   const [addProvidersOpen, setAddProvidersOpen] = useState(false)
+  const [headlineHost, setHeadlineHost] = useState(() => getTenantDisplayHost())
+  const [publicUsername, setPublicUsername] = useState<string | null>(null)
 
   useEffect(() => {
     if (!user) setAddProvidersOpen(false)
   }, [user])
+
+  useEffect(() => {
+    if (!user || !apiSessionReady) {
+      setHeadlineHost(getTenantDisplayHost())
+      setPublicUsername(null)
+      return
+    }
+    let cancelled = false
+    void (async () => {
+      try {
+        const idToken = await user.getIdToken()
+        const res = await apiClient.getJson('/api/onboarding/progress', { idToken })
+        if (cancelled || !res.ok) return
+        const data = (await res.json()) as {
+          payload?: { customDomain: string | null; username: string | null }
+        }
+        const p = data.payload
+        if (cancelled || !p) return
+        setHeadlineHost(resolveDashboardTenantHostname(p))
+        const slug = p.username?.trim()
+        setPublicUsername(slug ? slug.toLowerCase() : null)
+      } catch {
+        if (!cancelled) {
+          setHeadlineHost(getTenantDisplayHost())
+          setPublicUsername(null)
+        }
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [user, apiSessionReady])
+
+  const quickLinks = useMemo(
+    () => buildOverviewQuickLinks({ user, publicUsername }),
+    [user, publicUsername]
+  )
 
   const fetchAll = useCallback(async () => {
     setStates(Object.fromEntries(PROVIDERS.map((p) => [p.id, initialState()])))
@@ -144,25 +178,35 @@ export function OverviewSection() {
   const total = PROVIDERS.length
   const allDone = resolved.length === total && resolved.every((s) => !s.loading)
 
-  const tenantHost = getTenantDisplayHost()
-
   return (
     <div className={styles.page}>
       <div className={styles.hero}>
         <div className={styles.heroContent}>
           <p className={styles.label}>chronogrove · core</p>
-          <h1 className={styles.title}>{tenantHost || 'This site'}</h1>
+          <h1 className={styles.title}>{headlineHost || 'This site'}</h1>
           <p className={styles.meta}>
             {!allDone
               ? `${total} providers`
               : `${healthy} of ${total} providers healthy`}
           </p>
-          <nav className={styles.quickLinks} aria-label="Quick navigation">
-            {QUICK_LINKS.map((link) => (
-              <Link key={link.href} href={link.href} className={styles.quickLink}>
-                {link.label}
-              </Link>
-            ))}
+          <nav className={styles.quickLinks} aria-label="Quick links">
+            {quickLinks.map((link) =>
+              link.external === true ? (
+                <a
+                  key={link.href}
+                  href={link.href}
+                  className={styles.quickLink}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  {link.label}
+                </a>
+              ) : (
+                <Link key={link.href} href={link.href} className={styles.quickLink}>
+                  {link.label}
+                </Link>
+              )
+            )}
           </nav>
         </div>
         {user ? (

--- a/functions/CHANGELOG.md
+++ b/functions/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.1] - 2026-04-10
+
+### Added
+
+- **`POST /api/auth/clear-session-cookie`** — Clears the HttpOnly **`session`** cookie without Firebase sign-out (CSRF-protected; rate limited). Used when switching accounts so a previous login’s cookie cannot override the current Firebase user.
+
+### Changed
+
+- **Authentication** — **`authenticateUser`** resolves identity from both the **`session`** cookie and **`Authorization: Bearer`** (Firebase ID token). When both verify but refer to **different** users, the **Bearer** identity wins and the stale **`session`** cookie is cleared. **401** responses distinguish a present-but-invalid Bearer (**`Invalid or expired JWT token`**) from missing credentials (**`No valid authorization header found`**).
+- **Public onboarding / widgets** — **`resolveViewerUidForPublicOnboarding`** again applies the allowlisted-email + verification gate to the session identity before the Bearer fallback (same-uid / different-claim edge cases), while still clearing the session cookie on uid mismatch.
+
+### Removed
+
+- **Tests** — Removed two brittle **`authenticateUser` “outer catch”** cases superseded by the refactored session/Bearer resolution.
+
 ## [0.30.0] - 2026-04-08
 
 ### Added

--- a/functions/app/create-express-app.onboarding.test.ts
+++ b/functions/app/create-express-app.onboarding.test.ts
@@ -580,6 +580,43 @@ describe('createExpressApp onboarding routes', () => {
     expect(json).toHaveBeenCalledWith({ ok: true, available: true })
   })
 
+  it('GET check-username clears session and treats viewer as absent when session and bearer uids mismatch and bearer is unverified', async () => {
+    const { app } = await buildApp()
+    documentStore.getDocument.mockResolvedValue({ uid: 'other' })
+    authService.verifySessionCookie.mockResolvedValue({
+      uid: 'session-uid',
+      email: 'a@chrisvogt.me',
+      email_verified: true,
+    } as never)
+    authService.verifyIdToken.mockResolvedValue({
+      uid: 'bearer-uid',
+      email: 'b@chrisvogt.me',
+      email_verified: false,
+    } as never)
+
+    const handler = findRouteHandler(app, 'get', '/api/onboarding/check-username')
+    const json = vi.fn()
+    const clearCookie = vi.fn()
+    await handler(
+      {
+        query: { username: 'valid_user' },
+        cookies: { session: 'sess' },
+        headers: { authorization: 'Bearer tok' },
+      },
+      { json, clearCookie }
+    )
+
+    expect(clearCookie).toHaveBeenCalledWith('session', expect.objectContaining({ path: '/' }))
+    expect(logger.warn).toHaveBeenCalledWith(
+      'Session uid does not match Bearer uid; preferring Bearer and clearing session cookie',
+      expect.objectContaining({
+        sessionUid: 'session-uid',
+        bearerUid: 'bearer-uid',
+      }),
+    )
+    expect(json).toHaveBeenCalledWith({ ok: true, available: false })
+  })
+
   it('GET check-username uses bearer when production session email is not allowlisted', async () => {
     const prevEnv = process.env.NODE_ENV
     process.env.NODE_ENV = 'production'

--- a/functions/app/create-express-app.route-coverage.test.ts
+++ b/functions/app/create-express-app.route-coverage.test.ts
@@ -286,7 +286,7 @@ describe('createExpressApp route coverage', () => {
       next
     )
 
-    expect(logger.warn).toHaveBeenCalledWith('No valid authorization header found', {
+    expect(logger.warn).toHaveBeenCalledWith('No valid authorization', {
       path: '/api/user/profile',
       hasAuthHeader: true,
     })

--- a/functions/app/create-express-app.test.ts
+++ b/functions/app/create-express-app.test.ts
@@ -432,21 +432,6 @@ describe('createExpressApp auth and session branches', () => {
     expect(response.body.error).toBe('Invalid or expired JWT token')
   })
 
-  it('returns 401 when the auth middleware outer catch receives a non-Error failure', async () => {
-    const app = await buildApp()
-
-    logger.info.mockImplementationOnce(() => {
-      throw { code: 'logger-failure' }
-    })
-
-    const response = await request(app)
-      .get('/api/user/profile')
-      .set('Authorization', 'Bearer token')
-      .expect(401)
-
-    expect(response.body.error).toBe('Invalid or expired token')
-  })
-
   it('rejects state-changing requests when the CSRF token is missing', async () => {
     const app = await buildApp()
 

--- a/functions/app/create-express-app.ts
+++ b/functions/app/create-express-app.ts
@@ -5,7 +5,7 @@ import express from 'express'
 import lusca from 'lusca'
 import path from 'path'
 import { rateLimit } from 'express-rate-limit'
-import type { AuthService } from '../ports/auth-service.js'
+import type { AuthClaims, AuthService } from '../ports/auth-service.js'
 import type { DocumentStore } from '../ports/document-store.js'
 import type { MediaStore } from '../ports/media-store.js'
 import type { SyncJobQueue } from '../ports/sync-job-queue.js'
@@ -250,44 +250,150 @@ export function createExpressApp({
 }: CreateExpressAppOptions): express.Express {
   const expressApp = express()
 
+  const sessionCookieBaseOptions = {
+    httpOnly: true,
+    secure: isProductionEnvironment(),
+    sameSite: (isProductionEnvironment() ? 'strict' : 'lax') as 'strict' | 'lax',
+    path: '/',
+  }
+
   /**
-   * Same identity as authenticated API routes: session cookie first, then Bearer ID token.
-   * Used by public onboarding endpoints to recognize the signed-in user without requiring auth.
+   * Resolves the signed-in user from the HttpOnly session cookie and/or `Authorization: Bearer`
+   * (Firebase ID token). When both are present but refer to **different** accounts (e.g. user
+   * signed up or switched accounts without clearing the old session cookie), prefer the Bearer
+   * identity and clear the stale cookie so subsequent requests match Firebase Auth.
    */
-  const resolveViewerUidForPublicOnboarding = async (
-    req: express.Request
-  ): Promise<string | null> => {
+  const resolveChosenAuthClaims = async (
+    req: express.Request,
+    res: express.Response
+  ): Promise<AuthClaims | null> => {
     const sessionCookie = req.cookies?.session
+    const bearerToken = extractBearerToken(req.headers.authorization)
+
+    let sessionClaims: AuthClaims | null = null
     if (sessionCookie) {
       try {
-        const decoded = await authService.verifySessionCookie(sessionCookie)
-        if (
-          decoded.uid &&
-          isAllowedEmail(decoded.email) &&
-          !needsEmailVerification(decoded.email, decoded.emailVerified)
-        ) {
-          return decoded.uid
-        }
-      } catch {
-        /* treat as anonymous */
+        sessionClaims = await authService.verifySessionCookie(sessionCookie)
+        logger.info('Session cookie verified successfully', {
+          uid: sessionClaims.uid,
+          email: sessionClaims.email,
+          emailVerified: sessionClaims.emailVerified,
+        })
+      } catch (error) {
+        logger.error('Session cookie verification failed', {
+          error: error instanceof Error ? error.message : '',
+          code: (error as { code?: string }).code,
+          stack: error instanceof Error ? error.stack : undefined,
+        })
       }
     }
-    const token = extractBearerToken(req.headers.authorization)
-    if (token) {
+
+    let bearerClaims: AuthClaims | null = null
+    if (bearerToken) {
       try {
-        const decoded = await authService.verifyIdToken(token)
-        if (
-          decoded.uid &&
-          isAllowedEmail(decoded.email) &&
-          !needsEmailVerification(decoded.email, decoded.emailVerified)
-        ) {
-          return decoded.uid
-        }
-      } catch {
-        /* treat as anonymous */
+        bearerClaims = await authService.verifyIdToken(bearerToken)
+        logger.info('auth: bearer token', {
+          path: req.path,
+          uid: bearerClaims.uid,
+          email: bearerClaims.email,
+          emailVerified: bearerClaims.emailVerified,
+        })
+      } catch (error) {
+        logger.error('JWT token verification failed', {
+          error: error instanceof Error ? error.message : '',
+          code: (error as { code?: string }).code,
+        })
       }
     }
-    return null
+
+    const mismatch =
+      sessionClaims !== null &&
+      bearerClaims !== null &&
+      sessionClaims.uid !== bearerClaims.uid
+
+    if (mismatch) {
+      logger.warn(
+        'Session uid does not match Bearer uid; preferring Bearer and clearing session cookie',
+        {
+          sessionUid: sessionClaims.uid,
+          bearerUid: bearerClaims.uid,
+        }
+      )
+      res.clearCookie('session', sessionCookieBaseOptions)
+      return bearerClaims
+    }
+
+    return sessionClaims ?? bearerClaims
+  }
+
+  /**
+   * Public widget / onboarding helpers: session first **only if** it passes the same allowlist +
+   * verification gate as before; then Bearer. Uid mismatch still clears a stale session cookie.
+   * (Same uid can still swap claims when the session encodes a non-allowlisted email and the
+   * Bearer token does — e.g. production email allowlist.)
+   */
+  const resolveViewerUidForPublicOnboarding = async (
+    req: express.Request,
+    res: express.Response
+  ): Promise<string | null> => {
+    const sessionCookie = req.cookies?.session
+    const bearerToken = extractBearerToken(req.headers.authorization)
+
+    let sessionClaims: AuthClaims | null = null
+    if (sessionCookie) {
+      try {
+        sessionClaims = await authService.verifySessionCookie(sessionCookie)
+      } catch {
+        /* treat as missing */
+      }
+    }
+
+    let bearerClaims: AuthClaims | null = null
+    if (bearerToken) {
+      try {
+        bearerClaims = await authService.verifyIdToken(bearerToken)
+      } catch {
+        /* treat as missing */
+      }
+    }
+
+    const mismatch =
+      sessionClaims !== null &&
+      bearerClaims !== null &&
+      sessionClaims.uid !== bearerClaims.uid
+
+    if (mismatch) {
+      logger.warn(
+        'Session uid does not match Bearer uid; preferring Bearer and clearing session cookie',
+        {
+          sessionUid: sessionClaims.uid,
+          bearerUid: bearerClaims.uid,
+        }
+      )
+      res.clearCookie('session', sessionCookieBaseOptions)
+      const b = bearerClaims
+      if (
+        b.uid &&
+        isAllowedEmail(b.email) &&
+        !needsEmailVerification(b.email, b.emailVerified)
+      ) {
+        return b.uid
+      }
+      return null
+    }
+
+    const viewerFrom = (c: AuthClaims | null): string | null => {
+      if (
+        c?.uid &&
+        isAllowedEmail(c.email) &&
+        !needsEmailVerification(c.email, c.emailVerified)
+      ) {
+        return c.uid
+      }
+      return null
+    }
+
+    return viewerFrom(sessionClaims) ?? viewerFrom(bearerClaims)
   }
 
   const authenticateUser = async (
@@ -296,100 +402,38 @@ export function createExpressApp({
     next: express.NextFunction
   ): Promise<void> => {
     try {
-      const sessionCookie = req.cookies?.session
-      if (sessionCookie) {
-        try {
-          const decodedClaims = await authService.verifySessionCookie(sessionCookie)
-
-          logger.info('Session cookie verified successfully', {
-            uid: decodedClaims.uid,
-            email: decodedClaims.email,
-            emailVerified: decodedClaims.emailVerified,
-          })
-
-          if (!isAllowedEmail(decodedClaims.email)) {
-            logger.warn('Email domain rejected', {
-              email: decodedClaims.email,
-              uid: decodedClaims.uid,
-            })
-            res.status(403).json({
-              ok: false,
-              error:
-                'Access denied. Only chrisvogt.me or chronogrove.com domain users are allowed.',
-            })
-            return
-          }
-
-          req.user = {
-            uid: decodedClaims.uid,
-            email: decodedClaims.email,
-            emailVerified: decodedClaims.emailVerified,
-          }
-          next()
-          return
-        } catch (error) {
-          logger.error('Session cookie verification failed', {
-            error: error instanceof Error ? error.message : '',
-            code: (error as { code?: string }).code,
-            stack: error instanceof Error ? error.stack : undefined,
-          })
-        }
-      }
-
-      const authHeader = req.headers.authorization
-      const token = extractBearerToken(authHeader)
-      if (!token) {
-        logger.warn('No valid authorization header found', {
+      const chosen = await resolveChosenAuthClaims(req, res)
+      if (!chosen) {
+        const hasBearer = Boolean(extractBearerToken(req.headers.authorization))
+        logger.warn('No valid authorization', {
           path: req.path,
           hasAuthHeader: Boolean(req.headers.authorization),
         })
         res.status(401).json({
           ok: false,
-          error: 'No valid authorization header found',
+          error: hasBearer ? 'Invalid or expired JWT token' : 'No valid authorization header found',
         })
         return
       }
 
-      logger.info('auth: bearer token', { path: req.path })
-
-      try {
-        const decodedToken = await authService.verifyIdToken(token)
-
-        logger.info('JWT token verified successfully', {
-          uid: decodedToken.uid,
-          email: decodedToken.email,
-          emailVerified: decodedToken.emailVerified,
+      if (!isAllowedEmail(chosen.email)) {
+        logger.warn('Email domain rejected', {
+          email: chosen.email,
+          uid: chosen.uid,
         })
-
-        if (!isAllowedEmail(decodedToken.email)) {
-          logger.warn('JWT email domain rejected', {
-            email: decodedToken.email,
-            uid: decodedToken.uid,
-          })
-          res.status(403).json({
-            ok: false,
-            error:
-              'Access denied. Only chrisvogt.me or chronogrove.com domain users are allowed.',
-          })
-          return
-        }
-
-        req.user = {
-          uid: decodedToken.uid,
-          email: decodedToken.email,
-          emailVerified: decodedToken.emailVerified,
-        }
-        next()
-      } catch (error) {
-        logger.error('JWT token verification failed', {
-          error: error instanceof Error ? error.message : '',
-          code: (error as { code?: string }).code,
-        })
-        res.status(401).json({
+        res.status(403).json({
           ok: false,
-          error: 'Invalid or expired JWT token',
+          error: 'Access denied. Only chrisvogt.me or chronogrove.com domain users are allowed.',
         })
+        return
       }
+
+      req.user = {
+        uid: chosen.uid,
+        email: chosen.email,
+        emailVerified: chosen.emailVerified,
+      }
+      next()
     } catch (error) {
       logger.error('Authentication error:', {
         error: error instanceof Error ? error.message : '',
@@ -658,7 +702,7 @@ export function createExpressApp({
       }
       const userId =
         fromQuery === 'skip' ? getWidgetUserIdForHostname(originalHostname) : fromQuery.userId
-      const viewerUid = await resolveViewerUidForPublicOnboarding(req)
+      const viewerUid = await resolveViewerUidForPublicOnboarding(req, res)
 
       try {
         const { payload: widgetContent, meta } = await getWidgetContent(provider, userId, documentStore, {
@@ -906,11 +950,8 @@ export function createExpressApp({
         const sessionCookie = await authService.createSessionCookie(token, { expiresIn })
 
         const options = {
+          ...sessionCookieBaseOptions,
           maxAge: expiresIn,
-          httpOnly: true,
-          secure: isProductionEnvironment(),
-          sameSite: (isProductionEnvironment() ? 'strict' : 'lax') as 'strict' | 'lax',
-          path: '/',
         }
 
         res.cookie('session', sessionCookie, options)
@@ -926,6 +967,19 @@ export function createExpressApp({
           error: 'Failed to create session cookie',
         })
       }
+    }
+  )
+
+  /**
+   * Clears the HttpOnly session cookie without signing the user out in Firebase Auth. Used when
+   * switching accounts in the same browser so a stale cookie cannot override the current ID token.
+   */
+  expressApp.post(
+    '/api/auth/clear-session-cookie',
+    rateLimit({ ...rateLimitDefaults, windowMs: 15 * 60 * 1000, limit: 40 }),
+    (_req, res) => {
+      res.clearCookie('session', sessionCookieBaseOptions)
+      res.status(204).send()
     }
   )
 
@@ -968,12 +1022,7 @@ export function createExpressApp({
       if (!req.user) return
       try {
         await authService.revokeRefreshTokens(req.user.uid)
-        res.clearCookie('session', {
-          httpOnly: true,
-          secure: isProductionEnvironment(),
-          sameSite: isProductionEnvironment() ? 'strict' : 'lax',
-          path: '/',
-        })
+        res.clearCookie('session', sessionCookieBaseOptions)
         res.status(200).send({
           ok: true,
           message: 'User logged out successfully',
@@ -1027,7 +1076,7 @@ export function createExpressApp({
         const claim = await documentStore.getDocument<{ uid?: unknown }>(claimPath)
 
         if (claim && typeof claim.uid === 'string') {
-          const viewerUid = await resolveViewerUidForPublicOnboarding(req)
+          const viewerUid = await resolveViewerUidForPublicOnboarding(req, res)
           const ownedByCaller = viewerUid !== null && claim.uid === viewerUid
           if (!ownedByCaller) {
             res.json({ ok: true, available: false })
@@ -1049,7 +1098,7 @@ export function createExpressApp({
             res.json({ ok: true, available: true })
             return
           }
-          const viewerUid = await resolveViewerUidForPublicOnboarding(req)
+          const viewerUid = await resolveViewerUidForPublicOnboarding(req, res)
           if (viewerUid !== null && ownerUid === viewerUid) {
             res.json({ ok: true, available: true })
             return

--- a/functions/index.test.ts
+++ b/functions/index.test.ts
@@ -935,21 +935,6 @@ describe('index.js', () => {
         expect(response.body.ok).toBe(false)
       })
 
-      it('should return 401 from outer catch when authenticateUser throws unexpectedly', async () => {
-        const logSpy = vi.spyOn(logger, 'info').mockImplementationOnce(() => {
-          throw new Error('Unexpected auth error')
-        })
-
-        const response = await request(app)
-          .get('/api/user/profile')
-          .set('Authorization', 'Bearer some-token')
-          .expect(401)
-
-        expect(response.body.ok).toBe(false)
-        expect(response.body.error).toBe('Invalid or expired token')
-        logSpy.mockRestore()
-      })
-
       it('should return 401 with Invalid or expired JWT token when Bearer token verification fails', async () => {
         const admin = await import('firebase-admin')
         admin.default.auth = vi.fn(() => ({

--- a/functions/index.test.ts
+++ b/functions/index.test.ts
@@ -810,6 +810,18 @@ describe('index.js', () => {
       })
     })
 
+    describe('POST /api/auth/clear-session-cookie', () => {
+      it('should return 204 without signing out in Firebase Auth', async () => {
+        const { agent, csrfToken } = await getCsrfHeaders(app)
+        const response = await agent
+          .post('/api/auth/clear-session-cookie')
+          .set('X-XSRF-TOKEN', csrfToken)
+          .expect(204)
+
+        expect(response.text).toBe('')
+      })
+    })
+
     describe('GET /api/user/profile', () => {
       it('should export user profile endpoint', async () => {
         // This test just verifies the endpoint exists and is properly configured
@@ -895,6 +907,40 @@ describe('index.js', () => {
         expect(response.body.ok).toBe(true)
         expect(response.body.payload.uid).toBe('cookie-uid')
         expect(mockVerifySessionCookie).toHaveBeenCalledWith('valid-session-cookie', true)
+      })
+
+      it('should prefer Bearer identity when session cookie and Bearer refer to different users', async () => {
+        const mockGetUser = vi.fn().mockResolvedValue({
+          uid: 'bearer-uid',
+          email: 'test@chrisvogt.me',
+          displayName: 'Bearer User',
+          photoURL: null,
+          emailVerified: true,
+          metadata: { creationTime: '2020-01-01', lastSignInTime: '2024-01-01' },
+        })
+        const admin = await import('firebase-admin')
+        admin.default.auth = vi.fn(() => ({
+          verifySessionCookie: vi.fn().mockResolvedValue({
+            uid: 'session-uid',
+            email: 'test@chrisvogt.me',
+            email_verified: true,
+          }),
+          verifyIdToken: vi.fn().mockResolvedValue({
+            uid: 'bearer-uid',
+            email: 'test@chrisvogt.me',
+            email_verified: true,
+          }),
+          getUser: mockGetUser,
+        }))
+
+        const response = await request(app)
+          .get('/api/user/profile')
+          .set('Cookie', 'session=valid-session-cookie')
+          .set('Authorization', 'Bearer valid-jwt-token')
+          .expect(200)
+
+        expect(response.body.payload.uid).toBe('bearer-uid')
+        expect(mockGetUser).toHaveBeenCalledWith('bearer-uid')
       })
 
       it('should reject session cookie with disallowed email in production', async () => {

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chronogrove-functions",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "license": "Apache-2.0",
   "description": "Chronogrove server: Firebase Cloud Functions for the public widget API, authenticated admin routes, and provider sync jobs.",
   "type": "module",


### PR DESCRIPTION
## Summary

Ships **Console 0.6.22** and **Functions 0.30.1** (see root, `apps/console/CHANGELOG.md`, and `functions/CHANGELOG.md`).

### Functions
- Resolve identity from HttpOnly `session` and Bearer token; prefer Bearer and clear stale cookie on uid mismatch.
- `POST /api/auth/clear-session-cookie` (CSRF-protected).
- Tests updated for auth routes and public onboarding viewer resolution.

### Console
- Clear stale session when switching accounts; `getIdToken(true)` before session creation.
- **OnboardingUsernameGate** — redirect to `/onboarding/` until a public username is chosen (excludes marketing/auth/public status routes).
- Dashboard hero hostname via `resolveDashboardTenantHostname` + onboarding progress; hero typography/CSS tweaks.
- Overview quick links via `buildOverviewQuickLinks` (Settings, Docs, status or setup, GitHub).
- New/updated Vitest coverage; **SettingsProfileIdentity** username-check tests wait for input + fetch before asserting error copy.

### How to test
- `pnpm exec vitest run` in `apps/console` and `functions`.
- Smoke: sign-in, account switch, onboarding redirect, dashboard links and hero host.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication/session resolution on both client and Functions, including cookie clearing and identity precedence rules; mistakes could cause unexpected sign-outs or incorrect authorization. UI/dashboard changes are low risk but depend on onboarding progress calls and new env defaults.
> 
> **Overview**
> Improves auth/session consistency across Console and Functions by **preferring Bearer ID tokens when they disagree with an existing HttpOnly `session` cookie**, proactively clearing stale cookies, and adding a new CSRF-protected **`POST /api/auth/clear-session-cookie`** endpoint.
> 
> Adds a client-side **`OnboardingUsernameGate`** that redirects verified users to `/onboarding/` until a public `username` is selected, and forces `getIdToken(true)` when minting session cookies to keep `email_verified` in sync.
> 
> Updates the dashboard overview to fetch onboarding progress for **hero hostname resolution** (`resolveDashboardTenantHostname` with optional `NEXT_PUBLIC_DEFAULT_PUBLIC_API_HOST`) and to render **contextual quick links** via `buildOverviewQuickLinks`; includes new Vitest coverage and stabilizes `SettingsProfileIdentity` username-check tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d96d10a7e1d2ce2c2b3d9f32f9aa0a3f768e8cda. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->