### PR TITLE
feat(goodreads): readAt on widget books and newest-first sort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Package-specific changes:
 
 ### Changed
 
+- **Workspace** — **Functions 0.30.3** and **Console 0.6.23**: Goodreads **`readAt`** on each **`recentlyReadBooks`** row and stable **most-recent-first** ordering when saving widget content; **`utils/sort-goodreads-recently-read-books`**, expanded Vitest coverage, and schema examples updated. See [functions/CHANGELOG.md](functions/CHANGELOG.md) and [apps/console/CHANGELOG.md](apps/console/CHANGELOG.md).
+
 - **Workspace** — **Functions 0.30.2**: refactors dual session/Bearer verification into **`resolveSessionAndBearerClaims`** (shared mismatch handling and cookie clear); expanded Vitest coverage for mismatch and auth middleware paths. See [functions/CHANGELOG.md](functions/CHANGELOG.md).
 
 - **Workspace** — **Console 0.6.22** and **Functions 0.30.1**: account-switching session handling (stale HttpOnly **`session`** vs Firebase ID token), **`POST /api/auth/clear-session-cookie`**, onboarding redirect until a public **username** is chosen, **`getIdToken(true)`** for session cookie minting, dashboard hero hostname resolution (**`resolveDashboardTenantHostname`**), and overview **quick links** (**`buildOverviewQuickLinks`**) with Vitest coverage for the new helpers. See [functions/CHANGELOG.md](functions/CHANGELOG.md) and [apps/console/CHANGELOG.md](apps/console/CHANGELOG.md).

--- a/apps/console/CHANGELOG.md
+++ b/apps/console/CHANGELOG.md
@@ -7,6 +7,12 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.23] - 2026-05-03
+
+### Changed
+
+- **Schema / docs** — Goodreads widget example **`collections.recentlyReadBooks`** entries include **`readAt`** to match the Functions sync payload.
+
 ## [0.6.22] - 2026-04-10
 
 ### Added

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "license": "Apache-2.0",
   "description": "Chronogrove operator console: Next.js admin UI (SSR on Firebase App Hosting) for schema, status, sync, and onboarding.",
-  "version": "0.6.22",
+  "version": "0.6.23",
   "engines": {
     "node": ">=24"
   },

--- a/apps/console/src/sections/schemaExamples.ts
+++ b/apps/console/src/sections/schemaExamples.ts
@@ -74,6 +74,7 @@ const goodreadsBookItem = {
   isbn: '9780593135204',
   pageCount: 496,
   rating: '5',
+  readAt: '2025-03-15',
   smallThumbnail: 'http://books.google.com/books/content?id=example&printsec=frontcover&img=1&zoom=5',
   thumbnail: 'http://books.google.com/books/content?id=example&printsec=frontcover&img=1&zoom=1',
 }
