### PR TITLE
fix(console): stabilize settings profile load (CI flake)

### DIFF
--- a/apps/console/src/components/user-settings/SettingsProfileIdentity.tsx
+++ b/apps/console/src/components/user-settings/SettingsProfileIdentity.tsx
@@ -467,6 +467,9 @@ export function SettingsProfileIdentity({
   const [loadError, setLoadError] = useState<string | null>(null)
   const progressRef = useRef<OnboardingProgressPayload | null>(null)
   const [identitySaveInFlight, setIdentitySaveInFlight] = useState(false)
+  /** Avoid re-fetch loops when parents pass a new `user` object each render (e.g. tests). */
+  const userRef = useRef(user)
+  userRef.current = user
 
   const handleProgressUpdated = useCallback((p: OnboardingProgressPayload) => {
     progressRef.current = p
@@ -482,12 +485,16 @@ export function SettingsProfileIdentity({
     }
   }, [])
 
+  const authIdentityKey = user?.uid ?? ''
+
   const load = useCallback(async () => {
-    if (!user || !apiSessionReady) return
+    if (!apiSessionReady) return
+    const currentUser = userRef.current
+    if (!currentUser) return
     setLoading(true)
     setLoadError(null)
     try {
-      const idToken = await user.getIdToken()
+      const idToken = await currentUser.getIdToken()
       const res = await apiClient.getJson('/api/onboarding/progress', { idToken })
       if (!res.ok) throw new Error('Could not load profile.')
       const data = (await res.json()) as { payload?: OnboardingProgressPayload }
@@ -501,12 +508,13 @@ export function SettingsProfileIdentity({
     } finally {
       setLoading(false)
     }
-  }, [user, apiSessionReady])
+  }, [apiSessionReady])
 
   useEffect(() => {
-    if (!user || !apiSessionReady) return
+    if (!apiSessionReady) return
+    if (!userRef.current) return
     void load()
-  }, [user, apiSessionReady, load])
+  }, [apiSessionReady, authIdentityKey, load])
 
   if (!apiSessionReady) {
     return (


### PR DESCRIPTION
## Summary
Stops `SettingsProfileIdentity` from re-running the onboarding progress `load()` whenever the parent passes a new `User` object reference on each render (e.g. tests using `user={mockUser()}`).

## Problem
The load effect depended on `user` and `load`. After the first successful fetch, `setProgress` re-rendered the parent with a new `user` reference, which recreated `load` and re-fired the effect. The second `load()` called `setLoading(true)`, briefly showed the loading state, unmounted the username block, and cleared the debounced username availability check—so `SettingsProfileIdentity` tests timed out waiting for "is available" on CI.

## Change
- Hold the latest `user` in a ref for `getIdToken()`.
- Re-fetch when `apiSessionReady` or `user.uid` (`authIdentityKey`) changes, not on `user` reference identity.
- Keep `load` stable across re-renders for the same session.

## Testing
`npx vitest run src/components/user-settings/SettingsProfileIdentity.test.tsx` (22 tests) passes locally.

Made with [Cursor](https://cursor.com)