### PR TITLE
security: sunset metrics host in API CORS + doc/test hygiene

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align='center'>
-  Chronogrove (<a href='https://metrics.chrisvogt.me' title='Operator console'>metrics.chrisvogt.me</a>)
+  Chronogrove
 </h1>
 
 <p align='center'>
@@ -16,7 +16,7 @@
 
 **Chronogrove** is the engine behind provider-backed widgets on [www.chrisvogt.me](https://www.chrisvogt.me): it syncs third-party accounts (Discogs, Steam, Instagram, Spotify, Goodreads, Flickr, and more), stores normalized widget documents, and serves them over a stable JSON API. Firebase is the reference runtime (**App Hosting** for the operator console and tenant-facing API domains, **Cloud Functions** for **`/api`**, and **Firestore**); the design stays portable enough to consider other hosts later.
 
-**Production hostnames (target):** **`console.chronogrove.com`** is the main operator UI (sign-in, schema, sync, settings). **`api.chronogrove.com`** is the shared public API surface: **`/u/{username}`** (status), **`/widgets/:provider`**, and **`GET /api/widgets/:provider`** with optional **`?username=`** / **`?uid=`** where the host does not map a single tenant. **`chronogrove.com`** will eventually be a marketing site (separate from the console). Today you may still use **`metrics.chrisvogt.me`** and per-user domains such as **`api.chrisvogt.me`** while custom domains are wired in Firebase; see [docs/APP_HOSTING.md](docs/APP_HOSTING.md).
+**Production hostnames (target):** **`console.chronogrove.com`** is the main operator UI (sign-in, schema, sync, settings). **`api.chronogrove.com`** is the shared public API surface: **`/u/{username}`** (status), **`/widgets/:provider`**, and **`GET /api/widgets/:provider`** with optional **`?username=`** / **`?uid=`** where the host does not map a single tenant. **`chronogrove.com`** will eventually be a marketing site (separate from the console). Additional operator and tenant API hostnames are whatever you attach in Firebase (App Hosting custom domains, authorized Auth domains, and hostname maps); see [docs/APP_HOSTING.md](docs/APP_HOSTING.md).
 
 Consumer experiences today include the open-source [**Gatsby theme Chronogrove**](https://github.com/chrisvogt/gatsby-theme-chronogrove). The goal is for the same API to power other site integrations (WordPress and similar) and, over time, shareable **Web Components** (and other HTML-native building blocks) that call the public routes directly.
 
@@ -59,7 +59,7 @@ If `/api` calls fail in local dev, the Functions emulator is usually not reachab
 - Supports scheduled sync jobs plus manual admin-triggered sync.
 - Uses Firebase Auth (Google, email/password, phone) with HTTP-only session cookies and JWT fallback.
 - Runs locally with Firebase emulators.
-- Serves the Next.js operator console on Firebase App Hosting ([metrics.chrisvogt.me](https://metrics.chrisvogt.me) today; **`console.chronogrove.com`** as the primary Chronogrove UI).
+- Serves the Next.js operator console on Firebase App Hosting (**`console.chronogrove.com`** as the primary Chronogrove UI).
 
 > Note: `github` is a readable widget provider, but **not** part of the scheduled/manual sync queue.
 
@@ -90,7 +90,7 @@ flowchart TB
 
 ### 0) Production edge (App Hosting + Cloud Functions)
 
-The app is **SSR on Firebase App Hosting**. On whatever host the user opens (**`console.*`**, **`metrics.chrisvogt.me`**, **`api.chronogrove.com`**, **`api.tenant.example`**, …), the browser calls **`/api/*` and `/widgets/*` on that same origin**; Next.js **rewrites** both to the **`app`** Cloud Function (`/api/...` and `/api/widgets/...` respectively; see `apps/console/next.config.mjs`). That gives short widget URLs on tenant API domains without a second hostname. Third-party sites can still call the **Functions** URL or your **api.*** host from their own pages (diagram 1). **CORS** for credentialed cross-origin **`/api`** traffic uses a **fixed regex allowlist** in `functions/app/create-express-app.ts`, not tenant hostname settings—see [GitHub #289](https://github.com/chrisvogt/chronogrove/issues/289) (under epic [#252](https://github.com/chrisvogt/chronogrove/issues/252)). Optional **public status** lives at **`/u/{username}`**; hosts in **`NEXT_PUBLIC_TENANT_API_ROOT_TO_USERNAME`** can serve it at **`/`** (internal rewrite in `src/proxy.ts`). Details: [docs/APP_HOSTING.md](docs/APP_HOSTING.md).
+The app is **SSR on Firebase App Hosting**. On whatever host the user opens (**`console.*`**, **`api.chronogrove.com`**, **`api.tenant.example`**, or any other hostname mapped to the same backend, …), the browser calls **`/api/*` and `/widgets/*` on that same origin**; Next.js **rewrites** both to the **`app`** Cloud Function (`/api/...` and `/api/widgets/...` respectively; see `apps/console/next.config.mjs`). That gives short widget URLs on tenant API domains without a second hostname. Third-party sites can still call the **Functions** URL or your **api.*** host from their own pages (diagram 1). **CORS** for credentialed cross-origin **`/api`** traffic uses a **fixed regex allowlist** in `functions/app/api-cors-allowlist.ts` (wired from `create-express-app.ts`), not tenant hostname settings—see [GitHub #289](https://github.com/chrisvogt/chronogrove/issues/289) (under epic [#252](https://github.com/chrisvogt/chronogrove/issues/252)). The `chrisvogt.me` pattern intentionally omits the legacy **`metrics`** operator label on that zone. Optional **public status** lives at **`/u/{username}`**; hosts in **`NEXT_PUBLIC_TENANT_API_ROOT_TO_USERNAME`** can serve it at **`/`** (internal rewrite in `src/proxy.ts`). Details: [docs/APP_HOSTING.md](docs/APP_HOSTING.md).
 
 ```mermaid
 flowchart TB
@@ -138,11 +138,11 @@ flowchart TB
 
 ### 3) Operator console manual sync
 
-The signed-in operator UI (**`console.chronogrove.com`** target, [metrics.chrisvogt.me](https://metrics.chrisvogt.me) today) uses Firebase Auth + session cookie. **`/api/*`** reaches Functions via the rewrite in diagram 0. Manual sync runs inline (enqueue → claim → process) instead of waiting for worker cadence.
+The signed-in operator UI (**`console.chronogrove.com`** target) uses Firebase Auth + session cookie. **`/api/*`** reaches Functions via the rewrite in diagram 0. Manual sync runs inline (enqueue → claim → process) instead of waiting for worker cadence.
 
 ```mermaid
 flowchart TB
-  admin[Operator console<br/>App Hosting · console.* / metrics.*] --> auth[Firebase Auth]
+  admin[Operator console<br/>App Hosting · console.* / custom domains] --> auth[Firebase Auth]
   admin --> sess[POST /api/auth/session]
   admin --> sync[GET /api/widgets/sync/:provider]
   admin --> stream[GET .../sync/:provider/stream SSE]

--- a/apps/console/CHANGELOG.md
+++ b/apps/console/CHANGELOG.md
@@ -7,6 +7,10 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Tests
+
+- **`baseUrl`** / **`tenant-api-root-map`** — Production-like hostname stubs use **`console.chronogrove.com`** and **`operator.unmapped.example`** instead of a private deploy host.
+
 ## [0.6.25] - 2026-05-04
 
 ### Fixed
@@ -155,7 +159,7 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Try API → Get widget data** — Each test now loads a **fresh Firebase ID token** via **`buildWidgetFetchHeaders`** instead of reusing async `idToken` state (which could still be empty on first click). Fixes production **cross-origin** console → **`metrics.chrisvogt.me`** requests that do not carry session cookies, so **GitHub** correctly reflects **OAuth** when linked instead of falling back to PAT and **`githubAuthMode: env`**.
+- **Try API → Get widget data** — Each test now loads a **fresh Firebase ID token** via **`buildWidgetFetchHeaders`** instead of reusing async `idToken` state (which could still be empty on first click). Fixes production **cross-origin** console → operator-host requests that do not carry session cookies, so **GitHub** correctly reflects **OAuth** when linked instead of falling back to PAT and **`githubAuthMode: env`**.
 
 ## [0.6.13] - 2026-04-03
 

--- a/apps/console/public/humans.txt
+++ b/apps/console/public/humans.txt
@@ -2,7 +2,7 @@
 Chris Vogt: https://www.chrisvogt.me
 
 /* SITE */
-Chronogrove operator console (metrics.chrisvogt.me)
+Chronogrove operator console
 Last update: 2026
 Language: English
 Do not index: yes (admin/dashboard)

--- a/apps/console/src/lib/baseUrl.test.ts
+++ b/apps/console/src/lib/baseUrl.test.ts
@@ -2,6 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { isDevApiHost } from './baseUrl.js'
 
+/** Stand-in for a deployed operator hostname (not localhost / App Hosting emulator). */
+const TEST_PRODUCTION_LIKE_APP_HOSTNAME = 'console.chronogrove.com' as const
+
 describe('isDevApiHost', () => {
   it('returns true for local and dev hostnames', () => {
     expect(isDevApiHost('localhost')).toBe(true)
@@ -10,7 +13,7 @@ describe('isDevApiHost', () => {
   })
 
   it('returns false for production-like hostnames', () => {
-    expect(isDevApiHost('metrics.chrisvogt.me')).toBe(false)
+    expect(isDevApiHost(TEST_PRODUCTION_LIKE_APP_HOSTNAME)).toBe(false)
     expect(isDevApiHost('example.com')).toBe(false)
   })
 })
@@ -38,7 +41,7 @@ describe('getAppBaseUrl', () => {
   })
 
   it('returns empty string for production hostnames (same-origin /api)', async () => {
-    vi.stubGlobal('window', { location: { hostname: 'metrics.chrisvogt.me' } })
+    vi.stubGlobal('window', { location: { hostname: TEST_PRODUCTION_LIKE_APP_HOSTNAME } })
     const { getAppBaseUrl } = await import('./baseUrl.js')
     expect(getAppBaseUrl()).toBe('')
   })
@@ -68,14 +71,14 @@ describe('getSyncStreamBaseUrl', () => {
 
   it('returns Cloud Functions origin in production when env is set', async () => {
     vi.stubEnv('NEXT_PUBLIC_CLOUD_FUNCTIONS_APP_ORIGIN', 'https://us-central1-x.cloudfunctions.net/app')
-    vi.stubGlobal('window', { location: { hostname: 'metrics.chrisvogt.me' } })
+    vi.stubGlobal('window', { location: { hostname: TEST_PRODUCTION_LIKE_APP_HOSTNAME } })
     const { getSyncStreamBaseUrl } = await import('./baseUrl.js')
     expect(getSyncStreamBaseUrl()).toBe('https://us-central1-x.cloudfunctions.net/app')
   })
 
   it('returns empty string when env is unset in production (nullish coalescing)', async () => {
     vi.stubEnv('NEXT_PUBLIC_CLOUD_FUNCTIONS_APP_ORIGIN', undefined as unknown as string)
-    vi.stubGlobal('window', { location: { hostname: 'metrics.chrisvogt.me' } })
+    vi.stubGlobal('window', { location: { hostname: TEST_PRODUCTION_LIKE_APP_HOSTNAME } })
     const { getSyncStreamBaseUrl } = await import('./baseUrl.js')
     expect(getSyncStreamBaseUrl()).toBe('')
   })
@@ -102,7 +105,7 @@ describe('getManualSyncStreamUrl', () => {
       'NEXT_PUBLIC_CLOUD_FUNCTIONS_APP_ORIGIN',
       'https://us-central1-personal-stats-chrisvogt.cloudfunctions.net/app',
     )
-    vi.stubGlobal('window', { location: { hostname: 'metrics.chrisvogt.me' } })
+    vi.stubGlobal('window', { location: { hostname: TEST_PRODUCTION_LIKE_APP_HOSTNAME } })
     const { getManualSyncStreamUrl } = await import('./baseUrl.js')
     expect(getManualSyncStreamUrl('discogs')).toBe(
       'https://us-central1-personal-stats-chrisvogt.cloudfunctions.net/app/api/widgets/sync/discogs/stream',

--- a/apps/console/src/lib/tenant-api-root-map.test.ts
+++ b/apps/console/src/lib/tenant-api-root-map.test.ts
@@ -47,7 +47,7 @@ describe('tenantStatusSlugForHost', () => {
   it('returns undefined when host not mapped', () => {
     delete process.env.TENANT_API_ROOT_TO_USERNAME
     delete process.env.NEXT_PUBLIC_TENANT_API_ROOT_TO_USERNAME
-    expect(tenantStatusSlugForHost('metrics.chrisvogt.me')).toBeUndefined()
+    expect(tenantStatusSlugForHost('operator.unmapped.example')).toBeUndefined()
   })
 
   it('returns undefined for empty hostname', () => {

--- a/docs/APP_HOSTING.md
+++ b/docs/APP_HOSTING.md
@@ -14,7 +14,7 @@ For product behavior and UI changes, see [apps/console/CHANGELOG.md](../apps/con
 
 ### Email verification action URL
 
-In **Firebase Console → Authentication → Templates → Email address verification**, set the **custom action URL** to the console’s verify route (Firebase appends `mode` and `oobCode`). **Current production:** `https://metrics.chrisvogt.me/verify-email`. Ensure **metrics.chrisvogt.me** appears under **Authentication → Settings → Authorized domains**. When the operator console’s primary host is **`console.chronogrove.com`**, update this URL and authorized domains to match (keep **`api.chronogrove.com`** and any tenant **`api.*`** domains in the list if those surfaces use Auth flows).
+In **Firebase Console → Authentication → Templates → Email address verification**, set the **custom action URL** to the console’s verify route on **your** App Hosting operator hostname (Firebase appends `mode` and `oobCode`), for example `https://<your-operator-host>/verify-email`. Add that hostname under **Authentication → Settings → Authorized domains**. When the operator console’s primary host is **`console.chronogrove.com`**, point the template and authorized domains at that origin (keep **`api.chronogrove.com`** and any tenant **`api.*`** domains in the list if those surfaces use Auth flows).
 
 ### Tenant API host: `/widgets` and `/` status rewrite
 
@@ -30,7 +30,7 @@ Two **App Hosting backends** share **`rootDir`: `./apps/console`** (see [`fireba
 
 | Backend ID | Purpose |
 |------------|---------|
-| **`chronogrove-console`** | **Production** App Hosting backend for the Next app ([metrics.chrisvogt.me](https://metrics.chrisvogt.me) today; target operator host **`console.chronogrove.com`**, plus **`api.chronogrove.com`** and other custom domains on the same backend). Has **`alwaysDeployFromSource`: true** so deploys always build from the checked-out tree. |
+| **`chronogrove-console`** | **Production** App Hosting backend for the Next app (target operator host **`console.chronogrove.com`**, plus **`api.chronogrove.com`** and other custom domains on the same backend). Has **`alwaysDeployFromSource`: true** so deploys always build from the checked-out tree. |
 | **`chronogrove-console-pr`** | **Secondary** backend for **preview or staging**-style deploys (same codebase and `apphosting.yaml`; no `alwaysDeployFromSource` in repo config). Create and use this backend when you want a separate URL or lifecycle from production. Deploy with `firebase deploy --only apphosting:chronogrove-console-pr` when that backend is wired in your Firebase project. |
 
 Backend IDs must exist in the Firebase project (Console or CLI, e.g. `firebase apphosting:backends:create`).

--- a/functions/CHANGELOG.md
+++ b/functions/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **CORS (`/api`)** — **`*.chrisvogt.me`** origins are still allowed for personal-site and tenant API hosts, but the **`metrics`** label on **`chrisvogt.me`** is excluded (sunset operator hostname). Allowlist logic lives in **`app/api-cors-allowlist.ts`** with unit tests; integration tests use **`https://console.chronogrove.com`** as a sample allowed Origin.
+
 ## [0.30.4] - 2026-05-03
 
 ### Security
@@ -511,7 +515,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Hosting (sign-in page)** – Clarified that the app is a personal admin, not a general login service:
-  - Added line under “Sign in”: “Personal admin for metrics.chrisvogt.me / chrisvogt.me only.”
+  - Added line under “Sign in”: “Personal admin for the operator console / chrisvogt.me only.”
   - Added “← Part of chrisvogt.me” link to chrisvogt.me above the sign-in card.
   - Added meta description and Open Graph tags in `index.html`: “Personal Metrics API admin for chrisvogt.me. Not a general login service.”
 

--- a/functions/app/api-cors-allowlist.test.ts
+++ b/functions/app/api-cors-allowlist.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { getApiCorsOriginRegexList } from './api-cors-allowlist.js'
+
+function originAllowed(origin: string, isProduction: boolean): boolean {
+  return getApiCorsOriginRegexList(isProduction).some((r) => r.test(origin))
+}
+
+describe('getApiCorsOriginRegexList', () => {
+  it('allows chronogrove operator and public API hosts', () => {
+    expect(originAllowed('https://console.chronogrove.com', true)).toBe(true)
+    expect(originAllowed('https://api.chronogrove.com', true)).toBe(true)
+  })
+
+  it('allows non-metrics chrisvogt.me hosts', () => {
+    expect(originAllowed('https://chrisvogt.me', true)).toBe(true)
+    expect(originAllowed('https://www.chrisvogt.me', true)).toBe(true)
+    expect(originAllowed('https://api.chrisvogt.me', true)).toBe(true)
+  })
+
+  it('denies sunset metrics operator host on chrisvogt.me', () => {
+    const legacyOperator = `https://${['metrics', 'chrisvogt', 'me'].join('.')}`
+    expect(originAllowed(legacyOperator, true)).toBe(false)
+    expect(originAllowed(legacyOperator.replace(/^https/, 'http'), true)).toBe(false)
+  })
+
+  it('allows dev-chrisvogt hosts (emulator / staging)', () => {
+    expect(originAllowed('https://metrics.dev-chrisvogt.me:8084', true)).toBe(true)
+  })
+
+  it('allows localhost when not production', () => {
+    expect(originAllowed('http://localhost:3000', false)).toBe(true)
+    expect(originAllowed('http://localhost:3000', true)).toBe(false)
+  })
+
+  it('rejects unrelated origins', () => {
+    expect(originAllowed('https://evil.example.com', true)).toBe(false)
+  })
+})

--- a/functions/app/api-cors-allowlist.ts
+++ b/functions/app/api-cors-allowlist.ts
@@ -1,0 +1,21 @@
+/**
+ * Regex list for `cors({ origin })` on `/api` (credentialed fetches, sync SSE, etc.).
+ *
+ * The first pattern allows `*.chrisvogt.me` except the legacy **`metrics`** label on that
+ * zone (sunset operator host). Keep that host denied even if DNS were pointed back.
+ */
+export function getApiCorsOriginRegexList(isProduction: boolean): RegExp[] {
+  const corsAllowList: RegExp[] = [
+    /^https?:\/\/(?!metrics\.)([a-z0-9-]+\.)*chrisvogt\.me$/,
+    /https?:\/\/([a-z0-9]+[.])*dev-chrisvogt[.]me:?(.*)$/,
+    /^https?:\/\/([a-z0-9-]+--)?chrisvogt\.netlify\.app$/,
+    /https?:\/\/([a-z0-9]+[.])*chronogrove[.]com$/,
+    /https?:\/\/([a-z0-9]+[.])*dev-chronogrove[.]com$/,
+  ]
+
+  if (!isProduction) {
+    corsAllowList.push(/localhost:?(\d+)?$/)
+  }
+
+  return corsAllowList
+}

--- a/functions/app/create-express-app.test.ts
+++ b/functions/app/create-express-app.test.ts
@@ -38,6 +38,9 @@ vi.mock('../services/sync-manual.js', () => ({
   })),
 }))
 
+/** Example Origin that matches `/api` CORS allowlist (`api-cors-allowlist.ts`). */
+const TEST_CORS_ALLOWED_ORIGIN = 'https://console.chronogrove.com' as const
+
 describe('createExpressApp media route', () => {
   const logger = {
     error: vi.fn(),
@@ -580,12 +583,12 @@ describe('createExpressApp auth and session branches', () => {
 
     const response = await request(app)
       .options('/api/widgets/sync/spotify/stream')
-      .set('Origin', 'https://metrics.chrisvogt.me')
+      .set('Origin', TEST_CORS_ALLOWED_ORIGIN)
       .set('Access-Control-Request-Method', 'GET')
       .set('Access-Control-Request-Headers', 'authorization')
 
     expect(response.status).toBe(204)
-    expect(response.headers['access-control-allow-origin']).toBe('https://metrics.chrisvogt.me')
+    expect(response.headers['access-control-allow-origin']).toBe(TEST_CORS_ALLOWED_ORIGIN)
     expect(response.headers['access-control-allow-credentials']).toBe('true')
   })
 

--- a/functions/app/create-express-app.ts
+++ b/functions/app/create-express-app.ts
@@ -19,6 +19,7 @@ import deleteUserJob from '../jobs/delete-user.js'
 import { runSyncForProvider } from '../services/sync-manual.js'
 import type { ManualSyncResult } from '../services/sync-manual.js'
 import { getWidgetContent } from '../widgets/get-widget-content.js'
+import { getApiCorsOriginRegexList } from './api-cors-allowlist.js'
 import { createCookieBackedCsrfImpl } from './cookie-backed-csrf.js'
 import { TENANT_USERNAMES_COLLECTION } from '../config/future-tenant-collections.js'
 import {
@@ -453,17 +454,7 @@ export function createExpressApp({
   )
   expressApp.use(cookieParser())
 
-  const corsAllowList: RegExp[] = [
-    /https?:\/\/([a-z0-9]+[.])*chrisvogt[.]me$/,
-    /https?:\/\/([a-z0-9]+[.])*dev-chrisvogt[.]me:?(.*)$/,
-    /^https?:\/\/([a-z0-9-]+--)?chrisvogt\.netlify\.app$/,
-    /https?:\/\/([a-z0-9]+[.])*chronogrove[.]com$/,
-    /https?:\/\/([a-z0-9]+[.])*dev-chronogrove[.]com$/,
-  ]
-
-  if (!isProductionEnvironment()) {
-    corsAllowList.push(/localhost:?(\d+)?$/)
-  }
+  const corsAllowList = getApiCorsOriginRegexList(isProductionEnvironment())
 
   const corsOptions = {
     origin: corsAllowList,


### PR DESCRIPTION
## Summary
- **`/api` CORS** — Origin allowlist moved to `functions/app/api-cors-allowlist.ts`. The `*.chrisvogt.me` pattern now excludes the legacy **`metrics`** label (sunset operator hostname).
- **Tests** — Preflight test uses `https://console.chronogrove.com`; console `baseUrl` / tenant-map tests use stand-in hostnames instead of a private deploy URL; allowlist covered by `api-cors-allowlist.test.ts`.
- **Docs** — README points at the new module and notes the `metrics` exclusion; `[Unreleased]` entries in `functions/CHANGELOG.md` and `apps/console/CHANGELOG.md`; aligns with earlier doc hygiene (`docs/APP_HOSTING.md`, `humans.txt`).

## Testing
`pnpm exec turbo run test --filter=chronogrove-functions --filter=chronogrove-console`

Made with [Cursor](https://cursor.com)