### PR TITLE
test: harden extract-json and Steam summary tests for jsonrepair

### DIFF
--- a/functions/api/ai-summary/generate-steam-summary.test.ts
+++ b/functions/api/ai-summary/generate-steam-summary.test.ts
@@ -145,17 +145,37 @@ describe('generateSteamSummary', () => {
       text: async () => assistantJson('not valid json at all'),
     })
 
-    try {
-      await generateSteamSummary(mockSteamData)
-      throw new Error('Expected rejection')
-    } catch (err) {
-      expect(err.message).toContain('Failed to generate AI summary')
-      expect(err.cause).toBeDefined()
-      expect((err as Error & { cause: Error }).cause.message).toBe(
-        'Model response was not valid JSON (no markdown block or raw JSON)',
-      )
-    }
-    expect(logger.error).toHaveBeenCalled()
+    await expect(generateSteamSummary(mockSteamData)).rejects.toMatchObject({
+      message: expect.stringContaining('Failed to generate AI summary'),
+      cause: {
+        message: 'Model response was not valid JSON (no markdown block or raw JSON)',
+      },
+    })
+    expect(logger.error).toHaveBeenCalledWith(
+      'Error generating Steam AI summary:',
+      expect.any(Error),
+    )
+  })
+
+  it('should rethrow when fenced JSON is empty (unparseable object)', async () => {
+    const { logger } = await import('firebase-functions')
+    // Empty fenced body: jsonrepair can salvage many broken `{...}` snippets; use this for deterministic null from extractJsonFromAiResponse.
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => assistantJson('```json\n\n```'),
+    })
+
+    await expect(generateSteamSummary(mockSteamData)).rejects.toMatchObject({
+      message: expect.stringContaining('Failed to generate AI summary'),
+      cause: {
+        message: 'Model response was not valid JSON (no markdown block or raw JSON)',
+      },
+    })
+    expect(logger.error).toHaveBeenCalledWith(
+      'Error generating Steam AI summary:',
+      expect.any(Error),
+    )
   })
 
   it('returns empty string when response JSON field is not a string', async () => {

--- a/functions/utils/extract-json-from-ai-response.test.ts
+++ b/functions/utils/extract-json-from-ai-response.test.ts
@@ -52,19 +52,14 @@ describe('extractJsonFromAiResponse', () => {
     expect(result).toEqual({ b: 'hello' })
   })
 
-  it('returns null for invalid markdown JSON', () => {
-    const str = '```json\n{ broken }\n```'
-    const result = extractJsonFromAiResponse(str)
-    expect(result).toBeNull()
+  it('returns null for empty or unparsable json markdown fence body', () => {
+    // Empty fenced body: jsonrepair can turn many broken `{...}` snippets into objects, so do not use those to assert null.
+    expect(extractJsonFromAiResponse('```json\n\n```')).toBeNull()
   })
 
   it('returns null for primitives and non-objects', () => {
     expect(extractJsonFromAiResponse('123')).toBeNull()
     expect(extractJsonFromAiResponse('Just plain text')).toBeNull()
-  })
-
-  it('returns null for an empty json markdown fence body', () => {
-    expect(extractJsonFromAiResponse('```json\n\n```')).toBeNull()
   })
 
   it('returns null for empty or whitespace', () => {


### PR DESCRIPTION
Use an empty json code fence to assert null from extractJsonFromAiResponse (jsonrepair can salvage many broken object snippets). Merge the duplicate empty-fence test.

Add a Steam summary test for empty fenced JSON parity with Goodreads, and use rejects.toMatchObject plus an explicit logger.error call for invalid model JSON.

Co-authored-by: Cursor <cursoragent@cursor.com>
