### PR TITLE
fix(console): App Hosting deploy — pin Next exact + docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Package-specific changes:
 
 ### Changed
 
-- **Workspace** — **Console 0.6.25**: **Next.js** pinned to exact **`16.2.4`** so Firebase App Hosting’s **`@apphosting/adapter-nextjs`** CVE version check receives a valid semver (ranges like **`^16.2.4`** were mis-rejected and blocked deploy). See [apps/console/CHANGELOG.md](apps/console/CHANGELOG.md).
+- **Workspace** — **Console 0.6.25**: **Next.js** pinned to exact **`16.2.4`** so Firebase App Hosting’s **`@apphosting/adapter-nextjs`** CVE version check receives a valid semver (ranges like **`^16.2.4`** were mis-rejected and blocked deploy). Documented in **[docs/APP_HOSTING.md](docs/APP_HOSTING.md)** and **[apps/console/README.md](apps/console/README.md)**. See [apps/console/CHANGELOG.md](apps/console/CHANGELOG.md).
 
 - **Workspace** — **Functions 0.30.4** and **Console 0.6.24**: dependency refresh (security-motivated **Next.js** `^16.2.4`, shared **Firebase** `^12.12.1`, **Vitest** `^4.1.5`, **Turbo** `^2.9.8`, and related bumps in `apps/console` and `functions`); root **`pnpm.overrides`** pins transitive **`vite@8.0.5`** so Vitest / `@vitejs/plugin-react` no longer pull the **8.0.0–8.0.4** dev-server advisories. See [functions/CHANGELOG.md](functions/CHANGELOG.md) and [apps/console/CHANGELOG.md](apps/console/CHANGELOG.md).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Package-specific changes:
 
 ### Changed
 
+- **Workspace** — **Console 0.6.25**: **Next.js** pinned to exact **`16.2.4`** so Firebase App Hosting’s **`@apphosting/adapter-nextjs`** CVE version check receives a valid semver (ranges like **`^16.2.4`** were mis-rejected and blocked deploy). See [apps/console/CHANGELOG.md](apps/console/CHANGELOG.md).
+
 - **Workspace** — **Functions 0.30.4** and **Console 0.6.24**: dependency refresh (security-motivated **Next.js** `^16.2.4`, shared **Firebase** `^12.12.1`, **Vitest** `^4.1.5`, **Turbo** `^2.9.8`, and related bumps in `apps/console` and `functions`); root **`pnpm.overrides`** pins transitive **`vite@8.0.5`** so Vitest / `@vitejs/plugin-react` no longer pull the **8.0.0–8.0.4** dev-server advisories. See [functions/CHANGELOG.md](functions/CHANGELOG.md) and [apps/console/CHANGELOG.md](apps/console/CHANGELOG.md).
 
 - **Workspace** — **Functions 0.30.3** and **Console 0.6.23**: Goodreads **`readAt`** on each **`recentlyReadBooks`** row and stable **most-recent-first** ordering when saving widget content; **`utils/sort-goodreads-recently-read-books`**, expanded Vitest coverage, and schema examples updated. See [functions/CHANGELOG.md](functions/CHANGELOG.md) and [apps/console/CHANGELOG.md](apps/console/CHANGELOG.md).

--- a/apps/console/CHANGELOG.md
+++ b/apps/console/CHANGELOG.md
@@ -13,6 +13,10 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Firebase App Hosting** — Pin **Next.js** to exact **`16.2.4`** in **`package.json`** (not a **`^`** range). The **`@apphosting/adapter-nextjs`** CVE gate passes that string to **`semver.satisfies(version, …)`**, which treats **`^16.2.4`** as an invalid version and blocks deploy with a false “vulnerable Next” error even though **16.2.4** satisfies the patched **`>=16.1.0`** allowlist.
 
+### Documentation
+
+- **`docs/APP_HOSTING.md`** — “Next.js version string” note for the App Hosting buildpack; **`README.md`** (this app) links to it from the build section.
+
 ## [0.6.24] - 2026-05-03
 
 ### Security

