### PR TITLE
refactor(functions): shared session/Bearer auth resolution (v0.30.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Package-specific changes:
 
 ### Changed
 
+- **Workspace** — **Functions 0.30.2**: refactors dual session/Bearer verification into **`resolveSessionAndBearerClaims`** (shared mismatch handling and cookie clear); expanded Vitest coverage for mismatch and auth middleware paths. See [functions/CHANGELOG.md](functions/CHANGELOG.md).
+
 - **Workspace** — **Console 0.6.22** and **Functions 0.30.1**: account-switching session handling (stale HttpOnly **`session`** vs Firebase ID token), **`POST /api/auth/clear-session-cookie`**, onboarding redirect until a public **username** is chosen, **`getIdToken(true)`** for session cookie minting, dashboard hero hostname resolution (**`resolveDashboardTenantHostname`**), and overview **quick links** (**`buildOverviewQuickLinks`**) with Vitest coverage for the new helpers. See [functions/CHANGELOG.md](functions/CHANGELOG.md) and [apps/console/CHANGELOG.md](apps/console/CHANGELOG.md).
 
 - **Workspace** — **Console 0.6.20** and **Functions 0.30.0**: public tenant API and status routing ([GitHub #256](https://github.com/chrisvogt/chronogrove/issues/256)): optional widget **`uid`** / **`username`** query params; removed default **`api.chronogrove.com → chronogrove`** hostname map; console **`/u/[username]`**, **`/widgets/*`** rewrite, **`src/proxy.ts`** **`/`** → **`/u/{slug}`**, **`apps/console/.env.template`**, dev SSR widget fetches via **`127.0.0.1:5001`** emulator. See [functions/CHANGELOG.md](functions/CHANGELOG.md), [apps/console/CHANGELOG.md](apps/console/CHANGELOG.md), [docs/APP_HOSTING.md](docs/APP_HOSTING.md).

--- a/functions/CHANGELOG.md
+++ b/functions/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.2] - 2026-04-10
+
+### Changed
+
+- **Authentication** — **`resolveSessionAndBearerClaims`** centralizes session-cookie and Bearer verification, uid-mismatch detection, warning log, and **`session`** cookie clearing; **`resolveChosenAuthClaims`** and **`resolveViewerUidForPublicOnboarding`** only apply their distinct post-processing (full **`AuthClaims`** vs allowlist-gated **`uid`**). Optional verbose verify logging remains for the authenticated API path only.
+
+### Tests
+
+- **`create-express-app`** — Coverage for mismatch branches (verified vs unverified Bearer after uid mismatch), **`authenticateUser`** outer **`catch`**, and onboarding **`check-username`** mocks now use **`emailVerified`** (Firebase **`AuthClaims`** shape).
+
 ## [0.30.1] - 2026-04-10
 
 ### Added

--- a/functions/CHANGELOG.md
+++ b/functions/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Tests
 
-- **`create-express-app`** — Coverage for mismatch branches (verified vs unverified Bearer after uid mismatch), **`authenticateUser`** outer **`catch`**, and onboarding **`check-username`** mocks now use **`emailVerified`** (Firebase **`AuthClaims`** shape).
+- **`create-express-app`** — Coverage for mismatch branches (verified vs unverified Bearer after uid mismatch), **`authenticateUser`** outer **`catch`** ( **`email`** getter throws only after verbose logging reads it once), silent session-cookie verification failure on **`check-username`**, and onboarding mocks use **`emailVerified`** (Firebase **`AuthClaims`** shape).
 
 ## [0.30.1] - 2026-04-10
 

--- a/functions/app/create-express-app.onboarding.test.ts
+++ b/functions/app/create-express-app.onboarding.test.ts
@@ -586,12 +586,12 @@ describe('createExpressApp onboarding routes', () => {
     authService.verifySessionCookie.mockResolvedValue({
       uid: 'session-uid',
       email: 'a@chrisvogt.me',
-      email_verified: true,
+      emailVerified: true,
     } as never)
     authService.verifyIdToken.mockResolvedValue({
       uid: 'bearer-uid',
       email: 'b@chrisvogt.me',
-      email_verified: false,
+      emailVerified: false,
     } as never)
 
     const handler = findRouteHandler(app, 'get', '/api/onboarding/check-username')
@@ -614,6 +614,36 @@ describe('createExpressApp onboarding routes', () => {
         bearerUid: 'bearer-uid',
       }),
     )
+    expect(json).toHaveBeenCalledWith({ ok: true, available: false })
+  })
+
+  it('GET check-username clears session on uid mismatch but uses verified bearer uid when allowlist passes (mismatch bearer branch)', async () => {
+    const { app } = await buildApp()
+    documentStore.getDocument.mockResolvedValue({ uid: 'other' })
+    authService.verifySessionCookie.mockResolvedValue({
+      uid: 'session-uid',
+      email: 'a@chrisvogt.me',
+      emailVerified: true,
+    } as never)
+    authService.verifyIdToken.mockResolvedValue({
+      uid: 'bearer-uid',
+      email: 'b@chrisvogt.me',
+      emailVerified: true,
+    } as never)
+
+    const handler = findRouteHandler(app, 'get', '/api/onboarding/check-username')
+    const json = vi.fn()
+    const clearCookie = vi.fn()
+    await handler(
+      {
+        query: { username: 'valid_user' },
+        cookies: { session: 'sess' },
+        headers: { authorization: 'Bearer tok' },
+      },
+      { json, clearCookie }
+    )
+
+    expect(clearCookie).toHaveBeenCalledWith('session', expect.objectContaining({ path: '/' }))
     expect(json).toHaveBeenCalledWith({ ok: true, available: false })
   })
 

--- a/functions/app/create-express-app.onboarding.test.ts
+++ b/functions/app/create-express-app.onboarding.test.ts
@@ -368,6 +368,34 @@ describe('createExpressApp onboarding routes', () => {
     expect(json).toHaveBeenCalledWith({ ok: true, available: false })
   })
 
+  it('GET check-username ignores invalid session cookie without logging verify errors (silent path)', async () => {
+    const { app } = await buildApp()
+    documentStore.getDocument.mockResolvedValue({ uid: 'other' })
+    authService.verifySessionCookie.mockRejectedValue(new Error('revoked session'))
+    authService.verifyIdToken.mockResolvedValue({
+      uid: 'viewer',
+      email: 'v@chrisvogt.me',
+      emailVerified: true,
+    } as never)
+
+    const handler = findRouteHandler(app, 'get', '/api/onboarding/check-username')
+    const json = vi.fn()
+    await handler(
+      {
+        query: { username: 'valid_user' },
+        headers: { authorization: 'Bearer tok' },
+        cookies: { session: 'stale' },
+      },
+      { json }
+    )
+
+    expect(logger.error).not.toHaveBeenCalledWith(
+      'Session cookie verification failed',
+      expect.anything()
+    )
+    expect(json).toHaveBeenCalledWith({ ok: true, available: false })
+  })
+
   it('GET check-username ignores invalid bearer when claim exists', async () => {
     const { app } = await buildApp()
     documentStore.getDocument.mockResolvedValue({ uid: 'owner' })

--- a/functions/app/create-express-app.test.ts
+++ b/functions/app/create-express-app.test.ts
@@ -435,10 +435,13 @@ describe('createExpressApp auth and session branches', () => {
   it('returns 401 from authenticateUser when reading chosen.email throws (outer catch)', async () => {
     const app = await buildApp()
 
+    let emailReads = 0
     authService.verifyIdToken.mockResolvedValue({
       uid: 'test-uid',
       emailVerified: true,
       get email() {
+        emailReads += 1
+        if (emailReads < 2) return 'test@chrisvogt.me'
         throw new Error('boom')
       },
     } as never)
@@ -452,9 +455,9 @@ describe('createExpressApp auth and session branches', () => {
       ok: false,
       error: 'Invalid or expired token',
     })
-    expect(logger.error).toHaveBeenCalledWith(
-      'Authentication error:',
-      expect.objectContaining({ error: 'boom' }),
+    const authErr = vi.mocked(logger.error).mock.calls.find((c) => c[0] === 'Authentication error:')
+    expect(authErr?.[1]).toEqual(
+      expect.objectContaining({ error: 'boom', uid: 'unknown' }),
     )
   })
 

--- a/functions/app/create-express-app.test.ts
+++ b/functions/app/create-express-app.test.ts
@@ -432,6 +432,32 @@ describe('createExpressApp auth and session branches', () => {
     expect(response.body.error).toBe('Invalid or expired JWT token')
   })
 
+  it('returns 401 from authenticateUser when reading chosen.email throws (outer catch)', async () => {
+    const app = await buildApp()
+
+    authService.verifyIdToken.mockResolvedValue({
+      uid: 'test-uid',
+      emailVerified: true,
+      get email() {
+        throw new Error('boom')
+      },
+    } as never)
+
+    const response = await request(app)
+      .get('/api/user/profile')
+      .set('Authorization', 'Bearer valid-token')
+      .expect(401)
+
+    expect(response.body).toEqual({
+      ok: false,
+      error: 'Invalid or expired token',
+    })
+    expect(logger.error).toHaveBeenCalledWith(
+      'Authentication error:',
+      expect.objectContaining({ error: 'boom' }),
+    )
+  })
+
   it('rejects state-changing requests when the CSRF token is missing', async () => {
     const app = await buildApp()
 

--- a/functions/app/create-express-app.ts
+++ b/functions/app/create-express-app.ts
@@ -258,15 +258,19 @@ export function createExpressApp({
   }
 
   /**
-   * Resolves the signed-in user from the HttpOnly session cookie and/or `Authorization: Bearer`
-   * (Firebase ID token). When both are present but refer to **different** accounts (e.g. user
-   * signed up or switched accounts without clearing the old session cookie), prefer the Bearer
-   * identity and clear the stale cookie so subsequent requests match Firebase Auth.
+   * Verifies the HttpOnly session cookie and/or `Authorization: Bearer` (Firebase ID token),
+   * detects uid mismatch when both are present, and on mismatch logs, clears the stale session
+   * cookie, and returns `{ mismatch: true }` with both claim sets for callers to interpret.
    */
-  const resolveChosenAuthClaims = async (
+  const resolveSessionAndBearerClaims = async (
     req: express.Request,
-    res: express.Response
-  ): Promise<AuthClaims | null> => {
+    res: express.Response,
+    logVerificationDetails: boolean
+  ): Promise<{
+    sessionClaims: AuthClaims | null
+    bearerClaims: AuthClaims | null
+    mismatch: boolean
+  }> => {
     const sessionCookie = req.cookies?.session
     const bearerToken = extractBearerToken(req.headers.authorization)
 
@@ -274,17 +278,21 @@ export function createExpressApp({
     if (sessionCookie) {
       try {
         sessionClaims = await authService.verifySessionCookie(sessionCookie)
-        logger.info('Session cookie verified successfully', {
-          uid: sessionClaims.uid,
-          email: sessionClaims.email,
-          emailVerified: sessionClaims.emailVerified,
-        })
+        if (logVerificationDetails) {
+          logger.info('Session cookie verified successfully', {
+            uid: sessionClaims.uid,
+            email: sessionClaims.email,
+            emailVerified: sessionClaims.emailVerified,
+          })
+        }
       } catch (error) {
-        logger.error('Session cookie verification failed', {
-          error: error instanceof Error ? error.message : '',
-          code: (error as { code?: string }).code,
-          stack: error instanceof Error ? error.stack : undefined,
-        })
+        if (logVerificationDetails) {
+          logger.error('Session cookie verification failed', {
+            error: error instanceof Error ? error.message : '',
+            code: (error as { code?: string }).code,
+            stack: error instanceof Error ? error.stack : undefined,
+          })
+        }
       }
     }
 
@@ -292,17 +300,21 @@ export function createExpressApp({
     if (bearerToken) {
       try {
         bearerClaims = await authService.verifyIdToken(bearerToken)
-        logger.info('auth: bearer token', {
-          path: req.path,
-          uid: bearerClaims.uid,
-          email: bearerClaims.email,
-          emailVerified: bearerClaims.emailVerified,
-        })
+        if (logVerificationDetails) {
+          logger.info('auth: bearer token', {
+            path: req.path,
+            uid: bearerClaims.uid,
+            email: bearerClaims.email,
+            emailVerified: bearerClaims.emailVerified,
+          })
+        }
       } catch (error) {
-        logger.error('JWT token verification failed', {
-          error: error instanceof Error ? error.message : '',
-          code: (error as { code?: string }).code,
-        })
+        if (logVerificationDetails) {
+          logger.error('JWT token verification failed', {
+            error: error instanceof Error ? error.message : '',
+            code: (error as { code?: string }).code,
+          })
+        }
       }
     }
 
@@ -320,6 +332,25 @@ export function createExpressApp({
         }
       )
       res.clearCookie('session', sessionCookieBaseOptions)
+    }
+
+    return { sessionClaims, bearerClaims, mismatch }
+  }
+
+  /**
+   * Resolves the signed-in user from the HttpOnly session cookie and/or `Authorization: Bearer`
+   * (Firebase ID token). When both are present but refer to **different** accounts (e.g. user
+   * signed up or switched accounts without clearing the old session cookie), prefer the Bearer
+   * identity and clear the stale cookie so subsequent requests match Firebase Auth.
+   */
+  const resolveChosenAuthClaims = async (
+    req: express.Request,
+    res: express.Response
+  ): Promise<AuthClaims | null> => {
+    const { sessionClaims, bearerClaims, mismatch } =
+      await resolveSessionAndBearerClaims(req, res, true)
+
+    if (mismatch) {
       return bearerClaims
     }
 
@@ -336,48 +367,16 @@ export function createExpressApp({
     req: express.Request,
     res: express.Response
   ): Promise<string | null> => {
-    const sessionCookie = req.cookies?.session
-    const bearerToken = extractBearerToken(req.headers.authorization)
-
-    let sessionClaims: AuthClaims | null = null
-    if (sessionCookie) {
-      try {
-        sessionClaims = await authService.verifySessionCookie(sessionCookie)
-      } catch {
-        /* treat as missing */
-      }
-    }
-
-    let bearerClaims: AuthClaims | null = null
-    if (bearerToken) {
-      try {
-        bearerClaims = await authService.verifyIdToken(bearerToken)
-      } catch {
-        /* treat as missing */
-      }
-    }
-
-    const mismatch =
-      sessionClaims !== null &&
-      bearerClaims !== null &&
-      sessionClaims.uid !== bearerClaims.uid
+    const { sessionClaims, bearerClaims, mismatch } =
+      await resolveSessionAndBearerClaims(req, res, false)
 
     if (mismatch) {
-      logger.warn(
-        'Session uid does not match Bearer uid; preferring Bearer and clearing session cookie',
-        {
-          sessionUid: sessionClaims.uid,
-          bearerUid: bearerClaims.uid,
-        }
-      )
-      res.clearCookie('session', sessionCookieBaseOptions)
-      const b = bearerClaims
       if (
-        b.uid &&
-        isAllowedEmail(b.email) &&
-        !needsEmailVerification(b.email, b.emailVerified)
+        bearerClaims?.uid &&
+        isAllowedEmail(bearerClaims.email) &&
+        !needsEmailVerification(bearerClaims.email, bearerClaims.emailVerified)
       ) {
-        return b.uid
+        return bearerClaims.uid
       }
       return null
     }

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chronogrove-functions",
-  "version": "0.30.1",
+  "version": "0.30.2",
   "license": "Apache-2.0",
   "description": "Chronogrove server: Firebase Cloud Functions for the public widget API, authenticated admin routes, and provider sync jobs.",
   "type": "module",


### PR DESCRIPTION
## Summary

Extracts `resolveSessionAndBearerClaims` so session-cookie + Bearer verification, uid-mismatch detection, warn log, and stale `session` cookie clearing live in one place. `resolveChosenAuthClaims` and `resolveViewerUidForPublicOnboarding` only apply their distinct post-processing (full `AuthClaims` vs allowlist-gated `uid`).

## Release

- **chronogrove-functions** **0.30.2** (patch): see `functions/CHANGELOG.md`.

## Tests

- Mismatch branches (verified vs unverified Bearer after uid mismatch)
- `authenticateUser` outer `catch`
- Onboarding mocks use `emailVerified` (`AuthClaims` shape)

## Coverage

Full `npm run test:coverage` passes existing Vitest thresholds.

Made with [Cursor](https://cursor.com)