@@ -226,7 +227,15 @@ export const widgetResponseExamples = {
       aiSummary:
         'Mostly science fiction and literary fiction; finishes series quickly when hooked; rates generously on debut novels.',
       collections: {
-        recentlyReadBooks: [goodreadsBookItem, { ...goodreadsBookItem, id: 'gr-book-2', title: 'Sea of Tranquility' }],
+        recentlyReadBooks: [
+          goodreadsBookItem,
+          {
+            ...goodreadsBookItem,
+            id: 'gr-book-2',
+            title: 'Sea of Tranquility',
+            readAt: '2025-02-01',
+          },
+        ],
         updates: [
           {
             type: 'review',

--- a/functions/CHANGELOG.md
+++ b/functions/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.3] - 2026-05-03
+
+### Added
+
+- **Goodreads widget** — Each **`collections.recentlyReadBooks`** entry now includes **`readAt`** (Goodreads shelf **`read_at`** text) for ordering and client display.
+
+### Changed
+
+- **Goodreads sync** — **`fetch-recently-read-books`** carries **`readAt`** through **`transformBookData`**; **`sortGoodreadsRecentlyReadBooksByReadAtDesc`** (**`utils/sort-goodreads-recently-read-books.ts`**) orders by parsed date so the **most recently read** titles appear first before **`GOODREADS_BOOKS_TO_DISPLAY`** is applied. The same sort runs when assembling widget **`collections`** in **`sync-goodreads-data`**.
+
+### Tests
+
+- **`sort-goodreads-recently-read-books`** — Sort key, descending order, missing **`readAt`** at end, non-mutating copy.
+- **`fetch-recently-read-books`** — Assertions for **`readAt`** on shelf rows and newest-first order when two reviews resolve.
+- **`sync-goodreads-data`** — Persisted **`recentlyReadBooks`** order matches **`readAt`** descending when the fetch mock returns rows out of chronological order.
+
 ## [0.30.2] - 2026-04-10
 
 ### Changed
@@ -740,6 +756,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _This changelog was started with v0.8.0._
 
+[0.30.3]: https://github.com/chrisvogt/chronogrove/compare/v0.30.2...v0.30.3
+[0.30.2]: https://github.com/chrisvogt/chronogrove/compare/v0.30.1...v0.30.2
+[0.30.1]: https://github.com/chrisvogt/chronogrove/compare/v0.30.0...v0.30.1
+[0.30.0]: https://github.com/chrisvogt/chronogrove/compare/v0.29.2...v0.30.0
 [0.25.5]: https://github.com/chrisvogt/chronogrove/compare/v0.25.4...v0.25.5
 [0.25.4]: https://github.com/chrisvogt/chronogrove/compare/v0.25.3...v0.25.4
 [0.25.3]: https://github.com/chrisvogt/chronogrove/compare/v0.25.2...v0.25.3

--- a/functions/api/goodreads/fetch-recently-read-books.test.ts
+++ b/functions/api/goodreads/fetch-recently-read-books.test.ts
@@ -164,7 +164,8 @@ describe('fetchRecentlyReadBooks', () => {
       expect.arrayContaining([
         expect.objectContaining({
           isbn: '1234567890123',
-          rating: '4'
+          rating: '4',
+          readAt: '2023-01-01',
         })
       ]),
       expect.any(Function),
@@ -175,10 +176,13 @@ describe('fetchRecentlyReadBooks', () => {
     )
 
     // Verify Google Books API was called
-    expect(mockFetchBookFromGoogle).toHaveBeenCalledWith({
-      isbn: '1234567890123',
-      rating: '4'
-    })
+    expect(mockFetchBookFromGoogle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isbn: '1234567890123',
+        rating: '4',
+        readAt: '2023-01-01',
+      }),
+    )
 
     // Verify stored media was checked
     expect(mockListStoredMedia).toHaveBeenCalled()
@@ -211,6 +215,7 @@ describe('fetchRecentlyReadBooks', () => {
         pageCount: 300,
         previewLink: 'http://example.com/preview',
         rating: '4',
+        readAt: '2023-01-01',
         smallThumbnail: 'https://example.com/small.jpg',
         subtitle: 'Test Subtitle',
         thumbnail: 'https://example.com/thumb.jpg',
@@ -545,10 +550,13 @@ describe('fetchRecentlyReadBooks', () => {
 
     // Should only process the book with valid date (the second one should be filtered out)
     expect(mockFetchBookFromGoogle).toHaveBeenCalledTimes(1)
-    expect(mockFetchBookFromGoogle).toHaveBeenCalledWith({
-      isbn: '1234567890',
-      rating: '4'
-    })
+    expect(mockFetchBookFromGoogle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isbn: '1234567890',
+        rating: '4',
+        readAt: '2023-01-01',
+      }),
+    )
   })
 
   it('should filter out books with missing rating', async () => {
@@ -1032,6 +1040,10 @@ describe('fetchRecentlyReadBooks', () => {
     const result = await fetchRecentlyReadBooks()
 
     expect(result.books).toHaveLength(2)
+    expect(result.books[0].id).toBe('id2')
+    expect(result.books[0].readAt).toBe('2023-01-02')
+    expect(result.books[1].id).toBe('id1')
+    expect(result.books[1].readAt).toBe('2023-01-01')
     expect(mockFetchBookFromGoogle).toHaveBeenCalledTimes(2)
   })
 

--- a/functions/api/goodreads/fetch-recently-read-books.ts
+++ b/functions/api/goodreads/fetch-recently-read-books.ts
@@ -28,6 +28,7 @@ import type {
 } from '../../types/goodreads.js'
 
 import { getXmlTextOrUndefined } from '../../utils/goodreads-xml.js'
+import { sortGoodreadsRecentlyReadBooksByReadAtDesc } from '../../utils/sort-goodreads-recently-read-books.js'
 
 const toBookMediaDestinationPath = id => `books/${id}-thumbnail.jpg`
 
@@ -52,6 +53,7 @@ const transformBookData = (book: TransformBookDataInput): GoodreadsRecentlyReadB
     rating,
     goodreadsDescription,
     isbn,
+    readAt,
   } = book
 
   const mediaDestinationPath = toBookMediaDestinationPath(id)
@@ -68,6 +70,7 @@ const transformBookData = (book: TransformBookDataInput): GoodreadsRecentlyReadB
     pageCount,
     previewLink,
     rating,
+    ...(readAt != null && readAt !== '' ? { readAt } : {}),
     smallThumbnail: smallThumbnail ? convertToHttps(smallThumbnail) : '',
     subtitle,
     thumbnail: thumbnail ? convertToHttps(thumbnail) : '',
@@ -143,6 +146,7 @@ export default async () => {
           books.push({
             isbn,
             rating,
+            readAt: readDate,
             goodreadsDescription,
             ...(typeof title === 'string' && { title }),
             ...(typeof authorName === 'string' && { authorName }),
@@ -259,24 +263,27 @@ export default async () => {
     }
   )
 
-  const books: GoodreadsRecentlyReadBook[] = bookResults
-    .filter(
-      (bookResult): bookResult is {
-        googleBookResult: GoogleBooksFetchByIsbnResult & { book: GoogleBooksVolumeSubset }
-        goodreadsData: GoodreadsReviewListBookSource
-        originalIndex: number
-      } => Boolean(bookResult.googleBookResult?.book),
-    )
-    .map((bookResult) => {
-      const { googleBookResult, goodreadsData } = bookResult
+  const books = sortGoodreadsRecentlyReadBooksByReadAtDesc(
+    bookResults
+      .filter(
+        (bookResult): bookResult is {
+          googleBookResult: GoogleBooksFetchByIsbnResult & { book: GoogleBooksVolumeSubset }
+          goodreadsData: GoodreadsReviewListBookSource
+          originalIndex: number
+        } => Boolean(bookResult.googleBookResult?.book),
+      )
+      .map((bookResult) => {
+        const { googleBookResult, goodreadsData } = bookResult
 
-      return transformBookData({
-        book: googleBookResult.book,
-        rating: googleBookResult.rating ?? null,
-        goodreadsDescription: goodreadsData.goodreadsDescription,
-        isbn: goodreadsData.isbn,
-      })
-    })
+        return transformBookData({
+          book: googleBookResult.book,
+          rating: googleBookResult.rating ?? null,
+          goodreadsDescription: goodreadsData.goodreadsDescription,
+          isbn: goodreadsData.isbn,
+          readAt: goodreadsData.readAt,
+        })
+      }),
+  )
 
   const storedMediaFileNames = await listStoredMedia()
 

--- a/functions/jobs/sync-goodreads-data.test.ts
+++ b/functions/jobs/sync-goodreads-data.test.ts
@@ -155,6 +155,57 @@ describe('syncGoodreadsData', () => {
     )
   })
 
+  it('should sort recentlyReadBooks by readAt descending before persisting widget content', async () => {
+    fetchUser.mockResolvedValue({
+      profile: { displayName: 'Reader', readCount: 2 },
+      updates: [],
+      jsonResponse: {},
+    })
+    fetchRecentlyReadBooks.mockResolvedValue({
+      books: [
+        {
+          id: 'older',
+          title: 'Older read',
+          readAt: '2020-06-01',
+          categories: [],
+          cdnMediaURL: 'https://cdn.example/o.jpg',
+          mediaDestinationPath: 'books/older.jpg',
+          smallThumbnail: '',
+          thumbnail: '',
+          infoLink: '',
+        },
+        {
+          id: 'newer',
+          title: 'Newer read',
+          readAt: '2025-03-15',
+          categories: [],
+          cdnMediaURL: 'https://cdn.example/n.jpg',
+          mediaDestinationPath: 'books/newer.jpg',
+          smallThumbnail: '',
+          thumbnail: '',
+          infoLink: '',
+        },
+      ],
+      rawReviewsResponse: [],
+    })
+    generateGoodreadsSummary.mockResolvedValue('<p>Summary.</p>')
+
+    const result = await syncGoodreadsData(documentStore)
+
+    expect(result.result).toBe('SUCCESS')
+    const sorted = result.data.collections?.recentlyReadBooks ?? []
+    expect(sorted).toHaveLength(2)
+    expect(sorted[0]?.id).toBe('newer')
+    expect(sorted[0]?.readAt).toBe('2025-03-15')
+    expect(sorted[1]?.id).toBe('older')
+
+    const widgetCall = vi.mocked(documentStore.setDocument).mock.calls.find(
+      (call) => call[0] === 'users/chrisvogt/goodreads/widget-content',
+    )
+    const persisted = widgetCall?.[1] as { collections?: { recentlyReadBooks?: { id?: string }[] } }
+    expect(persisted?.collections?.recentlyReadBooks?.[0]?.id).toBe('newer')
+  })
+
   it('should handle API errors gracefully', async () => {
     fetchUser.mockRejectedValue(new Error('API Error'))
     fetchRecentlyReadBooks.mockResolvedValue({ books: [], rawReviewsResponse: {} })

--- a/functions/jobs/sync-goodreads-data.ts
+++ b/functions/jobs/sync-goodreads-data.ts
@@ -20,6 +20,7 @@ import { GOODREADS_BOOKS_TO_DISPLAY } from '../config/goodreads-config.js'
 import { getLogger } from '../services/logger.js'
 import { toStoredDateTime } from '../utils/time.js'
 import { getXmlTextOrNull } from '../utils/goodreads-xml.js'
+import { sortGoodreadsRecentlyReadBooksByReadAtDesc } from '../utils/sort-goodreads-recently-read-books.js'
 
 import type {
   GoogleBooksFetchByIsbnResult,
@@ -63,6 +64,7 @@ const transformBookData = (
     rating,
     goodreadsDescription,
     isbn,
+    readAt,
   } = book
 
   const mediaDestinationPath = toBookMediaDestinationPath(id)
@@ -79,6 +81,7 @@ const transformBookData = (
     pageCount,
     previewLink,
     rating,
+    ...(readAt != null && readAt !== '' ? { readAt } : {}),
     smallThumbnail: smallThumbnail ? convertToHttps(smallThumbnail) : '',
     subtitle,
     thumbnail: thumbnail ? convertToHttps(thumbnail) : '',
@@ -515,7 +518,9 @@ const fetchAllGoodreadsPromises = async (
 
     return {
       collections: {
-        recentlyReadBooks: (recentlyRead.books ?? []).slice(0, GOODREADS_BOOKS_TO_DISPLAY),
+        recentlyReadBooks: sortGoodreadsRecentlyReadBooksByReadAtDesc(
+          recentlyRead.books ?? [],
+        ).slice(0, GOODREADS_BOOKS_TO_DISPLAY),
         updates: processedUpdates,
       },
       fullReadShelf,

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chronogrove-functions",
-  "version": "0.30.2",
+  "version": "0.30.3",
   "license": "Apache-2.0",
   "description": "Chronogrove server: Firebase Cloud Functions for the public widget API, authenticated admin routes, and provider sync jobs.",
   "type": "module",

--- a/functions/types/goodreads.ts
+++ b/functions/types/goodreads.ts
@@ -99,6 +99,8 @@ export interface GoodreadsRecentlyReadBookFromGoogle {
   rating?: string | null
   goodreadsDescription?: string | undefined
   isbn?: string | null | undefined
+  /** Goodreads `read_at` text from the read shelf review list (for ordering). */
+  readAt?: string | null
 }
 
 export interface GoodreadsRecentlyReadBook {
@@ -113,6 +115,8 @@ export interface GoodreadsRecentlyReadBook {
   pageCount?: number
   previewLink?: string
   rating?: string | null
+  /** Goodreads `read_at` from the shelf review; used for most-recent-first ordering. */
+  readAt?: string
   smallThumbnail: string
   subtitle?: string
   thumbnail: string
@@ -129,6 +133,8 @@ export interface GoodreadsReviewListRawReview {
 export interface GoodreadsReviewListBookSource {
   isbn: string
   rating: string
+  /** Goodreads `read_at` for this review (required for rows we keep). */
+  readAt: string
   goodreadsDescription?: string
   title?: string
   authorName?: string

--- a/functions/utils/sort-goodreads-recently-read-books.test.ts
+++ b/functions/utils/sort-goodreads-recently-read-books.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import {
+  goodreadsReadAtToSortKey,
+  sortGoodreadsRecentlyReadBooksByReadAtDesc,
+} from './sort-goodreads-recently-read-books.js'
+import type { GoodreadsRecentlyReadBook } from '../types/goodreads.js'
+
+const minimalBook = (overrides: Partial<GoodreadsRecentlyReadBook>): GoodreadsRecentlyReadBook => ({
+  categories: [],
+  cdnMediaURL: '',
+  id: 'x',
+  infoLink: '',
+  mediaDestinationPath: 'books/x.jpg',
+  smallThumbnail: '',
+  thumbnail: '',
+  ...overrides,
+})
+
+describe('goodreadsReadAtToSortKey', () => {
+  it('returns NEGATIVE_INFINITY for empty or unparseable strings', () => {
+    expect(goodreadsReadAtToSortKey(undefined)).toBe(Number.NEGATIVE_INFINITY)
+    expect(goodreadsReadAtToSortKey('')).toBe(Number.NEGATIVE_INFINITY)
+    expect(goodreadsReadAtToSortKey('not a date')).toBe(Number.NEGATIVE_INFINITY)
+  })
+
+  it('parses ISO and common Goodreads-style dates', () => {
+    expect(goodreadsReadAtToSortKey('2023-01-01')).toBe(Date.parse('2023-01-01'))
+    expect(goodreadsReadAtToSortKey('2023/01/02')).toBe(Date.parse('2023/01/02'))
+  })
+})
+
+describe('sortGoodreadsRecentlyReadBooksByReadAtDesc', () => {
+  it('orders most recently read first and pushes missing readAt to the end', () => {
+    const a = minimalBook({ id: 'a', readAt: '2023-01-01', title: 'Old' })
+    const b = minimalBook({ id: 'b', readAt: '2024-06-15', title: 'New' })
+    const c = minimalBook({ id: 'c', title: 'No date' })
+    const sorted = sortGoodreadsRecentlyReadBooksByReadAtDesc([a, c, b])
+    expect(sorted.map((x) => x.id)).toEqual(['b', 'a', 'c'])
+  })
+
+  it('does not mutate the input array', () => {
+    const input: GoodreadsRecentlyReadBook[] = [
+      minimalBook({ id: '1', readAt: '2022-01-01' }),
+      minimalBook({ id: '2', readAt: '2023-01-01' }),
+    ]
+    const copy = [...input]
+    sortGoodreadsRecentlyReadBooksByReadAtDesc(input)
+    expect(input).toEqual(copy)
+  })
+})

--- a/functions/utils/sort-goodreads-recently-read-books.ts
+++ b/functions/utils/sort-goodreads-recently-read-books.ts
@@ -1,0 +1,21 @@
+import type { GoodreadsRecentlyReadBook } from '../types/goodreads.js'
+
+/**
+ * Parse Goodreads `read_at` text for chronological sort.
+ * Unparseable or missing values sort last when ordering most-recent-first.
+ */
+export const goodreadsReadAtToSortKey = (readAt: string | null | undefined): number => {
+  if (readAt == null || readAt === '') {
+    return Number.NEGATIVE_INFINITY
+  }
+  const ms = Date.parse(readAt)
+  return Number.isFinite(ms) ? ms : Number.NEGATIVE_INFINITY
+}
+
+/** Most recently read first; entries without a usable `readAt` sort to the end. */
+export const sortGoodreadsRecentlyReadBooksByReadAtDesc = (
+  books: GoodreadsRecentlyReadBook[],
+): GoodreadsRecentlyReadBook[] =>
+  [...books].sort(
+    (a, b) => goodreadsReadAtToSortKey(b.readAt) - goodreadsReadAtToSortKey(a.readAt),
+  )


### PR DESCRIPTION
## Summary

- Persist Goodreads shelf **`read_at`** on each **`collections.recentlyReadBooks`** item as **`readAt`** (widget JSON / Firestore `widget-content`).
- Sort **`recentlyReadBooks`** by parsed **`readAt`** descending (most recently finished first) before applying **`GOODREADS_BOOKS_TO_DISPLAY`**, using shared **`utils/sort-goodreads-recently-read-books`** in both **`fetch-recently-read-books`** and **`sync-goodreads-data`** so stored order stays correct even when upstream or Google enrichment changes row order.

## Tests / coverage

- **`functions/utils/sort-goodreads-recently-read-books.test.ts`** — sort key, desc order, missing dates last, non-mutating.
- **`fetch-recently-read-books.test.ts`** — **`readAt`** on transformed books; two-book case asserts newer read first.
- **`sync-goodreads-data.test.ts`** — persisted widget **`recentlyReadBooks`** order when mock fetch returns rows out of chronological order.
- **`pnpm -C functions test:coverage`** — green; overall Functions coverage remains **~99.9%** statements.

## Releases

- **chronogrove-functions** `0.30.2` → **`0.30.3`**
- **chronogrove-console** `0.6.22` → **`0.6.23`** (schema examples: sample **`readAt`** on Goodreads books)

Changelogs: root `CHANGELOG.md`, `functions/CHANGELOG.md`, `apps/console/CHANGELOG.md`.

Made with [Cursor](https://cursor.com)