### PR TITLE
fix(steam-ai): avoid Anthropic JSON truncation in production

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Package-specific changes:
 
 ### Changed
 
+- **Workspace** — **Functions 0.30.7** and **Console 0.6.27**: Steam AI summary prompt slimmed so default Anthropic **`max_tokens`** no longer truncates JSON in production; console **`SettingsProfileIdentity`** clear-username test hardened for CI; functions release also includes CORS allowlist tweak for **`chrisvogt.me`**, emulator **`prestart` → `build`**, and AI summary **`jsonrepair`** / logging adjustments documented in **[functions/CHANGELOG.md](functions/CHANGELOG.md)**. See [functions/CHANGELOG.md](functions/CHANGELOG.md) and [apps/console/CHANGELOG.md](apps/console/CHANGELOG.md).
+
 - **Workspace** — **Console 0.6.25**: **Next.js** pinned to exact **`16.2.4`** so Firebase App Hosting’s **`@apphosting/adapter-nextjs`** CVE version check receives a valid semver (ranges like **`^16.2.4`** were mis-rejected and blocked deploy). Documented in **[docs/APP_HOSTING.md](docs/APP_HOSTING.md)** and **[apps/console/README.md](apps/console/README.md)**. See [apps/console/CHANGELOG.md](apps/console/CHANGELOG.md).
 
 - **Workspace** — **Functions 0.30.5**: AI summary provider swapped from Gemini to **Anthropic** (`claude-sonnet-4-6`); `@google/generative-ai` removed; `GEMINI_API_KEY` / `gemini.api_key` renamed to `ANTHROPIC_API_KEY` / `anthropic.api_key`; new `utils/ai-summary-messages.ts` direct HTTP client with `resolveMaxTokens` and 23 new unit tests. See [functions/CHANGELOG.md](functions/CHANGELOG.md).

--- a/apps/console/CHANGELOG.md
+++ b/apps/console/CHANGELOG.md
@@ -7,6 +7,8 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.27] - 2026-05-10
+
 ### Fixed
 
 - **`SettingsProfileIdentity`** — Onboarding **`load()`** no longer forces the full-page loading state when **`progressRef`** already holds a payload, so overlapping or Strict Mode effect runs do not unmount the username block and wipe in-flight edits (flaky **`/is available`** assertions under **`test:coverage`**).
@@ -14,7 +16,7 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Tests
 
 - **`baseUrl`** / **`tenant-api-root-map`** — Production-like hostname stubs use **`console.chronogrove.com`** and **`operator.unmapped.example`** instead of a private deploy host.
-- **`SettingsProfileIdentity`** — **`mockUser()`** includes a stable **`uid`**; username-save flows wait for **`Save username`** to become enabled instead of matching availability hint text.
+- **`SettingsProfileIdentity`** — **`mockUser()`** includes a stable **`uid`**; username-save flows wait for **`Save username`** to become enabled instead of matching availability hint text. Clearing the username (advanced) uses **`userEvent.clear`**, **`waitFor`** an empty input, and **`waitUntilSaveUsernameEnabled`** before **`Save username`** so **`fireEvent.change` + `user.click`** cannot race on slow CI.
 
 ## [0.6.26] - 2026-05-09
 

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "license": "Apache-2.0",
   "description": "Chronogrove operator console: Next.js admin UI (SSR on Firebase App Hosting) for schema, status, sync, and onboarding.",
-  "version": "0.6.26",
+  "version": "0.6.27",
   "engines": {
     "node": ">=24"
   },

