### PR TITLE
fix(console): identity settings load + test hardening

### DIFF
--- a/apps/console/CHANGELOG.md
+++ b/apps/console/CHANGELOG.md
@@ -7,9 +7,14 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`SettingsProfileIdentity`** — Onboarding **`load()`** no longer forces the full-page loading state when **`progressRef`** already holds a payload, so overlapping or Strict Mode effect runs do not unmount the username block and wipe in-flight edits (flaky **`/is available`** assertions under **`test:coverage`**).
+
 ### Tests
 
 - **`baseUrl`** / **`tenant-api-root-map`** — Production-like hostname stubs use **`console.chronogrove.com`** and **`operator.unmapped.example`** instead of a private deploy host.
+- **`SettingsProfileIdentity`** — **`mockUser()`** includes a stable **`uid`**; username-save flows wait for **`Save username`** to become enabled instead of matching availability hint text.
 
 ## [0.6.25] - 2026-05-04
 

--- a/apps/console/src/components/user-settings/SettingsProfileIdentity.test.tsx
+++ b/apps/console/src/components/user-settings/SettingsProfileIdentity.test.tsx
@@ -65,6 +65,7 @@ function jsonResponse(data: unknown, ok = true, status = ok ? 200 : 400): Respon
 
 function mockUser(): User {
   return {
+    uid: 'test-settings-profile-uid',
     getIdToken: vi.fn().mockResolvedValue('mock-id-token'),
   } as unknown as User
 }
@@ -88,6 +89,13 @@ function setupLoad(progress: OnboardingProgressPayload) {
 async function afterUsernameDebounce() {
   await new Promise<void>((resolve) => {
     setTimeout(resolve, 800)
+  })
+}
+
+/** Waits until username check succeeded (`canSaveUsername`); avoids brittle copy matchers. */
+async function waitUntilSaveUsernameEnabled() {
+  await waitFor(() => {
+    expect(screen.getByRole('button', { name: /save username/i })).toBeEnabled()
   })
 }
 
@@ -189,9 +197,7 @@ describe('SettingsProfileIdentity', () => {
     await waitFor(() => {
       expect(globalThis.fetch).toHaveBeenCalled()
     })
-    await waitFor(() => {
-      expect(screen.getByText(/is available/i)).toBeInTheDocument()
-    })
+    await waitUntilSaveUsernameEnabled()
 
     await user.click(screen.getByRole('button', { name: /save username/i }))
 
@@ -228,7 +234,7 @@ describe('SettingsProfileIdentity', () => {
     })
     await afterUsernameDebounce()
     await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled())
-    await waitFor(() => expect(screen.getByText(/is available/i)).toBeInTheDocument())
+    await waitUntilSaveUsernameEnabled()
 
     fireEvent.click(screen.getByRole('button', { name: /save username/i }))
 
@@ -285,7 +291,7 @@ describe('SettingsProfileIdentity', () => {
     })
     await afterUsernameDebounce()
     await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled())
-    await waitFor(() => expect(screen.getByText(/is available/i)).toBeInTheDocument())
+    await waitUntilSaveUsernameEnabled()
 
     await user.click(screen.getByRole('button', { name: /save username/i }))
 
@@ -546,7 +552,7 @@ describe('SettingsUsernameBlock (progressRef guard)', () => {
     })
     await afterUsernameDebounce()
     await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled())
-    await waitFor(() => expect(screen.getByText(/is available/i)).toBeInTheDocument())
+    await waitUntilSaveUsernameEnabled()
 
     await userEvent.click(screen.getByRole('button', { name: /save username/i }))
 

--- a/apps/console/src/components/user-settings/SettingsProfileIdentity.tsx
+++ b/apps/console/src/components/user-settings/SettingsProfileIdentity.tsx
@@ -491,7 +491,13 @@ export function SettingsProfileIdentity({
     if (!apiSessionReady) return
     const currentUser = userRef.current
     if (!currentUser) return
-    setLoading(true)
+    // Only swap to the full-page spinner when we have nothing to show yet. A second
+    // `load()` (e.g. React Strict Mode re-invoke or overlapping effects) would otherwise
+    // set `loading` true again, unmount the identity form, and clear in-flight username edits.
+    const showFullPageLoader = progressRef.current === null
+    if (showFullPageLoader) {
+      setLoading(true)
+    }
     setLoadError(null)
     try {
       const idToken = await currentUser.getIdToken()


### PR DESCRIPTION
## Summary
- **`SettingsProfileIdentity`** — Skip the full-page loading state on `load()` when `progressRef` already has payload, so a second load (e.g. Strict Mode / coverage) does not unmount the form and clear the username draft (fixes flaky **`/is available`** under **`test:coverage`**).
- **Tests** — Stable **`uid`** on `mockUser()`; wait for **Save username** to enable instead of matching availability hint text.

## Testing
`pnpm run test:coverage` in `apps/console` (183 tests).

Made with [Cursor](https://cursor.com)