--- a/apps/console/CHANGELOG.md
+++ b/apps/console/CHANGELOG.md
@@ -7,6 +7,12 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.25] - 2026-05-04
+
+### Fixed
+
+- **Firebase App Hosting** — Pin **Next.js** to exact **`16.2.4`** in **`package.json`** (not a **`^`** range). The **`@apphosting/adapter-nextjs`** CVE gate passes that string to **`semver.satisfies(version, …)`**, which treats **`^16.2.4`** as an invalid version and blocks deploy with a false “vulnerable Next” error even though **16.2.4** satisfies the patched **`>=16.1.0`** allowlist.
+
 ## [0.6.24] - 2026-05-03
 
 ### Security

--- a/apps/console/README.md
+++ b/apps/console/README.md
@@ -59,6 +59,8 @@ pnpm run build
 
 Next.js output is under **`apps/console/.next`** (SSR bundle for App Hosting). The root scripts run this build before App Hosting deploys.
 
+**App Hosting:** keep the **`next`** dependency in **`package.json`** as an **exact** semver (e.g. **`"16.2.4"`**, not **`^16.2.4`**). Firebase’s **`@apphosting/adapter-nextjs`** CVE gate passes that string to **`semver.satisfies`**; range strings are rejected and the remote build fails. See [docs/APP_HOSTING.md](../docs/APP_HOSTING.md#nextjs-version-string-appsconsolepackagejson).
+
 ## Deploy
 
 From the **repo root**:

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "license": "Apache-2.0",
   "description": "Chronogrove operator console: Next.js admin UI (SSR on Firebase App Hosting) for schema, status, sync, and onboarding.",
-  "version": "0.6.24",
+  "version": "0.6.25",
   "engines": {
     "node": ">=24"
   },
@@ -19,7 +19,7 @@
     "hast-util-to-jsx-runtime": "^2.3.6",
     "highlight.js": "^11.11.1",
     "lowlight": "^3.3.0",
-    "next": "^16.2.4",
+    "next": "16.2.4",
     "next-themes": "^0.4.6",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",

--- a/docs/APP_HOSTING.md
+++ b/docs/APP_HOSTING.md
@@ -42,6 +42,10 @@ Backend IDs must exist in the Firebase project (Console or CLI, e.g. `firebase a
 
 Do not put private API keys in `apphosting.yaml`; use Firebase-managed secrets or your team’s secret store for sensitive values and wire them through the console or CLI as required by App Hosting.
 
+### Next.js version string (`apps/console/package.json`)
+
+The App Hosting build runs **`@apphosting/adapter-nextjs`**, which validates the **`next`** field from **`package.json`** against a patched-version allowlist (React2Shell / [CVE-2025-55182](https://www.cve.org/CVERecord?id=CVE-2025-55182)). The check uses **`semver.satisfies(version, range)`** and expects **`version`** to be a **single concrete semver** (e.g. **`16.2.4`**). A **caret or other range** (e.g. **`^16.2.4`**) is not a valid “version” argument to that API, so the build fails with a misleading “vulnerable Next” error even when the resolved install is patched. **Keep `next` as an exact version** in this app until the adapter reads the resolved package version instead; after bumps, run **`pnpm install`** and commit the lockfile as usual.
+
 ## Deploy
 
 **CI** runs lint, tests, and a workspace build; it does not deploy. **App Hosting** and **Functions** releases typically go through the **Firebase** GitHub app / project integration when that is connected; you can also deploy from the **repository root** with the CLI:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0
       next:
-        specifier: ^16.2.4
+        specifier: 16.2.4
         version: 16.2.4(@opentelemetry/api@1.9.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-themes:
         specifier: ^0.4.6


### PR DESCRIPTION
## Summary

Firebase App Hosting builds failed after `next` was set to `^16.2.4`: `@apphosting/adapter-nextjs` passes the raw `package.json` value to `semver.satisfies(version, …)`, and caret ranges are not valid `version` arguments, so the CVE gate threw a false "vulnerable Next" error.

## Changes

- **Console 0.6.25** — `next` pinned to exact **`16.2.4`** in `apps/console/package.json`.
- **Changelogs** — [apps/console/CHANGELOG.md](apps/console/CHANGELOG.md), [CHANGELOG.md](CHANGELOG.md).
- **Docs** — [docs/APP_HOSTING.md](docs/APP_HOSTING.md) (`### Next.js version string`), [apps/console/README.md](apps/console/README.md) (build section link).

## Verification

- `pnpm install`
- `pnpm test`

## Deploy

After merge, App Hosting should build again without changing resolved Next behavior beyond the semver string fix.

Made with [Cursor](https://cursor.com)