--- a/apps/console/src/components/user-settings/SettingsProfileIdentity.test.tsx
+++ b/apps/console/src/components/user-settings/SettingsProfileIdentity.test.tsx
@@ -491,7 +491,13 @@ describe('SettingsProfileIdentity', () => {
     render(<SettingsProfileIdentity user={mockUser()} apiSessionReady />)
     await waitFor(() => screen.getByPlaceholderText('your-username'))
 
-    fireEvent.change(screen.getByPlaceholderText('your-username'), { target: { value: '' } })
+    const nameInput = screen.getByPlaceholderText('your-username')
+    // Use userEvent + explicit waits: fireEvent.change + user.click can race on slow CI
+    // (click runs before React commits '', Save stays disabled, putJson never fires).
+    await user.clear(nameInput)
+    await waitFor(() => expect(nameInput).toHaveValue(''))
+    await waitUntilSaveUsernameEnabled()
+
     await user.click(screen.getByRole('button', { name: /save username/i }))
 
     await waitFor(() => {

--- a/functions/.env.template
+++ b/functions/.env.template
@@ -63,7 +63,7 @@ STEAM_USER_ID=your_steam_user_id_here
 
 # Anthropic API (Goodreads + Steam AI summaries on Firebase Functions)
 ANTHROPIC_API_KEY=your_anthropic_api_key_here
-# Optional overrides (defaults: claude-sonnet-4-6, 4096 max output tokens)
+# Optional overrides (defaults: claude-sonnet-4-6, 1024 max output tokens in code)
 # ANTHROPIC_MODEL=claude-sonnet-4-6
 # ANTHROPIC_MAX_OUTPUT_TOKENS=4096
 

--- a/functions/CHANGELOG.md
+++ b/functions/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.7] - 2026-05-10
+
+### Fixed
+
+- **Steam AI summary** — **`generate-steam-summary`** prompt requests only **`{ "response" }`** (no **`debug`** echo of game lists) so Anthropic completions fit the default **`max_tokens` (1024)** in production and no longer truncate to invalid JSON. **`functions/.env.template`** documents the real default for **`ANTHROPIC_MAX_OUTPUT_TOKENS`** (1024 unless overridden).
+- **AI summaries** — **`extract-json-from-ai-response`** uses a greedy **` ```json `** fence capture (avoids truncating when the model echoes fence-like characters) and **`jsonrepair`** after strict **`JSON.parse`** so common LLM JSON defects in **`response`** HTML (unescaped quotes, raw newlines in strings) still parse. Steam and Goodreads prompts add explicit JSON string-safety rules.
+
 ### Security
 
 - **CORS (`/api`)** — **`*.chrisvogt.me`** origins are still allowed for personal-site and tenant API hosts, but the **`metrics`** label on **`chrisvogt.me`** is excluded (sunset operator hostname). Allowlist logic lives in **`app/api-cors-allowlist.ts`** with unit tests; integration tests use **`https://console.chronogrove.com`** as a sample allowed Origin.
@@ -14,10 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Local emulators** — **`pnpm start`** in **`functions/`** runs **`prestart` → `build`** so **`lib/`** matches TypeScript before **`firebase emulators:start`**. Root **`pnpm run dev:full`** builds functions once before starting emulators. **`firebase emulators:start` alone** still does not compile; **`ENVIRONMENT_SETUP.md`** documents the stale-**`lib/`** pitfall.
-
-### Fixed
-
-- **AI summaries** — **`extract-json-from-ai-response`** uses a greedy **` ```json `** fence capture (avoids truncating when the model echoes fence-like characters) and **`jsonrepair`** after strict **`JSON.parse`** so common LLM JSON defects in **`response`** HTML (unescaped quotes, raw newlines in strings) still parse. Steam and Goodreads prompts add explicit JSON string-safety rules.
 
 ### Removed
 

--- a/functions/api/ai-summary/generate-steam-summary.ts
+++ b/functions/api/ai-summary/generate-steam-summary.ts
@@ -20,13 +20,9 @@ const generateSteamSummary = async (steamData: SteamSummaryInput): Promise<strin
   const prompt = `
 Hi — please analyze the following Steam gaming data and return a natural-sounding summary in **valid JSON**.
 
-Use this structure:
+Use exactly this structure (one key only — do not echo game lists back into the JSON; the page already shows them):
 {
-  "response": "<2-3 paragraphs in limited HTML with third-person summary of Chris Vogt's Steam activity. Mention recent games played, genre or playstyle trends, and any standout titles. Use natural and informative language.>",
-  "debug": {
-    "recentlyPlayedGames": [...], // title, playTime2Weeks, playTimeForever
-    "topPlayedGames": [...]       // title, playTimeForever
-  }
+  "response": "<2-3 paragraphs in limited HTML with third-person summary of Chris Vogt's Steam activity. Mention recent games played, genre or playstyle trends, and any standout titles. Use natural and informative language.>"
 }
 
 Instructions:

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chronogrove-functions",
-  "version": "0.30.6",
+  "version": "0.30.7",
   "license": "Apache-2.0",
   "description": "Chronogrove server: Firebase Cloud Functions for the public widget API, authenticated admin routes, and provider sync jobs.",
   "type": "module",


### PR DESCRIPTION
## Summary
Steam AI summaries failed in production with `Model response was not valid JSON` while Goodreads summaries and local runs worked.

## Root cause
The Steam prompt asked the model to return large `debug` arrays echoing the full recently played and top-owned game lists. With the default `max_tokens` of **1024**, completions often **truncated mid-JSON**, so parsing failed. Goodreads stays within the budget; local dev may also set a higher `ANTHROPIC_MAX_OUTPUT_TOKENS`.

## Changes
- **`generate-steam-summary.ts`**: Request JSON with only `{ "response": "..." }`; do not ask the model to echo game lists (the UI already shows them). The code only consumed `response` anyway.
- **`.env.template`**: Correct the comment so the documented default matches the code (**1024** output tokens unless overridden).

## Testing
- `vitest run api/ai-summary/generate-steam-summary.test.ts`

Made with [Cursor](https://cursor.com)