### PR TITLE
fix: console and Functions Sonar cleanups, a11y, and manual sync hardening

### DIFF
--- a/apps/console/next-env.d.ts
+++ b/apps/console/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/console/next-env.d.ts
+++ b/apps/console/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/console/src/app/(main)/layout.tsx
+++ b/apps/console/src/app/(main)/layout.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, type ReactNode } from 'react'
 import { usePathname, useRouter } from 'next/navigation'
 import { useAuth } from '@/auth/AuthContext'
 import { mustVerifyEmailBeforeConsole } from '@/lib/emailVerificationGate'
@@ -25,7 +25,7 @@ const sectionToPath: Record<SectionId, string> = {
   auth: '/auth/',
 }
 
-export default function MainLayout({ children }: { children: React.ReactNode }) {
+export default function MainLayout({ children }: Readonly<{ children: ReactNode }>) {
   const pathname = usePathname() ?? '/schema/'
   const router = useRouter()
   const { user, loading } = useAuth()

--- a/apps/console/src/app/layout.tsx
+++ b/apps/console/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import type { ReactNode } from 'react'
 import { DM_Sans, JetBrains_Mono } from 'next/font/google'
 import { Providers } from './providers'
 import './globals.css'
@@ -36,7 +37,7 @@ export const metadata: Metadata = {
   },
 }
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({ children }: Readonly<{ children: ReactNode }>) {
   return (
     <html lang="en" suppressHydrationWarning>
       <body className={`${sans.variable} ${mono.variable}`}>

--- a/apps/console/src/app/providers.tsx
+++ b/apps/console/src/app/providers.tsx
@@ -11,7 +11,7 @@ import {
   DEFAULT_THEME,
 } from '@/theme/chronogroveTheme'
 
-export function Providers({ children }: { children: ReactNode }) {
+export function Providers({ children }: Readonly<{ children: ReactNode }>) {
   return (
     <ThemeProvider
       attribute="data-theme"

--- a/apps/console/src/app/u/[username]/page.tsx
+++ b/apps/console/src/app/u/[username]/page.tsx
@@ -11,10 +11,10 @@ import {
 } from '@/lib/widget-status'
 import styles from './PublicTenantStatus.module.css'
 
-type PageProps = {
+type PageProps = Readonly<{
   params: Promise<{ username: string }>
   searchParams?: Promise<Record<string, string | string[] | undefined>>
-}
+}>
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { username } = await params

--- a/apps/console/src/auth/AuthContext.tsx
+++ b/apps/console/src/auth/AuthContext.tsx
@@ -41,9 +41,9 @@ export interface AuthContextValue {
 
 const AuthContext = createContext<AuthContextValue | null>(null)
 
-interface AuthProviderProps {
+type AuthProviderProps = Readonly<{
   children: ReactNode
-}
+}>
 
 export function AuthProvider({ children }: AuthProviderProps) {
   const pathname = usePathname()
@@ -165,14 +165,20 @@ export function AuthProvider({ children }: AuthProviderProps) {
       await establishApiSessionCoalesced(cred.user)
     } catch (e) {
       const err = e as { code?: string; message?: string }
-      const msg =
-        err.code === 'auth/email-already-in-use'
-          ? 'An account with this email already exists.'
-          : err.code === 'auth/weak-password'
-            ? 'Password should be at least 6 characters.'
-            : err.code === 'auth/invalid-email'
-              ? 'Invalid email address.'
-              : err.message ?? 'Sign-up failed'
+      let msg: string
+      switch (err.code) {
+        case 'auth/email-already-in-use':
+          msg = 'An account with this email already exists.'
+          break
+        case 'auth/weak-password':
+          msg = 'Password should be at least 6 characters.'
+          break
+        case 'auth/invalid-email':
+          msg = 'Invalid email address.'
+          break
+        default:
+          msg = err.message ?? 'Sign-up failed'
+      }
       setError(msg)
       throw e
     }
@@ -185,14 +191,20 @@ export function AuthProvider({ children }: AuthProviderProps) {
       await signInWithEmailAndPassword(auth, email, password)
     } catch (e) {
       const err = e as { code?: string; message?: string }
-      const msg =
-        err.code === 'auth/user-not-found'
-          ? 'No account with this email.'
-          : err.code === 'auth/wrong-password'
-            ? 'Incorrect password.'
-            : err.code === 'auth/invalid-email'
-              ? 'Invalid email address.'
-              : err.message ?? 'Sign-in failed'
+      let msg: string
+      switch (err.code) {
+        case 'auth/user-not-found':
+          msg = 'No account with this email.'
+          break
+        case 'auth/wrong-password':
+          msg = 'Incorrect password.'
+          break
+        case 'auth/invalid-email':
+          msg = 'Invalid email address.'
+          break
+        default:
+          msg = err.message ?? 'Sign-in failed'
+      }
       setError(msg)
       throw e
     }

--- a/apps/console/src/auth/apiClient.ts
+++ b/apps/console/src/auth/apiClient.ts
@@ -17,11 +17,7 @@ export class SessionCreateError extends Error {
 }
 
 export class ApiClient {
-  private baseUrl: string
-
-  constructor(baseUrl = '') {
-    this.baseUrl = baseUrl
-  }
+  constructor(private readonly baseUrl = '') {}
 
   getAuthToken(): string | null {
     const sessionCookie = this.getSessionCookie()

--- a/apps/console/src/components/AuthScenePageShell.tsx
+++ b/apps/console/src/components/AuthScenePageShell.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react'
 import { AuthScene } from '@/components/AuthScene'
 
 /** Full-bleed `AuthScene` with foreground content stacked at `z-index: 1` (onboarding, auth, settings). */
-export function AuthScenePageShell({ children }: { children: ReactNode }) {
+export function AuthScenePageShell({ children }: Readonly<{ children: ReactNode }>) {
   return (
     <>
       <AuthScene />

--- a/apps/console/src/components/ChronogroveThemeOptionList.module.css
+++ b/apps/console/src/components/ChronogroveThemeOptionList.module.css
@@ -4,6 +4,18 @@
   gap: 0.75rem;
 }
 
+.radioInput {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .option {
   display: grid;
   gap: 0.35rem;
@@ -18,17 +30,17 @@
     background var(--duration-fast) var(--ease-standard);
 }
 
-.option:hover:not(:disabled) {
+.option:hover:not(:has(input:disabled)) {
   border-color: var(--border-strong);
   background: var(--surface-soft);
 }
 
-.option:focus-visible {
+.option:focus-within {
   outline: 2px solid var(--accent-hover);
   outline-offset: 2px;
 }
 
-.option:disabled {
+.option:has(input:disabled) {
   opacity: 0.65;
   cursor: wait;
 }

--- a/apps/console/src/components/ChronogroveThemeOptionList.tsx
+++ b/apps/console/src/components/ChronogroveThemeOptionList.tsx
@@ -9,31 +9,35 @@ export function ChronogroveThemeOptionList({
   disabled,
   labelledBy,
   onSelect,
-}: {
+}: Readonly<{
   value: ChronogroveThemeId
   disabled?: boolean
   labelledBy: string
   onSelect: (id: ChronogroveThemeId) => void
-}) {
+}>) {
   return (
     <div className={styles.options} role="radiogroup" aria-labelledby={labelledBy}>
       {CHRONOGROVE_THEMES.map((id) => {
         const meta = CHRONOGROVE_THEME_INFO[id]
         const selected = value === id
         return (
-          <button
+          <label
             key={id}
-            type="button"
-            role="radio"
-            aria-checked={selected}
             className={`${styles.option} ${selected ? styles.optionSelected : ''}`}
-            onClick={() => onSelect(id)}
-            disabled={disabled}
           >
+            <input
+              type="radio"
+              name="chronogrove-theme-option"
+              value={id}
+              className={styles.radioInput}
+              checked={selected}
+              onChange={() => onSelect(id)}
+              disabled={disabled}
+            />
             <span className={styles.optionTitle}>{meta.label}</span>
             <span className={styles.optionBlurb}>{meta.blurb}</span>
             <span className={styles.swatchStrip} data-theme-preview={id} aria-hidden />
-          </button>
+          </label>
         )
       })}
     </div>

--- a/apps/console/src/components/FloatingLines.tsx
+++ b/apps/console/src/components/FloatingLines.tsx
@@ -239,7 +239,7 @@ export interface WavePosition {
   rotate?: number
 }
 
-export interface FloatingLinesProps {
+export type FloatingLinesProps = Readonly<{
   linesGradient?: string[]
   enabledWaves?: WaveType[]
   lineCount?: number | number[]
@@ -255,7 +255,7 @@ export interface FloatingLinesProps {
   parallax?: boolean
   parallaxStrength?: number
   mixBlendMode?: string
-}
+}>
 
 export default function FloatingLines({
   linesGradient,

--- a/apps/console/src/components/JsonCodeBlock.tsx
+++ b/apps/console/src/components/JsonCodeBlock.tsx
@@ -10,10 +10,10 @@ import styles from './JsonCodeBlock.module.css'
 
 const jsxRuntime = { Fragment, jsx, jsxs }
 
-export interface JsonCodeBlockProps {
+export type JsonCodeBlockProps = Readonly<{
   code: string
   className?: string
-}
+}>
 
 function formatJsonIfPossible(source: string): string {
   try {

--- a/apps/console/src/components/MarketingShell.tsx
+++ b/apps/console/src/components/MarketingShell.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import Link from 'next/link'
 
 import { CHRONOGROVE_GITHUB_REPO, CHRONOGROVE_LICENSE_URL } from '@/lib/chronogroveRepo'
@@ -21,11 +22,11 @@ const DEFAULT_FOOTER =
 export function MarketingShell({
   children,
   footerCopy = DEFAULT_FOOTER,
-}: {
-  children: React.ReactNode
+}: Readonly<{
+  children: ReactNode
   /** Full footer paragraph. Defaults to a short factual description. */
   footerCopy?: string
-}) {
+}>) {
   return (
     <div className={styles.shell}>
       <header className={styles.header}>

--- a/apps/console/src/components/SonoranDuskScene.tsx
+++ b/apps/console/src/components/SonoranDuskScene.tsx
@@ -20,6 +20,7 @@ import {
   CanvasTexture,
   DoubleSide,
 } from 'three'
+import type { Material } from 'three'
 import { EffectComposer } from 'three/examples/jsm/postprocessing/EffectComposer.js'
 import { RenderPass } from 'three/examples/jsm/postprocessing/RenderPass.js'
 import { UnrealBloomPass } from 'three/examples/jsm/postprocessing/UnrealBloomPass.js'
@@ -134,10 +135,18 @@ function drawSaguaro(
   ctx.arc(cx, baseY - h, tw, 0, Math.PI * 2)
   ctx.fill()
 
-  const armN = rng() > 0.25 ? (rng() > 0.55 ? 2 : 1) : 0
+  let armN = 0
+  if (rng() > 0.25) {
+    armN = rng() > 0.55 ? 2 : 1
+  }
   let prevSide = 0
   for (let a = 0; a < armN; a++) {
-    const side = a === 0 ? (rng() > 0.5 ? 1 : -1) : -prevSide
+    let side: number
+    if (a === 0) {
+      side = rng() > 0.5 ? 1 : -1
+    } else {
+      side = -prevSide
+    }
     prevSide = side
     const armY = baseY - h * (0.35 + rng() * 0.3)
     const reach = tw * 1.5 + h * (0.08 + rng() * 0.1)
@@ -231,9 +240,26 @@ function makeSilhouette(
   return tex
 }
 
+function disposeMaterialResource(m: Material | Material[]): void {
+  if (Array.isArray(m)) {
+    for (const mat of m) mat.dispose()
+    return
+  }
+  m.dispose()
+}
+
+function disposeMeshOrPointsResources(obj: Mesh | Points, disposed: Set<BufferGeometry>): void {
+  const { geometry } = obj
+  if (!disposed.has(geometry)) {
+    disposed.add(geometry)
+    geometry.dispose()
+  }
+  disposeMaterialResource(obj.material)
+}
+
 /* ── Component ───────────────────────────────────────────────────────── */
 
-export default function SonoranDuskScene({ className }: { className?: string }) {
+export default function SonoranDuskScene({ className }: Readonly<{ className?: string }>) {
   const mountRef = useRef<HTMLDivElement>(null)
   const mouseRef = useRef({ x: 0, y: 0 })
   const smoothRef = useRef({ x: 0, y: 0 })
@@ -500,13 +526,7 @@ export default function SonoranDuskScene({ className }: { className?: string }) 
       const disposed = new Set<BufferGeometry>()
       scene.traverse((obj) => {
         if (obj instanceof Mesh || obj instanceof Points) {
-          if (!disposed.has(obj.geometry)) {
-            disposed.add(obj.geometry)
-            obj.geometry.dispose()
-          }
-          const m = obj.material
-          if (Array.isArray(m)) m.forEach((mt) => mt.dispose())
-          else m.dispose()
+          disposeMeshOrPointsResources(obj, disposed)
         }
       })
       bloom.dispose()

--- a/apps/console/src/components/StarryNightBrush.tsx
+++ b/apps/console/src/components/StarryNightBrush.tsx
@@ -13,24 +13,27 @@ interface Stroke {
   color: string
 }
 
+type BezierCurveSpec = Readonly<{
+  mx: number
+  my: number
+  c1x: number
+  c1y: number
+  c2x: number
+  c2y: number
+  ex: number
+  ey: number
+  width: number
+  color: string
+  segments: number
+}>
+
 function buildSwirlStrokes(w: number, h: number): Stroke[] {
   const nx = (x: number) => x * w
   const ny = (y: number) => y * h
   const strokes: Stroke[] = []
 
-  const addBezier = (
-    mx: number,
-    my: number,
-    c1x: number,
-    c1y: number,
-    c2x: number,
-    c2y: number,
-    ex: number,
-    ey: number,
-    width: number,
-    color: string,
-    segments: number
-  ) => {
+  const addBezier = (spec: BezierCurveSpec) => {
+    const { mx, my, c1x, c1y, c2x, c2y, ex, ey, width, color, segments } = spec
     const pts: Array<{ x: number; y: number }> = []
     for (let i = 0; i <= segments; i++) {
       const t = i / segments
@@ -51,22 +54,142 @@ function buildSwirlStrokes(w: number, h: number): Stroke[] {
   }
 
   // Back: deep indigo washes (chunky segments read like dry brush)
-  addBezier(0.85, 0.92, 0.98, 0.55, 0.35, 0.05, 0.05, 0.35, 55, 'rgba(25, 35, 85, 0.34)', 28)
-  addBezier(0.1, 0.15, 0.35, 0.0, 0.55, 0.25, 0.72, 0.42, 48, 'rgba(30, 45, 95, 0.30)', 24)
+  addBezier({
+    mx: 0.85,
+    my: 0.92,
+    c1x: 0.98,
+    c1y: 0.55,
+    c2x: 0.35,
+    c2y: 0.05,
+    ex: 0.05,
+    ey: 0.35,
+    width: 55,
+    color: 'rgba(25, 35, 85, 0.34)',
+    segments: 28,
+  })
+  addBezier({
+    mx: 0.1,
+    my: 0.15,
+    c1x: 0.35,
+    c1y: 0.0,
+    c2x: 0.55,
+    c2y: 0.25,
+    ex: 0.72,
+    ey: 0.42,
+    width: 48,
+    color: 'rgba(30, 45, 95, 0.30)',
+    segments: 24,
+  })
 
   // Mid: cobalt spirals (Van Gogh sky rhythm)
-  addBezier(0.72, 0.18, 0.95, 0.32, 0.88, 0.62, 0.42, 0.78, 38, 'rgba(70, 110, 195, 0.26)', 32)
-  addBezier(0.38, 0.12, 0.55, 0.42, 0.2, 0.65, 0.08, 0.55, 32, 'rgba(90, 130, 210, 0.22)', 28)
-  addBezier(0.55, 0.25, 0.75, 0.1, 0.92, 0.35, 0.68, 0.48, 28, 'rgba(120, 155, 235, 0.18)', 26)
-  addBezier(0.5, 0.55, 0.72, 0.45, 0.65, 0.72, 0.35, 0.88, 36, 'rgba(75, 115, 200, 0.20)', 30)
-  addBezier(0.22, 0.72, 0.08, 0.55, 0.22, 0.38, 0.42, 0.28, 30, 'rgba(85, 125, 215, 0.17)', 24)
+  addBezier({
+    mx: 0.72,
+    my: 0.18,
+    c1x: 0.95,
+    c1y: 0.32,
+    c2x: 0.88,
+    c2y: 0.62,
+    ex: 0.42,
+    ey: 0.78,
+    width: 38,
+    color: 'rgba(70, 110, 195, 0.26)',
+    segments: 32,
+  })
+  addBezier({
+    mx: 0.38,
+    my: 0.12,
+    c1x: 0.55,
+    c1y: 0.42,
+    c2x: 0.2,
+    c2y: 0.65,
+    ex: 0.08,
+    ey: 0.55,
+    width: 32,
+    color: 'rgba(90, 130, 210, 0.22)',
+    segments: 28,
+  })
+  addBezier({
+    mx: 0.55,
+    my: 0.25,
+    c1x: 0.75,
+    c1y: 0.1,
+    c2x: 0.92,
+    c2y: 0.35,
+    ex: 0.68,
+    ey: 0.48,
+    width: 28,
+    color: 'rgba(120, 155, 235, 0.18)',
+    segments: 26,
+  })
+  addBezier({
+    mx: 0.5,
+    my: 0.55,
+    c1x: 0.72,
+    c1y: 0.45,
+    c2x: 0.65,
+    c2y: 0.72,
+    ex: 0.35,
+    ey: 0.88,
+    width: 36,
+    color: 'rgba(75, 115, 200, 0.20)',
+    segments: 30,
+  })
+  addBezier({
+    mx: 0.22,
+    my: 0.72,
+    c1x: 0.08,
+    c1y: 0.55,
+    c2x: 0.22,
+    c2y: 0.38,
+    ex: 0.42,
+    ey: 0.28,
+    width: 30,
+    color: 'rgba(85, 125, 215, 0.17)',
+    segments: 24,
+  })
 
   // Light cerulean highlights
-  addBezier(0.62, 0.38, 0.78, 0.28, 0.82, 0.52, 0.58, 0.62, 22, 'rgba(160, 190, 255, 0.14)', 22)
-  addBezier(0.48, 0.42, 0.58, 0.35, 0.52, 0.58, 0.4, 0.72, 18, 'rgba(180, 205, 255, 0.10)', 20)
+  addBezier({
+    mx: 0.62,
+    my: 0.38,
+    c1x: 0.78,
+    c1y: 0.28,
+    c2x: 0.82,
+    c2y: 0.52,
+    ex: 0.58,
+    ey: 0.62,
+    width: 22,
+    color: 'rgba(160, 190, 255, 0.14)',
+    segments: 22,
+  })
+  addBezier({
+    mx: 0.48,
+    my: 0.42,
+    c1x: 0.58,
+    c1y: 0.35,
+    c2x: 0.52,
+    c2y: 0.58,
+    ex: 0.4,
+    ey: 0.72,
+    width: 18,
+    color: 'rgba(180, 205, 255, 0.10)',
+    segments: 20,
+  })
 
   // Warm glow near “moon” / horizon (subtle)
-  addBezier(0.18, 0.88, 0.12, 0.7, 0.28, 0.58, 0.35, 0.72, 40, 'rgba(232, 188, 56, 0.06)', 18)
+  addBezier({
+    mx: 0.18,
+    my: 0.88,
+    c1x: 0.12,
+    c1y: 0.7,
+    c2x: 0.28,
+    c2y: 0.58,
+    ex: 0.35,
+    ey: 0.72,
+    width: 40,
+    color: 'rgba(232, 188, 56, 0.06)',
+    segments: 18,
+  })
 
   return strokes
 }
@@ -231,7 +354,7 @@ function drawVillageBand(ctx: CanvasRenderingContext2D, w: number, h: number) {
   ctx.fill()
 }
 
-export function StarryNightBrush({ className }: { className?: string }) {
+export function StarryNightBrush({ className }: Readonly<{ className?: string }>) {
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const strokesRef = useRef<Stroke[] | null>(null)
   const cypressRef = useRef<Stroke[] | null>(null)
@@ -319,16 +442,16 @@ export function StarryNightBrush({ className }: { className?: string }) {
   }, [])
 
   return (
-    <canvas
-      ref={canvasRef}
-      className={className}
-      aria-hidden
-      style={{
-        display: 'block',
-        width: '100%',
-        height: '100%',
-        objectFit: 'cover',
-      }}
-    />
+    <div aria-hidden className={className} style={{ width: '100%', height: '100%' }}>
+      <canvas
+        ref={canvasRef}
+        style={{
+          display: 'block',
+          width: '100%',
+          height: '100%',
+          objectFit: 'cover',
+        }}
+      />
+    </div>
   )
 }

--- a/apps/console/src/components/StarryNightScene.tsx
+++ b/apps/console/src/components/StarryNightScene.tsx
@@ -420,7 +420,7 @@ function buildVillage(): Group {
 
 /* ── Component ───────────────────────────────────────────────────────── */
 
-export default function StarryNightScene({ className }: { className?: string }) {
+export default function StarryNightScene({ className }: Readonly<{ className?: string }>) {
   const mountRef = useRef<HTMLDivElement>(null)
   const mouseRef = useRef({ x: 0, y: 0 })
   const smoothRef = useRef({ x: 0, y: 0 })

--- a/apps/console/src/components/UserMenu.module.css
+++ b/apps/console/src/components/UserMenu.module.css
@@ -68,6 +68,13 @@
   z-index: 80;
 }
 
+.menuThemeFieldset {
+  border: none;
+  margin: 0;
+  padding: 0;
+  min-width: 0;
+}
+
 .menuSectionLabel {
   margin: 0.2rem 0.5rem 0.25rem;
   font-size: 0.65rem;

--- a/apps/console/src/components/UserMenu.tsx
+++ b/apps/console/src/components/UserMenu.tsx
@@ -16,7 +16,7 @@ function userInitial(user: User): string {
   return fromEmail ? fromEmail.toUpperCase() : '?'
 }
 
-export function UserMenu({ user }: { user: User }) {
+export function UserMenu({ user }: Readonly<{ user: User }>) {
   const [open, setOpen] = useState(false)
   const wrapRef = useRef<HTMLDivElement>(null)
   const { logout } = useAuth()
@@ -83,7 +83,7 @@ export function UserMenu({ user }: { user: User }) {
           <p className={styles.menuSectionLabel} id="user-menu-theme-label">
             Theme
           </p>
-          <div role="group" aria-labelledby="user-menu-theme-label">
+          <fieldset className={styles.menuThemeFieldset} aria-labelledby="user-menu-theme-label">
             {CHRONOGROVE_THEMES.map((id) => (
             <button
               key={id}
@@ -92,7 +92,7 @@ export function UserMenu({ user }: { user: User }) {
               role="menuitemradio"
               aria-checked={activeTheme === id}
               onClick={() => {
-                void persist(id)
+                persist(id).catch(() => {})
               }}
             >
               <span className={styles.menuItemText}>{CHRONOGROVE_THEME_INFO[id].menuLabel}</span>
@@ -103,7 +103,7 @@ export function UserMenu({ user }: { user: User }) {
               ) : null}
             </button>
             ))}
-          </div>
+          </fieldset>
           <div className={styles.menuDivider} />
           <Link
             href="/user-settings/"
@@ -119,7 +119,7 @@ export function UserMenu({ user }: { user: User }) {
             role="menuitem"
             onClick={() => {
               setOpen(false)
-              void logout()
+              logout().catch(() => {})
             }}
           >
             Sign out

--- a/apps/console/src/components/onboarding/AddProvidersFlyout.module.css
+++ b/apps/console/src/components/onboarding/AddProvidersFlyout.module.css
@@ -26,6 +26,10 @@
 dialog.panel {
   margin: 0;
   max-width: none;
+  padding: 0;
+  /* UA `<dialog>` defaults add padding and a border on all sides; restore aside-like chrome. */
+  border: none;
+  border-left: 1px solid var(--border);
 }
 
 .panel {

--- a/apps/console/src/components/onboarding/AddProvidersFlyout.module.css
+++ b/apps/console/src/components/onboarding/AddProvidersFlyout.module.css
@@ -23,6 +23,11 @@
   }
 }
 
+dialog.panel {
+  margin: 0;
+  max-width: none;
+}
+
 .panel {
   position: fixed;
   top: 0;

--- a/apps/console/src/components/onboarding/AddProvidersFlyout.tsx
+++ b/apps/console/src/components/onboarding/AddProvidersFlyout.tsx
@@ -34,7 +34,7 @@ export function AddProvidersFlyout({
   const [integrationStatuses, setIntegrationStatuses] = useState<Record<string, string>>({})
   const [progressReady, setProgressReady] = useState(false)
   const baselineRef = useRef<OnboardingProgressPayload | null>(null)
-  const panelRef = useRef<HTMLDivElement>(null)
+  const panelRef = useRef<HTMLDialogElement>(null)
 
   const load = useCallback(async () => {
     if (!user || !apiSessionReady) return
@@ -193,9 +193,9 @@ export function AddProvidersFlyout({
         aria-label="Close panel"
         onClick={onClose}
       />
-      <aside
+      <dialog
         className={styles.panel}
-        role="dialog"
+        open
         aria-modal="true"
         aria-labelledby="add-providers-title"
         ref={panelRef}
@@ -239,6 +239,7 @@ export function AddProvidersFlyout({
           {user && loading && (
             <div className={styles.loading}>
               <span className="spinner" aria-hidden />
+              {' '}
               Loading your connections…
             </div>
           )}
@@ -252,21 +253,39 @@ export function AddProvidersFlyout({
           )}
           {user && !loading && integrationStatuses.flickr === 'pending_oauth' && (
             <p className={styles.cancelFlickr}>
-              <button type="button" className={styles.cancelFlickrBtn} onClick={() => void cancelOAuthPending('flickr')}>
+              <button
+                type="button"
+                className={styles.cancelFlickrBtn}
+                onClick={() => {
+                  cancelOAuthPending('flickr').catch(() => {})
+                }}
+              >
                 Cancel Flickr link
               </button>
             </p>
           )}
           {user && !loading && integrationStatuses.discogs === 'pending_oauth' && (
             <p className={styles.cancelFlickr}>
-              <button type="button" className={styles.cancelFlickrBtn} onClick={() => void cancelOAuthPending('discogs')}>
+              <button
+                type="button"
+                className={styles.cancelFlickrBtn}
+                onClick={() => {
+                  cancelOAuthPending('discogs').catch(() => {})
+                }}
+              >
                 Cancel Discogs link
               </button>
             </p>
           )}
           {user && !loading && integrationStatuses.github === 'pending_oauth' && (
             <p className={styles.cancelFlickr}>
-              <button type="button" className={styles.cancelFlickrBtn} onClick={() => void cancelOAuthPending('github')}>
+              <button
+                type="button"
+                className={styles.cancelFlickrBtn}
+                onClick={() => {
+                  cancelOAuthPending('github').catch(() => {})
+                }}
+              >
                 Cancel GitHub link
               </button>
             </p>
@@ -287,13 +306,15 @@ export function AddProvidersFlyout({
               type="button"
               className={obStyles.btnPrimary}
               disabled={saving || !user || loading || !progressReady}
-              onClick={() => void handleSave()}
+              onClick={() => {
+                handleSave().catch(() => {})
+              }}
             >
               {saving ? 'Saving…' : 'Save'}
             </button>
           </div>
         </footer>
-      </aside>
+      </dialog>
     </>
   )
 }

--- a/apps/console/src/components/onboarding/AddProvidersFlyout.tsx
+++ b/apps/console/src/components/onboarding/AddProvidersFlyout.tsx
@@ -21,11 +21,11 @@ export function AddProvidersFlyout({
   open,
   onClose,
   onSaved,
-}: {
+}: Readonly<{
   open: boolean
   onClose: () => void
   onSaved?: () => void
-}) {
+}>) {
   const { user, apiSessionReady } = useAuth()
   const [loading, setLoading] = useState(false)
   const [saving, setSaving] = useState(false)
@@ -67,7 +67,7 @@ export function AddProvidersFlyout({
       setProgressReady(false)
       return
     }
-    void load()
+    load().catch(() => {})
   }, [open, load])
 
   useEffect(() => {
@@ -106,9 +106,10 @@ export function AddProvidersFlyout({
       }
       await load()
     } catch (e) {
-      const label =
-        providerId === 'discogs' ? 'Discogs' : providerId === 'github' ? 'GitHub' : 'Flickr'
-      setError(e instanceof Error ? e.message : `Could not cancel ${label} link.`)
+      let providerLabel = 'Flickr'
+      if (providerId === 'discogs') providerLabel = 'Discogs'
+      else if (providerId === 'github') providerLabel = 'GitHub'
+      setError(e instanceof Error ? e.message : `Could not cancel ${providerLabel} link.`)
     }
   }
 

--- a/apps/console/src/components/onboarding/ProviderConnectionGrid.tsx
+++ b/apps/console/src/components/onboarding/ProviderConnectionGrid.tsx
@@ -18,18 +18,20 @@ function labelForProvider(
   return 'Connected'
 }
 
-export function ProviderConnectionGrid({
-  connectedIds,
-  integrationStatuses = {},
-  onToggle,
-  onOAuthProviderConnect,
-}: {
+type ProviderConnectionGridProps = Readonly<{
   connectedIds: ReadonlySet<string>
   integrationStatuses?: Readonly<Record<string, string>>
   onToggle: (providerId: string) => void
   /** For OAuth-native providers (e.g. Flickr), invoked instead of a plain toggle when linking. */
   onOAuthProviderConnect?: (providerId: string) => void | Promise<void>
-}) {
+}>
+
+export function ProviderConnectionGrid({
+  connectedIds,
+  integrationStatuses = {},
+  onToggle,
+  onOAuthProviderConnect,
+}: ProviderConnectionGridProps) {
   return (
     <div className={styles.providerGrid}>
       {ONBOARDING_PROVIDERS.map((provider) => {
@@ -52,7 +54,7 @@ export function ProviderConnectionGrid({
                   onToggle(provider.id)
                   return
                 }
-                void onOAuthProviderConnect?.(provider.id)
+                Promise.resolve(onOAuthProviderConnect?.(provider.id)).catch(() => {})
                 return
               }
               onToggle(provider.id)

--- a/apps/console/src/components/user-settings/SettingsDeleteAccount.tsx
+++ b/apps/console/src/components/user-settings/SettingsDeleteAccount.tsx
@@ -12,7 +12,7 @@ import settingsStyles from '@/sections/UserSettingsSection.module.css'
 
 export { DELETE_ACCOUNT_CONFIRM_PHRASE }
 
-export function SettingsDeleteAccount({ apiSessionReady }: { apiSessionReady: boolean }) {
+export function SettingsDeleteAccount({ apiSessionReady }: Readonly<{ apiSessionReady: boolean }>) {
   const router = useRouter()
   const { user, logout } = useAuth()
   const [phrase, setPhrase] = useState('')
@@ -68,7 +68,7 @@ export function SettingsDeleteAccount({ apiSessionReady }: { apiSessionReady: bo
       </p>
 
       <label className={settingsStyles.dangerLabel} htmlFor="delete-account-confirm">
-        Confirmation
+        <span>Confirmation</span>
         <input
           id="delete-account-confirm"
           type="text"
@@ -91,7 +91,9 @@ export function SettingsDeleteAccount({ apiSessionReady }: { apiSessionReady: bo
         type="button"
         className={settingsStyles.btnDanger}
         disabled={!canDelete}
-        onClick={() => void handleDelete()}
+        onClick={() => {
+          handleDelete().catch(() => {})
+        }}
       >
         {deleting ? 'Deleting…' : 'Delete my account permanently'}
       </button>

--- a/apps/console/src/components/user-settings/SettingsProfileIdentity.test.tsx
+++ b/apps/console/src/components/user-settings/SettingsProfileIdentity.test.tsx
@@ -524,6 +524,136 @@ describe('SettingsProfileIdentity', () => {
     unmount()
     intervalSpy.mockRestore()
   })
+
+  it('DNS polling interval re-invokes check-domain (covers interval callback)', async () => {
+    setupLoad(sampleProgress({ customDomain: 'interval.coverage.test' }))
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      jsonResponse({ verified: false }) as Awaited<ReturnType<typeof fetch>>,
+    )
+
+    const realSetInterval = globalThis.setInterval.bind(globalThis)
+    const intervalSpy = vi.spyOn(globalThis, 'setInterval').mockImplementation((handler, timeout) => {
+      if (timeout === 15_000 && typeof handler === 'function') {
+        queueMicrotask(() => {
+          ;(handler as () => void)()
+        })
+        return 77_777 as unknown as ReturnType<typeof setInterval>
+      }
+      return realSetInterval(handler as TimerHandler, timeout as number)
+    })
+
+    try {
+      const user = userEvent.setup()
+      render(<SettingsProfileIdentity user={mockUser()} apiSessionReady />)
+      await waitFor(() => screen.getByRole('button', { name: /verify dns/i }))
+      await user.click(screen.getByRole('button', { name: /verify dns/i }))
+
+      await waitFor(() => {
+        expect(globalThis.fetch).toHaveBeenCalledTimes(2)
+      })
+      expect(globalThis.fetch).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining('/api/onboarding/check-domain?domain=interval.coverage.test'),
+        expect.objectContaining({ method: 'GET' }),
+      )
+    } finally {
+      intervalSpy.mockRestore()
+    }
+  })
+
+  it('shows generic load error when progress GET rejects with a non-Error', async () => {
+    getJson.mockRejectedValue('not-an-error-instance')
+    render(<SettingsProfileIdentity user={mockUser()} apiSessionReady />)
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/load failed/i)
+    })
+  })
+
+  it('re-fetches when Firebase user uid changes without dropping into full-page loading', async () => {
+    const userA = { ...mockUser(), uid: 'settings-uid-a' } as User
+    const userB = { ...mockUser(), uid: 'settings-uid-b' } as User
+
+    getJson.mockResolvedValueOnce(jsonResponse({ payload: sampleProgress({ username: 'alpha' }) }))
+    const { rerender } = render(<SettingsProfileIdentity user={userA} apiSessionReady />)
+    await waitFor(() => expect(screen.getByDisplayValue('alpha')).toBeInTheDocument())
+
+    getJson.mockResolvedValueOnce(jsonResponse({ payload: sampleProgress({ username: 'bravo' }) }))
+    rerender(<SettingsProfileIdentity user={userB} apiSessionReady />)
+
+    await waitFor(() => expect(screen.getByDisplayValue('bravo')).toBeInTheDocument())
+    expect(getJson).toHaveBeenCalled()
+  })
+
+  it('username save onClick swallows rejection when PUT throws (covers defensive catch)', async () => {
+    setupLoad(sampleProgress({ username: null, customDomain: null }))
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      jsonResponse({ available: true }) as Awaited<ReturnType<typeof fetch>>,
+    )
+    putJson.mockRejectedValue(new Error('network down'))
+
+    const user = userEvent.setup()
+    render(<SettingsProfileIdentity user={mockUser()} apiSessionReady />)
+    await waitFor(() => screen.getByPlaceholderText('your-username'))
+
+    fireEvent.change(screen.getByPlaceholderText('your-username'), {
+      target: { value: 'throwusr' },
+    })
+    await afterUsernameDebounce()
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled())
+    await waitUntilSaveUsernameEnabled()
+
+    await user.click(screen.getByRole('button', { name: /save username/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save username/i })).toBeEnabled()
+    })
+  })
+
+  it('domain save onClick swallows rejection when PUT throws (covers defensive catch)', async () => {
+    setupLoad(sampleProgress({ username: 'u', customDomain: null }))
+    putJson.mockRejectedValue(new Error('network down'))
+
+    render(<SettingsProfileIdentity user={mockUser()} apiSessionReady />)
+    await waitFor(() => screen.getByPlaceholderText('api.yourdomain.com'))
+
+    fireEvent.change(screen.getByPlaceholderText('api.yourdomain.com'), {
+      target: { value: 'api.throw.test' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /save domain/i }))
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /save domain/i })).toBeEnabled()
+    })
+  })
+
+  it('username save succeeds when PUT body JSON fails but response is OK (putOnboarding json catch)', async () => {
+    setupLoad(sampleProgress({ username: null, customDomain: null }))
+    vi.mocked(globalThis.fetch).mockResolvedValue(
+      jsonResponse({ available: true }) as Awaited<ReturnType<typeof fetch>>,
+    )
+    putJson.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.reject(new Error('malformed')),
+    } as unknown as Response)
+
+    const user = userEvent.setup()
+    render(<SettingsProfileIdentity user={mockUser()} apiSessionReady />)
+    await waitFor(() => screen.getByPlaceholderText('your-username'))
+
+    fireEvent.change(screen.getByPlaceholderText('your-username'), {
+      target: { value: 'jsonusr' },
+    })
+    await afterUsernameDebounce()
+    await waitFor(() => expect(globalThis.fetch).toHaveBeenCalled())
+    await waitUntilSaveUsernameEnabled()
+
+    await user.click(screen.getByRole('button', { name: /save username/i }))
+
+    await waitFor(() => {
+      expect(screen.getByText(/username updated/i)).toBeInTheDocument()
+    })
+  })
 })
 
 describe('SettingsUsernameBlock (progressRef guard)', () => {

--- a/apps/console/src/components/user-settings/SettingsProfileIdentity.tsx
+++ b/apps/console/src/components/user-settings/SettingsProfileIdentity.tsx
@@ -55,7 +55,7 @@ export function SettingsUsernameBlock({
   runIdentitySave,
   isSaving,
   subsectionClassName,
-}: {
+}: Readonly<{
   user: User
   progress: OnboardingProgressPayload
   progressRef: MutableRefObject<OnboardingProgressPayload | null>
@@ -64,7 +64,7 @@ export function SettingsUsernameBlock({
   runIdentitySave: <T>(fn: () => Promise<T>) => Promise<T>
   isSaving: boolean
   subsectionClassName: string
-}) {
+}>) {
   const saved = (progress.username ?? '').toLowerCase()
   const [usernameDraft, setUsernameDraft] = useState(saved)
   const [usernameStatus, setUsernameStatus] = useState<UsernameStatus>('idle')
@@ -120,7 +120,9 @@ export function SettingsUsernameBlock({
       return
     }
     if (sanitized.length >= 3) {
-      timerRef.current = setTimeout(() => void checkUsername(sanitized), 500)
+      timerRef.current = setTimeout(() => {
+        checkUsername(sanitized).catch(() => {})
+      }, 500)
     }
   }
 
@@ -227,7 +229,9 @@ export function SettingsUsernameBlock({
         type="button"
         className={obStyles.btnPrimary}
         disabled={!canSaveUsername}
-        onClick={() => void saveUsername()}
+        onClick={() => {
+          saveUsername().catch(() => {})
+        }}
       >
         {isSaving ? 'Saving…' : 'Save username'}
       </button>
@@ -250,7 +254,7 @@ export function SettingsCustomDomainBlock({
   onProgressUpdated,
   runIdentitySave,
   isSaving,
-}: {
+}: Readonly<{
   user: User
   progress: OnboardingProgressPayload
   progressRef: MutableRefObject<OnboardingProgressPayload | null>
@@ -258,7 +262,7 @@ export function SettingsCustomDomainBlock({
   onProgressUpdated: (p: OnboardingProgressPayload) => void
   runIdentitySave: <T>(fn: () => Promise<T>) => Promise<T>
   isSaving: boolean
-}) {
+}>) {
   const saved = progress.customDomain ?? ''
   const [domainDraft, setDomainDraft] = useState(saved)
   const [dnsStatus, setDnsStatus] = useState<DnsStatus>('idle')
@@ -311,9 +315,11 @@ export function SettingsCustomDomainBlock({
 
   const startDnsCheck = () => {
     if (!domainDraft) return
-    void checkDns(domainDraft)
+    checkDns(domainDraft).catch(() => {})
     clearDnsVerificationTimers({ dnsTimerRef, dnsPollingRef })
-    dnsPollingRef.current = setInterval(() => void checkDns(domainDraft), 15000)
+    dnsPollingRef.current = setInterval(() => {
+      checkDns(domainDraft).catch(() => {})
+    }, 15000)
   }
 
   const unchanged = domainDraft === saved
@@ -355,7 +361,7 @@ export function SettingsCustomDomainBlock({
       </p>
 
       <label className={obStyles.label} htmlFor="settings-domain-input">
-        Domain name
+        <span>Domain name</span>
         <input
           id="settings-domain-input"
           type="text"
@@ -389,6 +395,7 @@ export function SettingsCustomDomainBlock({
             {dnsStatus === 'checking' ? (
               <>
                 <span className="spinner" aria-hidden />
+                {' '}
                 Verifying…
               </>
             ) : (
@@ -439,7 +446,9 @@ export function SettingsCustomDomainBlock({
           type="button"
           className={obStyles.btnPrimary}
           disabled={!canSaveDomain}
-          onClick={() => void saveDomain()}
+          onClick={() => {
+            saveDomain().catch(() => {})
+          }}
         >
           {isSaving ? 'Saving…' : 'Save domain'}
         </button>
@@ -457,10 +466,10 @@ export function SettingsCustomDomainBlock({
 export function SettingsProfileIdentity({
   user,
   apiSessionReady,
-}: {
+}: Readonly<{
   user: User
   apiSessionReady: boolean
-}) {
+}>) {
   const baseUrl = getAppBaseUrl()
   const [loading, setLoading] = useState(true)
   const [progress, setProgress] = useState<OnboardingProgressPayload | null>(null)
@@ -519,7 +528,7 @@ export function SettingsProfileIdentity({
   useEffect(() => {
     if (!apiSessionReady) return
     if (!userRef.current) return
-    void load()
+    load().catch(() => {})
   }, [apiSessionReady, authIdentityKey, load])
 
   if (!apiSessionReady) {

--- a/apps/console/src/components/user-settings/SettingsProfileIdentity.tsx
+++ b/apps/console/src/components/user-settings/SettingsProfileIdentity.tsx
@@ -121,7 +121,7 @@ export function SettingsUsernameBlock({
     }
     if (sanitized.length >= 3) {
       timerRef.current = setTimeout(() => {
-        checkUsername(sanitized).catch(() => {})
+        void checkUsername(sanitized)
       }, 500)
     }
   }
@@ -315,10 +315,10 @@ export function SettingsCustomDomainBlock({
 
   const startDnsCheck = () => {
     if (!domainDraft) return
-    checkDns(domainDraft).catch(() => {})
+    void checkDns(domainDraft)
     clearDnsVerificationTimers({ dnsTimerRef, dnsPollingRef })
     dnsPollingRef.current = setInterval(() => {
-      checkDns(domainDraft).catch(() => {})
+      void checkDns(domainDraft)
     }, 15000)
   }
 
@@ -528,7 +528,7 @@ export function SettingsProfileIdentity({
   useEffect(() => {
     if (!apiSessionReady) return
     if (!userRef.current) return
-    load().catch(() => {})
+    void load()
   }, [apiSessionReady, authIdentityKey, load])
 
   if (!apiSessionReady) {

--- a/apps/console/src/layout/Layout.module.css
+++ b/apps/console/src/layout/Layout.module.css
@@ -315,8 +315,15 @@ a.logoSub:hover {
   display: none;
   position: fixed;
   inset: 0;
+  margin: 0;
+  padding: 0;
+  border: none;
   background: rgba(0, 0, 0, 0.5);
   z-index: 99;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  appearance: none;
 }
 
 @media (max-width: 768px) {
@@ -326,7 +333,7 @@ a.logoSub:hover {
     opacity: 0;
     transition: opacity 0.2s;
   }
-  .overlay[aria-hidden="false"] {
+  .overlay[data-open="true"] {
     pointer-events: auto;
     opacity: 1;
   }

--- a/apps/console/src/layout/Layout.test.tsx
+++ b/apps/console/src/layout/Layout.test.tsx
@@ -63,15 +63,14 @@ describe('Layout', () => {
     expect(onSectionChange).toHaveBeenCalledWith('overview')
 
     const menuToggle = screen.getByRole('button', { name: 'Open navigation menu' })
-    const overlay = document.querySelector('[class*="overlay"]') as HTMLDivElement | null
-    expect(overlay).not.toBeNull()
-    expect(overlay).toHaveAttribute('aria-hidden', 'true')
+    const overlay = screen.getByRole('button', { name: 'Close navigation menu' })
+    expect(overlay).not.toHaveAttribute('data-open')
 
     await user.click(menuToggle)
-    expect(overlay).toHaveAttribute('aria-hidden', 'false')
+    expect(overlay).toHaveAttribute('data-open', 'true')
 
-    await user.click(overlay!)
-    expect(overlay).toHaveAttribute('aria-hidden', 'true')
+    await user.click(overlay)
+    expect(overlay).not.toHaveAttribute('data-open')
   })
 
   it('shows auth copy and hides protected nav items for signed-out users on auth', async () => {

--- a/apps/console/src/layout/Layout.tsx
+++ b/apps/console/src/layout/Layout.tsx
@@ -90,7 +90,7 @@ const buildCommitUrl = buildSha
   ? `https://github.com/chrisvogt/chronogrove/commit/${buildSha}`
   : null
 
-export function Layout({ children, user, activeSection, onSectionChange }: LayoutProps) {
+export function Layout({ children, user, activeSection, onSectionChange }: Readonly<LayoutProps>) {
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const tenantHost = getTenantDisplayHost()
   const activeCopy =
@@ -215,10 +215,11 @@ export function Layout({ children, user, activeSection, onSectionChange }: Layou
         type="button"
         className={styles.overlay}
         data-open={sidebarOpen ? 'true' : undefined}
-        aria-label="Close navigation menu"
         tabIndex={sidebarOpen ? 0 : -1}
         onClick={() => setSidebarOpen(false)}
-      />
+      >
+        <span className={styles.srOnly}>Close navigation menu</span>
+      </button>
     </div>
   )
 }

--- a/apps/console/src/layout/Layout.tsx
+++ b/apps/console/src/layout/Layout.tsx
@@ -211,9 +211,12 @@ export function Layout({ children, user, activeSection, onSectionChange }: Layou
         </header>
         <div className={styles.content}>{children}</div>
       </div>
-      <div
+      <button
+        type="button"
         className={styles.overlay}
-        aria-hidden={!sidebarOpen}
+        data-open={sidebarOpen ? 'true' : undefined}
+        aria-label="Close navigation menu"
+        tabIndex={sidebarOpen ? 0 : -1}
         onClick={() => setSidebarOpen(false)}
       />
     </div>

--- a/apps/console/src/lib/overviewQuickLinks.ts
+++ b/apps/console/src/lib/overviewQuickLinks.ts
@@ -6,10 +6,10 @@ export type OverviewQuickLink = { href: string; label: string; external?: boolea
  * Dashboard hero “quick links”: routes that complement the main nav (not Schema / Status / Try API / Sync).
  */
 export function buildOverviewQuickLinks(input: {
-  user: unknown | null
+  user: unknown
   publicUsername: string | null
 }): OverviewQuickLink[] {
-  if (!input.user) {
+  if (input.user == null) {
     return [
       { href: '/docs/', label: 'Docs' },
       { href: '/about/', label: 'About' },

--- a/apps/console/src/lib/tenant-api-root-map.ts
+++ b/apps/console/src/lib/tenant-api-root-map.ts
@@ -44,7 +44,7 @@ export function isAuthlessPublicStatusSurface(
   pathname: string | null | undefined,
   browserHostname: string | undefined
 ): boolean {
-  if (pathname != null && pathname.startsWith('/u/')) {
+  if (pathname?.startsWith('/u/')) {
     return true
   }
   if (pathname === '/' || pathname === '') {

--- a/apps/console/src/sections/ApiTestingSection.module.css
+++ b/apps/console/src/sections/ApiTestingSection.module.css
@@ -202,6 +202,7 @@
 
 /* Chatbot-style “thinking” strip: one line at a time, no history (like Cursor / many AI UIs). */
 .thinkingShell {
+  display: block;
   margin-top: 0.85rem;
   padding: 0.85rem 1rem;
   border-radius: 16px;

--- a/apps/console/src/sections/ApiTestingSection.tsx
+++ b/apps/console/src/sections/ApiTestingSection.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, type Dispatch, type SetStateAction } from 'react'
 import type { SectionId } from '../layout/Layout'
 import { useAuth } from '../auth/AuthContext'
 import { ApiClient } from '../auth/apiClient'
@@ -32,7 +32,336 @@ interface LoadingState {
   sync: boolean
 }
 
-export function ApiTestingSection({ activeSection }: ApiTestingSectionProps) {
+function handleSyncSseDataLine(
+  raw: string,
+  startMs: number,
+  setSyncThinkingLine: (message: string | null) => void,
+  setSyncResult: Dispatch<SetStateAction<FetchResult | null>>
+): void {
+  const line = raw.replace(/\r$/, '')
+  if (!line.startsWith('data: ')) return
+  let payload: {
+    type?: string
+    message?: string
+    result?: unknown
+  }
+  try {
+    payload = JSON.parse(line.slice(6)) as typeof payload
+  } catch {
+    return
+  }
+  if (payload.type === 'progress' && typeof payload.message === 'string') {
+    setSyncThinkingLine(payload.message)
+  }
+  if (payload.type === 'done') {
+    setSyncResult({
+      ok: true,
+      status: 200,
+      time: Date.now() - startMs,
+      data: payload.result,
+    })
+  }
+  if (payload.type === 'error') {
+    setSyncResult({
+      ok: false,
+      time: Date.now() - startMs,
+      error: typeof payload.message === 'string' ? payload.message : 'Sync stream error',
+    })
+  }
+}
+
+async function consumeManualSyncStreamBody(
+  body: ReadableStream<Uint8Array>,
+  startMs: number,
+  setSyncThinkingLine: (message: string | null) => void,
+  setSyncResult: Dispatch<SetStateAction<FetchResult | null>>
+): Promise<void> {
+  const reader = body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ''
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    buffer += decoder.decode(value, { stream: true })
+    const parts = buffer.split('\n')
+    buffer = parts.pop() ?? ''
+    for (const part of parts) {
+      handleSyncSseDataLine(part, startMs, setSyncThinkingLine, setSyncResult)
+    }
+  }
+  if (buffer.trim()) {
+    handleSyncSseDataLine(buffer, startMs, setSyncThinkingLine, setSyncResult)
+  }
+}
+
+async function runManualSyncStreamRequest(
+  syncProvider: string,
+  idToken: string,
+  startMs: number,
+  setSyncThinkingLine: (message: string | null) => void,
+  setSyncResult: Dispatch<SetStateAction<FetchResult | null>>
+): Promise<void> {
+  const res = await fetch(getManualSyncStreamUrl(syncProvider), {
+    headers: { Authorization: `Bearer ${idToken}` },
+    credentials: 'include',
+    cache: 'no-store',
+  })
+
+  if (!res.ok) {
+    const errText = await res.text().catch(() => '')
+    setSyncResult({
+      ok: false,
+      status: res.status,
+      time: Date.now() - startMs,
+      error: errText || `HTTP ${res.status}`,
+    })
+    setSyncThinkingLine(null)
+    return
+  }
+
+  if (!res.body) {
+    setSyncResult({
+      ok: false,
+      time: Date.now() - startMs,
+      error: 'No response body (streaming not supported?)',
+    })
+    setSyncThinkingLine(null)
+    return
+  }
+
+  await consumeManualSyncStreamBody(res.body, startMs, setSyncThinkingLine, setSyncResult)
+}
+
+interface ResultBoxProps {
+  result: FetchResult
+}
+
+function ResultBox({ result }: Readonly<ResultBoxProps>) {
+  const isOk = result.ok
+  const status = result.status != null ? `${result.status}` : ''
+  const time = result.time != null ? `${result.time}ms` : ''
+  const body = result.data ?? result.error
+
+  return (
+    <div className={`${styles.result} ${isOk ? styles.resultOk : styles.resultError}`}>
+      <div className={styles.resultHeader}>
+        <span className={styles.resultStatus}>
+          {isOk ? '✓' : '✗'} {status} {time}
+        </span>
+      </div>
+      <pre className={styles.resultBody}>
+        {typeof body === 'string' ? body : JSON.stringify(body, null, 2)}
+      </pre>
+    </div>
+  )
+}
+
+interface TryApiPanelProps {
+  idToken: string | null
+  tokenLoading: boolean
+  widgetProvider: string
+  setWidgetProvider: (v: string) => void
+  widgetResult: FetchResult | null
+  sessionResult: FetchResult | null
+  loading: LoadingState
+  widgetGitHubAuthMode: string | undefined
+  onFetchToken: () => void
+  onTestSession: () => void
+  onTestWidgets: () => void
+}
+
+function TryApiPanel({
+  idToken,
+  tokenLoading,
+  widgetProvider,
+  setWidgetProvider,
+  widgetResult,
+  sessionResult,
+  loading,
+  widgetGitHubAuthMode,
+  onFetchToken,
+  onTestSession,
+  onTestWidgets,
+}: Readonly<TryApiPanelProps>) {
+  return (
+    <>
+      <div className={styles.block}>
+        <h2 className={styles.sectionTitle}>Try API</h2>
+        <p className={styles.sectionSubtitle}>
+          Test the authenticated and public route surface from one place. Widget feeds are public; session and sync flows
+          require sign-in.
+        </p>
+      </div>
+      <div className={styles.block}>
+        <h3 className={styles.blockTitle}>Auth token</h3>
+        <p className={styles.blockText}>Refresh the current Firebase ID token before calling protected routes.</p>
+        <div className={styles.row}>
+          <button type="button" className={styles.btnPrimary} onClick={onFetchToken} disabled={tokenLoading}>
+            {tokenLoading ? 'Getting token…' : 'Get fresh ID token'}
+          </button>
+          {idToken && (
+            <span className={styles.tokenPreview}>
+              Token: <code>{idToken.slice(0, 40)}…</code>
+            </span>
+          )}
+        </div>
+      </div>
+      <div className={styles.block}>
+        <h3 className={styles.blockTitle}>Session</h3>
+        <div className={styles.endpoint}>
+          <span className={styles.methodPost}>POST</span>
+          <code className={styles.path}>/api/auth/session</code>
+          <div className={styles.controls}>
+            <button type="button" className={styles.btnSecondary} onClick={onTestSession} disabled={!idToken || loading.session}>
+              {loading.session ? 'Testing…' : 'Test'}
+            </button>
+          </div>
+          {sessionResult && <ResultBox result={sessionResult} />}
+        </div>
+      </div>
+      <div className={styles.block}>
+        <h3 className={styles.blockTitle}>Get widget data</h3>
+        <p className={styles.sectionSubtitle}>
+          When you are signed in, each test sends your current Firebase ID token so GitHub can use your linked account
+          (OAuth) instead of the server PAT. On production the console origin is usually cross-site to the API, so session
+          cookies are not relied on here; the token is attached automatically.
+        </p>
+        <div className={styles.endpoint}>
+          <span className={styles.methodGet}>GET</span>
+          <code className={styles.path}>/api/widgets/&#123;provider&#125;</code>
+          <div className={styles.controls}>
+            <select value={widgetProvider} onChange={(e) => setWidgetProvider(e.target.value)} className={styles.select}>
+              {WIDGET_PROVIDERS.map((p) => (
+                <option key={p} value={p}>
+                  {p}
+                </option>
+              ))}
+            </select>
+            <button type="button" className={styles.btnSecondary} onClick={onTestWidgets} disabled={loading.widgets}>
+              {loading.widgets ? 'Testing…' : 'Test'}
+            </button>
+          </div>
+          {widgetGitHubAuthMode ? (
+            <output
+              className={`${styles.flickrAuthBadge} ${
+                widgetGitHubAuthMode === 'oauth' ? styles.flickrAuthBadgeOAuth : styles.flickrAuthBadgeLegacy
+              }`}
+            >
+              {widgetGitHubAuthMode === 'oauth'
+                ? 'GitHub credentials: OAuth (connected account)'
+                : 'GitHub credentials: PAT (server env / legacy)'}
+            </output>
+          ) : null}
+          {widgetResult && <ResultBox result={widgetResult} />}
+        </div>
+      </div>
+    </>
+  )
+}
+
+interface SyncPanelProps {
+  syncProvider: string
+  setSyncProvider: (v: string) => void
+  idToken: string | null
+  loading: LoadingState
+  syncThinkingLine: string | null
+  syncFlickrAuthMode: string | undefined
+  syncDiscogsAuthMode: string | undefined
+  syncResult: FetchResult | null
+  onTestSync: () => void
+}
+
+function SyncPanel({
+  syncProvider,
+  setSyncProvider,
+  idToken,
+  loading,
+  syncThinkingLine,
+  syncFlickrAuthMode,
+  syncDiscogsAuthMode,
+  syncResult,
+  onTestSync,
+}: Readonly<SyncPanelProps>) {
+  return (
+    <>
+      <div className={styles.block}>
+        <h2 className={styles.sectionTitle}>Sync</h2>
+        <p className={styles.sectionSubtitle}>
+          Trigger a provider sync from the console. Your ID token loads automatically after sign-in, and the API page can
+          refresh it or create a session cookie when needed.
+        </p>
+      </div>
+      <div className={styles.block}>
+        <h3 className={styles.blockTitle}>Sync provider</h3>
+        <p className={styles.blockText}>
+          Run the queue-backed sync via{' '}
+          <code className={styles.inlineCode}>GET /api/widgets/sync/&#123;provider&#125;/stream</code> so you can watch live
+          steps and inspect the same final payload returned by the JSON endpoint.
+          {syncProvider === 'flickr' || syncProvider === 'discogs'
+            ? ' Flickr and Discogs manual sync load OAuth from your signed-in user when that provider is linked; otherwise the job uses server env credentials. Widget data still updates the default site owner path.'
+            : ''}
+        </p>
+        <div className={styles.endpoint}>
+          <span className={styles.methodGet}>GET</span>
+          <code className={styles.path}>/api/widgets/sync/&#123;provider&#125;/stream</code>
+          <div className={styles.controls}>
+            <select value={syncProvider} onChange={(e) => setSyncProvider(e.target.value)} className={styles.select}>
+              {SYNC_PROVIDERS.map((p) => (
+                <option key={p} value={p}>
+                  {p}
+                </option>
+              ))}
+            </select>
+            <button type="button" className={styles.btnSecondary} onClick={onTestSync} disabled={!idToken || loading.sync}>
+              {loading.sync ? 'Testing…' : 'Test'}
+            </button>
+          </div>
+          {loading.sync && syncThinkingLine !== null ? (
+            <output className={styles.thinkingShell} aria-live="polite">
+              <div className={styles.thinkingHeader}>
+                <span className={styles.thinkingPulse} aria-hidden />
+                <span className={styles.thinkingTitle}>Sync progress</span>
+                <span className={styles.thinkingDots} aria-hidden>
+                  <span />
+                  <span />
+                  <span />
+                </span>
+              </div>
+              <p key={syncThinkingLine} className={styles.thinkingLine}>
+                {syncThinkingLine}
+              </p>
+            </output>
+          ) : null}
+          {syncFlickrAuthMode ? (
+            <output
+              className={`${styles.flickrAuthBadge} ${
+                syncFlickrAuthMode === 'oauth' ? styles.flickrAuthBadgeOAuth : styles.flickrAuthBadgeLegacy
+              }`}
+            >
+              {syncFlickrAuthMode === 'oauth'
+                ? 'Flickr credentials: OAuth (connected account)'
+                : 'Flickr credentials: legacy (server API key)'}
+            </output>
+          ) : null}
+          {syncDiscogsAuthMode ? (
+            <output
+              className={`${styles.flickrAuthBadge} ${
+                syncDiscogsAuthMode === 'oauth' ? styles.flickrAuthBadgeOAuth : styles.flickrAuthBadgeLegacy
+              }`}
+            >
+              {syncDiscogsAuthMode === 'oauth'
+                ? 'Discogs credentials: OAuth (connected account)'
+                : 'Discogs credentials: legacy (personal token + username in env)'}
+            </output>
+          ) : null}
+          {syncResult && <ResultBox result={syncResult} />}
+        </div>
+      </div>
+    </>
+  )
+}
+
+export function ApiTestingSection({ activeSection }: Readonly<ApiTestingSectionProps>) {
   const { user } = useAuth()
   const [idToken, setIdToken] = useState<string | null>(null)
   const [tokenLoading, setTokenLoading] = useState(false)
@@ -41,7 +370,6 @@ export function ApiTestingSection({ activeSection }: ApiTestingSectionProps) {
   const [widgetResult, setWidgetResult] = useState<FetchResult | null>(null)
   const [sessionResult, setSessionResult] = useState<FetchResult | null>(null)
   const [syncResult, setSyncResult] = useState<FetchResult | null>(null)
-  /** Single live status line for the active SSE sync stream. */
   const [syncThinkingLine, setSyncThinkingLine] = useState<string | null>(null)
   const [loading, setLoading] = useState<LoadingState>({
     widgets: false,
@@ -153,84 +481,8 @@ export function ApiTestingSection({ activeSection }: ApiTestingSectionProps) {
     setSyncThinkingLine('Starting sync…')
     const start = Date.now()
 
-    const applySseLine = (raw: string) => {
-      const line = raw.replace(/\r$/, '')
-      if (!line.startsWith('data: ')) return
-      let payload: {
-        type?: string
-        message?: string
-        result?: unknown
-      }
-      try {
-        payload = JSON.parse(line.slice(6)) as typeof payload
-      } catch {
-        return
-      }
-      if (payload.type === 'progress' && typeof payload.message === 'string') {
-        setSyncThinkingLine(payload.message)
-      }
-      if (payload.type === 'done') {
-        setSyncResult({
-          ok: true,
-          status: 200,
-          time: Date.now() - start,
-          data: payload.result,
-        })
-      }
-      if (payload.type === 'error') {
-        setSyncResult({
-          ok: false,
-          time: Date.now() - start,
-          error: typeof payload.message === 'string' ? payload.message : 'Sync stream error',
-        })
-      }
-    }
-
     try {
-      const res = await fetch(getManualSyncStreamUrl(syncProvider), {
-        headers: { Authorization: `Bearer ${idToken}` },
-        credentials: 'include',
-        cache: 'no-store',
-      })
-
-      if (!res.ok) {
-        const errText = await res.text().catch(() => '')
-        setSyncResult({
-          ok: false,
-          status: res.status,
-          time: Date.now() - start,
-          error: errText || `HTTP ${res.status}`,
-        })
-        setSyncThinkingLine(null)
-        return
-      }
-
-      if (!res.body) {
-        setSyncResult({
-          ok: false,
-          time: Date.now() - start,
-          error: 'No response body (streaming not supported?)',
-        })
-        setSyncThinkingLine(null)
-        return
-      }
-
-      const reader = res.body.getReader()
-      const decoder = new TextDecoder()
-      let buffer = ''
-      while (true) {
-        const { done, value } = await reader.read()
-        if (done) break
-        buffer += decoder.decode(value, { stream: true })
-        const parts = buffer.split('\n')
-        buffer = parts.pop() ?? ''
-        for (const part of parts) {
-          applySseLine(part)
-        }
-      }
-      if (buffer.trim()) {
-        applySseLine(buffer)
-      }
+      await runManualSyncStreamRequest(syncProvider, idToken, start, setSyncThinkingLine, setSyncResult)
     } catch (err) {
       setSyncResult({
         ok: false,
@@ -246,220 +498,33 @@ export function ApiTestingSection({ activeSection }: ApiTestingSectionProps) {
   return (
     <>
       {showApi && (
-        <>
-          <div className={styles.block}>
-            <h2 className={styles.sectionTitle}>Try API</h2>
-            <p className={styles.sectionSubtitle}>
-              Test the authenticated and public route surface from one place. Widget feeds are public; session and sync
-              flows require sign-in.
-            </p>
-          </div>
-          <div className={styles.block}>
-            <h3 className={styles.blockTitle}>Auth token</h3>
-            <p className={styles.blockText}>
-              Refresh the current Firebase ID token before calling protected routes.
-            </p>
-            <div className={styles.row}>
-              <button
-                type="button"
-                className={styles.btnPrimary}
-                onClick={fetchToken}
-                disabled={tokenLoading}
-              >
-                {tokenLoading ? 'Getting token…' : 'Get fresh ID token'}
-              </button>
-              {idToken && (
-                <span className={styles.tokenPreview}>
-                  Token: <code>{idToken.slice(0, 40)}…</code>
-                </span>
-              )}
-            </div>
-          </div>
-          <div className={styles.block}>
-            <h3 className={styles.blockTitle}>Session</h3>
-            <div className={styles.endpoint}>
-              <span className={styles.methodPost}>POST</span>
-              <code className={styles.path}>/api/auth/session</code>
-              <div className={styles.controls}>
-                <button
-                  type="button"
-                  className={styles.btnSecondary}
-                  onClick={testSession}
-                  disabled={!idToken || loading.session}
-                >
-                  {loading.session ? 'Testing…' : 'Test'}
-                </button>
-              </div>
-              {sessionResult && <ResultBox result={sessionResult} />}
-            </div>
-          </div>
-          <div className={styles.block}>
-            <h3 className={styles.blockTitle}>Get widget data</h3>
-            <p className={styles.sectionSubtitle}>
-              When you are signed in, each test sends your current Firebase ID token so GitHub can use your linked
-              account (OAuth) instead of the server PAT. On production the console origin is usually cross-site to the
-              API, so session cookies are not relied on here; the token is attached automatically.
-            </p>
-            <div className={styles.endpoint}>
-              <span className={styles.methodGet}>GET</span>
-              <code className={styles.path}>/api/widgets/&#123;provider&#125;</code>
-              <div className={styles.controls}>
-                <select
-                  value={widgetProvider}
-                  onChange={(e) => setWidgetProvider(e.target.value)}
-                  className={styles.select}
-                >
-                  {WIDGET_PROVIDERS.map((p) => (
-                    <option key={p} value={p}>
-                      {p}
-                    </option>
-                  ))}
-                </select>
-                <button
-                  type="button"
-                  className={styles.btnSecondary}
-                  onClick={testWidgets}
-                  disabled={loading.widgets}
-                >
-                  {loading.widgets ? 'Testing…' : 'Test'}
-                </button>
-              </div>
-              {widgetGitHubAuthMode ? (
-                <p
-                  className={`${styles.flickrAuthBadge} ${
-                    widgetGitHubAuthMode === 'oauth'
-                      ? styles.flickrAuthBadgeOAuth
-                      : styles.flickrAuthBadgeLegacy
-                  }`}
-                  role="status"
-                >
-                  {widgetGitHubAuthMode === 'oauth'
-                    ? 'GitHub credentials: OAuth (connected account)'
-                    : 'GitHub credentials: PAT (server env / legacy)'}
-                </p>
-              ) : null}
-              {widgetResult && <ResultBox result={widgetResult} />}
-            </div>
-          </div>
-        </>
+        <TryApiPanel
+          idToken={idToken}
+          tokenLoading={tokenLoading}
+          widgetProvider={widgetProvider}
+          setWidgetProvider={setWidgetProvider}
+          widgetResult={widgetResult}
+          sessionResult={sessionResult}
+          loading={loading}
+          widgetGitHubAuthMode={widgetGitHubAuthMode}
+          onFetchToken={fetchToken}
+          onTestSession={testSession}
+          onTestWidgets={testWidgets}
+        />
       )}
-
       {showSync && (
-        <>
-          <div className={styles.block}>
-            <h2 className={styles.sectionTitle}>Sync</h2>
-            <p className={styles.sectionSubtitle}>
-              Trigger a provider sync from the console. Your ID token loads automatically after sign-in, and the API
-              page can refresh it or create a session cookie when needed.
-            </p>
-          </div>
-          <div className={styles.block}>
-            <h3 className={styles.blockTitle}>Sync provider</h3>
-            <p className={styles.blockText}>
-              Run the queue-backed sync via{' '}
-              <code className={styles.inlineCode}>GET /api/widgets/sync/&#123;provider&#125;/stream</code>{' '}
-              so you can watch live steps and inspect the same final payload returned by the JSON endpoint.
-              {syncProvider === 'flickr' || syncProvider === 'discogs'
-                ? ' Flickr and Discogs manual sync load OAuth from your signed-in user when that provider is linked; otherwise the job uses server env credentials. Widget data still updates the default site owner path.'
-                : ''}
-            </p>
-            <div className={styles.endpoint}>
-              <span className={styles.methodGet}>GET</span>
-              <code className={styles.path}>/api/widgets/sync/&#123;provider&#125;/stream</code>
-              <div className={styles.controls}>
-                <select
-                  value={syncProvider}
-                  onChange={(e) => setSyncProvider(e.target.value)}
-                  className={styles.select}
-                >
-                  {SYNC_PROVIDERS.map((p) => (
-                    <option key={p} value={p}>
-                      {p}
-                    </option>
-                  ))}
-                </select>
-                <button
-                  type="button"
-                  className={styles.btnSecondary}
-                  onClick={testSync}
-                  disabled={!idToken || loading.sync}
-                >
-                  {loading.sync ? 'Testing…' : 'Test'}
-                </button>
-              </div>
-              {loading.sync && syncThinkingLine !== null ? (
-                <div className={styles.thinkingShell} role="status" aria-live="polite">
-                  <div className={styles.thinkingHeader}>
-                    <span className={styles.thinkingPulse} aria-hidden />
-                    <span className={styles.thinkingTitle}>Sync progress</span>
-                    <span className={styles.thinkingDots} aria-hidden>
-                      <span />
-                      <span />
-                      <span />
-                    </span>
-                  </div>
-                  <p key={syncThinkingLine} className={styles.thinkingLine}>
-                    {syncThinkingLine}
-                  </p>
-                </div>
-              ) : null}
-              {syncFlickrAuthMode ? (
-                <p
-                  className={`${styles.flickrAuthBadge} ${
-                    syncFlickrAuthMode === 'oauth'
-                      ? styles.flickrAuthBadgeOAuth
-                      : styles.flickrAuthBadgeLegacy
-                  }`}
-                  role="status"
-                >
-                  {syncFlickrAuthMode === 'oauth'
-                    ? 'Flickr credentials: OAuth (connected account)'
-                    : 'Flickr credentials: legacy (server API key)'}
-                </p>
-              ) : null}
-              {syncDiscogsAuthMode ? (
-                <p
-                  className={`${styles.flickrAuthBadge} ${
-                    syncDiscogsAuthMode === 'oauth'
-                      ? styles.flickrAuthBadgeOAuth
-                      : styles.flickrAuthBadgeLegacy
-                  }`}
-                  role="status"
-                >
-                  {syncDiscogsAuthMode === 'oauth'
-                    ? 'Discogs credentials: OAuth (connected account)'
-                    : 'Discogs credentials: legacy (personal token + username in env)'}
-                </p>
-              ) : null}
-              {syncResult && <ResultBox result={syncResult} />}
-            </div>
-          </div>
-        </>
+        <SyncPanel
+          syncProvider={syncProvider}
+          setSyncProvider={setSyncProvider}
+          idToken={idToken}
+          loading={loading}
+          syncThinkingLine={syncThinkingLine}
+          syncFlickrAuthMode={syncFlickrAuthMode}
+          syncDiscogsAuthMode={syncDiscogsAuthMode}
+          syncResult={syncResult}
+          onTestSync={testSync}
+        />
       )}
     </>
-  )
-}
-
-interface ResultBoxProps {
-  result: FetchResult
-}
-
-function ResultBox({ result }: ResultBoxProps) {
-  const isOk = result.ok
-  const status = result.status != null ? `${result.status}` : ''
-  const time = result.time != null ? `${result.time}ms` : ''
-  const body = result.data != null ? result.data : result.error
-
-  return (
-    <div className={`${styles.result} ${isOk ? styles.resultOk : styles.resultError}`}>
-      <div className={styles.resultHeader}>
-        <span className={styles.resultStatus}>
-          {isOk ? '✓' : '✗'} {status} {time}
-        </span>
-      </div>
-      <pre className={styles.resultBody}>
-        {typeof body === 'string' ? body : JSON.stringify(body, null, 2)}
-      </pre>
-    </div>
   )
 }

--- a/apps/console/src/sections/AuthSection.tsx
+++ b/apps/console/src/sections/AuthSection.tsx
@@ -117,7 +117,7 @@ export function AuthSection() {
           <div role="tabpanel" id="auth-panel-email" aria-labelledby="auth-tab-email">
             <form onSubmit={handleEmailSubmit} className={styles.form}>
               <label className={styles.label}>
-                Email
+                <span>Email</span>
                 <input
                   type="email"
                   value={email}
@@ -129,7 +129,7 @@ export function AuthSection() {
                 />
               </label>
               <label className={styles.label}>
-                Password
+                <span>Password</span>
                 <input
                   type="password"
                   value={password}

--- a/apps/console/src/sections/AuthSection.tsx
+++ b/apps/console/src/sections/AuthSection.tsx
@@ -162,7 +162,7 @@ export function AuthSection() {
             <div id="phone-recaptcha" />
             <form onSubmit={handlePhoneSubmit} className={styles.form}>
               <label className={styles.label}>
-                Phone number
+                <span>Phone number</span>
                 <input
                   type="tel"
                   value={phone}
@@ -175,7 +175,7 @@ export function AuthSection() {
               </label>
               {phoneStep === 'confirm' && (
                 <label className={styles.label}>
-                  Verification code
+                  <span>Verification code</span>
                   <input
                     type="text"
                     value={code}
@@ -188,7 +188,7 @@ export function AuthSection() {
                 </label>
               )}
               <button type="submit" className={styles.btnPrimary} disabled={loading}>
-                {loading ? '…' : phoneStep === 'send' ? 'Send code' : 'Verify'}
+                {phoneSubmitButtonLabel(loading, phoneStep)}
               </button>
             </form>
             <div className={styles.divider}>or</div>
@@ -226,6 +226,12 @@ export function AuthSection() {
       </div>
     </section>
   )
+}
+
+function phoneSubmitButtonLabel(loading: boolean, phoneStep: 'send' | 'confirm'): string {
+  if (loading) return '…'
+  if (phoneStep === 'send') return 'Send code'
+  return 'Verify'
 }
 
 function GoogleIcon() {

--- a/apps/console/src/sections/OnboardingSection.module.css
+++ b/apps/console/src/sections/OnboardingSection.module.css
@@ -55,19 +55,31 @@
 }
 
 .progressBarTrack {
+  display: block;
   width: 100%;
   height: 6px;
+  appearance: none;
+  border: none;
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.06);
   margin-bottom: 1.25rem;
   overflow: hidden;
 }
 
-.progressBarFill {
-  height: 100%;
+.progressBarTrack::-webkit-progress-bar {
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.progressBarTrack::-webkit-progress-value {
   border-radius: 999px;
   background: linear-gradient(90deg, var(--success), var(--accent));
   transition: width 0.35s ease;
+}
+
+.progressBarTrack::-moz-progress-bar {
+  border-radius: 999px;
+  background: linear-gradient(90deg, var(--success), var(--accent));
 }
 
 .saveError {
@@ -81,6 +93,7 @@
 }
 
 .oauthFlash {
+  display: block;
   padding: 0.75rem 1rem;
   margin-bottom: 1rem;
   background: rgba(52, 211, 153, 0.1);
@@ -706,7 +719,7 @@
     opacity: 0.9;
   }
 
-  .progressBarFill {
+  .progressBarTrack::-webkit-progress-value {
     transition: none;
   }
 }

--- a/apps/console/src/sections/OnboardingSection.tsx
+++ b/apps/console/src/sections/OnboardingSection.tsx
@@ -39,6 +39,12 @@ type UsernameStatus =
   | 'error'
 type DnsStatus = 'idle' | 'checking' | 'verified' | 'not-verified' | 'error'
 
+function oauthIntegrationLabel(id: string): 'Discogs' | 'GitHub' | 'Flickr' {
+  if (id === 'discogs') return 'Discogs'
+  if (id === 'github') return 'GitHub'
+  return 'Flickr'
+}
+
 function isStepId(v: string): v is StepId {
   return STEPS.some((s) => s.id === v)
 }
@@ -189,7 +195,9 @@ export function OnboardingSection() {
         setDomain(p.customDomain ?? '')
         setDnsStatus('idle')
         if (savedUsername.length >= 3) {
-          queueMicrotask(() => void checkUsername(savedUsername))
+          queueMicrotask(() => {
+            checkUsername(savedUsername).catch(() => {})
+          })
         }
       } catch {
         if (!cancelled) setSaveError('Could not load saved progress. You can still continue.')
@@ -214,8 +222,7 @@ export function OnboardingSection() {
     if (oauthProvider !== 'flickr' && oauthProvider !== 'discogs' && oauthProvider !== 'github') return
     const status = params.get('status')
     const reason = params.get('reason')
-    const label =
-      oauthProvider === 'discogs' ? 'Discogs' : oauthProvider === 'github' ? 'GitHub' : 'Flickr'
+    const label = oauthIntegrationLabel(oauthProvider)
     if (status === 'success') {
       setOauthFlash(`${label} is now linked to your account.`)
     } else if (status === 'error') {
@@ -230,7 +237,8 @@ export function OnboardingSection() {
     params.delete('status')
     params.delete('reason')
     const rest = params.toString()
-    const clean = `${window.location.pathname}${rest ? `?${rest}` : ''}`
+    const query = rest.length > 0 ? `?${rest}` : ''
+    const clean = `${window.location.pathname}${query}`
     window.history.replaceState(null, '', clean)
   }, [hydrated])
 
@@ -263,8 +271,7 @@ export function OnboardingSection() {
       }
       await reloadProgressFromServer()
     } catch (e) {
-      const label =
-        providerId === 'discogs' ? 'Discogs' : providerId === 'github' ? 'GitHub' : 'Flickr'
+      const label = oauthIntegrationLabel(providerId)
       setSaveError(e instanceof Error ? e.message : `Could not cancel ${label} link.`)
     }
   }
@@ -302,7 +309,9 @@ export function OnboardingSection() {
     setUsernameStatus('idle')
     if (usernameTimerRef.current) clearTimeout(usernameTimerRef.current)
     if (sanitized.length >= 3) {
-      usernameTimerRef.current = setTimeout(() => void checkUsername(sanitized), 500)
+      usernameTimerRef.current = setTimeout(() => {
+        checkUsername(sanitized).catch(() => {})
+      }, 500)
     }
   }
 
@@ -332,9 +341,11 @@ export function OnboardingSection() {
 
   const startDnsCheck = () => {
     if (!domain) return
-    void checkDns(domain)
+    checkDns(domain).catch(() => {})
     if (dnsPollingRef.current) clearInterval(dnsPollingRef.current)
-    dnsPollingRef.current = setInterval(() => void checkDns(domain), 15000)
+    dnsPollingRef.current = setInterval(() => {
+      checkDns(domain).catch(() => {})
+    }, 15000)
   }
 
   useEffect(() => {
@@ -382,7 +393,7 @@ export function OnboardingSection() {
       return
     }
     const t = setTimeout(() => {
-      void persistProgress(buildSnapshot())
+      persistProgress(buildSnapshot()).catch(() => {})
     }, 650)
     return () => clearTimeout(t)
   }, [user, hydrated, currentStep, connectedProviders, buildSnapshot, persistProgress])
@@ -399,7 +410,6 @@ export function OnboardingSection() {
   const visualStepIndex =
     currentStep === 'done' ? STEPS.length - 1 : STEPS.findIndex((s) => s.id === currentStep)
   const safeVisualIndex = visualStepIndex >= 0 ? visualStepIndex : 0
-  const progressPercent = ((safeVisualIndex + 1) / STEPS.length) * 100
   const stepMetaLabel = STEPS[safeVisualIndex]?.label ?? ''
 
   if (authLoading) {
@@ -467,21 +477,12 @@ export function OnboardingSection() {
               {saving && <span className={styles.savingBadge}>Saving…</span>}
             </div>
 
-            <div
+            <progress
               className={styles.progressBarTrack}
-              role="progressbar"
-              aria-valuemin={1}
-              aria-valuemax={STEPS.length}
-              aria-valuenow={safeVisualIndex + 1}
+              max={STEPS.length}
+              value={safeVisualIndex + 1}
               aria-label="Onboarding steps completed"
-            >
-              <div
-                className={styles.progressBarFill}
-                style={{
-                  width: `${progressPercent}%`,
-                }}
-              />
-            </div>
+            />
 
             <div className={styles.stepIndicator}>
               {STEPS.map((step, i) => (
@@ -491,7 +492,9 @@ export function OnboardingSection() {
                     className={`${styles.stepDot} ${
                       currentStep === step.id ? styles.stepDotActive : ''
                     } ${completedSteps.has(step.id) ? styles.stepDotDone : ''}`}
-                    onClick={() => void navigateToStep(step.id)}
+                    onClick={() => {
+                      navigateToStep(step.id).catch(() => {})
+                    }}
                     aria-current={currentStep === step.id ? 'step' : undefined}
                   >
                     {completedSteps.has(step.id) ? <CheckIcon /> : <span>{i + 1}</span>}
@@ -515,9 +518,9 @@ export function OnboardingSection() {
             )}
 
             {oauthFlash && (
-              <div className={styles.oauthFlash} role="status">
+              <output className={styles.oauthFlash} aria-live="polite">
                 {oauthFlash}
-              </div>
+              </output>
             )}
 
             {currentStep === 'username' && (
@@ -579,7 +582,9 @@ export function OnboardingSection() {
               type="button"
               className={styles.btnPrimary}
               disabled={usernameStatus !== 'available' || saving}
-              onClick={() => void handleStepComplete('username')}
+              onClick={() => {
+                handleStepComplete('username').catch(() => {})
+              }}
             >
               Continue
             </button>
@@ -603,21 +608,39 @@ export function OnboardingSection() {
 
             {integrationStatuses.flickr === 'pending_oauth' && (
               <p className={styles.oauthCancelRow}>
-                <button type="button" className={styles.oauthCancelBtn} onClick={() => void cancelOAuthPending('flickr')}>
+                <button
+                  type="button"
+                  className={styles.oauthCancelBtn}
+                  onClick={() => {
+                    cancelOAuthPending('flickr').catch(() => {})
+                  }}
+                >
                   Cancel Flickr link
                 </button>
               </p>
             )}
             {integrationStatuses.discogs === 'pending_oauth' && (
               <p className={styles.oauthCancelRow}>
-                <button type="button" className={styles.oauthCancelBtn} onClick={() => void cancelOAuthPending('discogs')}>
+                <button
+                  type="button"
+                  className={styles.oauthCancelBtn}
+                  onClick={() => {
+                    cancelOAuthPending('discogs').catch(() => {})
+                  }}
+                >
                   Cancel Discogs link
                 </button>
               </p>
             )}
             {integrationStatuses.github === 'pending_oauth' && (
               <p className={styles.oauthCancelRow}>
-                <button type="button" className={styles.oauthCancelBtn} onClick={() => void cancelOAuthPending('github')}>
+                <button
+                  type="button"
+                  className={styles.oauthCancelBtn}
+                  onClick={() => {
+                    cancelOAuthPending('github').catch(() => {})
+                  }}
+                >
                   Cancel GitHub link
                 </button>
               </p>
@@ -628,7 +651,9 @@ export function OnboardingSection() {
                 type="button"
                 className={styles.btnSecondary}
                 disabled={saving}
-                onClick={() => void handleStepComplete('connections')}
+                onClick={() => {
+                  handleStepComplete('connections').catch(() => {})
+                }}
               >
                 Skip for now
               </button>
@@ -636,7 +661,9 @@ export function OnboardingSection() {
                 type="button"
                 className={styles.btnPrimary}
                 disabled={saving}
-                onClick={() => void handleStepComplete('connections')}
+                onClick={() => {
+                  handleStepComplete('connections').catch(() => {})
+                }}
               >
                 Continue
                 {connectedProviders.size > 0 && (
@@ -656,7 +683,7 @@ export function OnboardingSection() {
             </p>
 
             <label className={styles.label}>
-              Domain name
+              <span>Domain name</span>
               <input
                 type="text"
                 value={domain}
@@ -689,7 +716,8 @@ export function OnboardingSection() {
                   {dnsStatus === 'checking' ? (
                     <>
                       <span className="spinner" aria-hidden />
-                      Verifying…
+                      {' '}
+                      <span>Verifying…</span>
                     </>
                   ) : (
                     'Verify DNS'
@@ -740,7 +768,9 @@ export function OnboardingSection() {
                 type="button"
                 className={styles.btnSecondary}
                 disabled={saving}
-                onClick={() => void handleStepComplete('domain')}
+                onClick={() => {
+                  handleStepComplete('domain').catch(() => {})
+                }}
               >
                 Skip for now
               </button>
@@ -748,7 +778,9 @@ export function OnboardingSection() {
                 type="button"
                 className={styles.btnPrimary}
                 disabled={saving}
-                onClick={() => void handleStepComplete('domain')}
+                onClick={() => {
+                  handleStepComplete('domain').catch(() => {})
+                }}
               >
                 Finish setup
               </button>

--- a/apps/console/src/sections/OverviewSection.tsx
+++ b/apps/console/src/sections/OverviewSection.tsx
@@ -139,7 +139,11 @@ function OverviewProviderCard({
     <article className={`${styles.card} ${s.loading ? styles.cardLoading : ''}`} style={cardStyle}>
       <div className={styles.cardHeader}>
         <span className={styles.providerName}>{provider.label}</span>
-        <span className={`${styles.dot} ${dotClassForTone(tone)}`} aria-label={dotAriaLabel(s)} />
+        <span
+          className={`${styles.dot} ${dotClassForTone(tone)}`}
+          role="img"
+          aria-label={dotAriaLabel(s)}
+        />
       </div>
 
       {body}

--- a/apps/console/src/sections/OverviewSection.tsx
+++ b/apps/console/src/sections/OverviewSection.tsx
@@ -1,6 +1,13 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from 'react'
 import Link from 'next/link'
 import { useAuth } from '@/auth/AuthContext'
 import { apiClient } from '@/auth/apiClient'
@@ -39,6 +46,18 @@ interface ProviderState {
   lastSynced: string | null
 }
 
+function dotTone(s: ProviderState): 'pending' | 'ok' | 'bad' {
+  if (s.loading) return 'pending'
+  if (s.ok) return 'ok'
+  return 'bad'
+}
+
+function dotAriaLabel(s: ProviderState): string {
+  if (s.loading) return 'checking'
+  if (s.ok) return 'healthy'
+  return 'error'
+}
+
 function formatRelative(iso: string | null): string {
   if (!iso) return '—'
   const d = new Date(iso)
@@ -62,6 +81,77 @@ const initialState = (): ProviderState => ({
   lastSynced: null,
 })
 
+function dotClassForTone(tone: 'pending' | 'ok' | 'bad'): string {
+  switch (tone) {
+    case 'pending':
+      return styles.dotPending ?? ''
+    case 'ok':
+      return styles.dotOk ?? ''
+    default:
+      return styles.dotBad ?? ''
+  }
+}
+
+function OverviewProviderCard({
+  provider,
+  index,
+  state: s,
+}: {
+  provider: ProviderConfig
+  index: number
+  state: ProviderState
+}) {
+  const tone = dotTone(s)
+  const cardStyle = {
+    '--delay': String(index * 72),
+    '--card-accent': provider.accent,
+  } as CSSProperties
+
+  let body: ReactNode
+  if (s.loading) {
+    body = (
+      <div className={styles.skeleton}>
+        <div className={styles.skeletonLine} />
+        <div className={styles.skeletonLine} style={{ width: '55%' }} />
+      </div>
+    )
+  } else if (s.metrics.length > 0) {
+    body = (
+      <ul className={styles.metricList}>
+        {s.metrics.map((m) => (
+          <li key={m.displayName} className={styles.metric}>
+            <span className={styles.metricValue}>{m.value.toLocaleString()}</span>
+            <span className={styles.metricLabel}>{m.displayName}</span>
+          </li>
+        ))}
+      </ul>
+    )
+  } else {
+    body = <p className={styles.noData}>{s.ok ? 'Live — no stored metrics' : 'Unavailable'}</p>
+  }
+
+  let latencyText = '—'
+  if (!s.loading && s.ms != null) {
+    latencyText = `${s.ms}ms`
+  }
+
+  return (
+    <article className={`${styles.card} ${s.loading ? styles.cardLoading : ''}`} style={cardStyle}>
+      <div className={styles.cardHeader}>
+        <span className={styles.providerName}>{provider.label}</span>
+        <span className={`${styles.dot} ${dotClassForTone(tone)}`} aria-label={dotAriaLabel(s)} />
+      </div>
+
+      {body}
+
+      <div className={styles.cardFooter}>
+        <span className={styles.latency}>{latencyText}</span>
+        <span className={styles.synced}>{s.loading ? '—' : formatRelative(s.lastSynced)}</span>
+      </div>
+    </article>
+  )
+}
+
 export function OverviewSection() {
   const { user, apiSessionReady } = useAuth()
   const baseUrl = getAppBaseUrl()
@@ -81,7 +171,7 @@ export function OverviewSection() {
       return
     }
     let cancelled = false
-    void (async () => {
+    ;(async () => {
       try {
         const idToken = await user.getIdToken()
         const res = await apiClient.getJson('/api/onboarding/progress', { idToken })
@@ -100,7 +190,7 @@ export function OverviewSection() {
           setPublicUsername(null)
         }
       }
-    })()
+    })().catch(() => {})
     return () => {
       cancelled = true
     }
@@ -148,7 +238,7 @@ export function OverviewSection() {
   }, [baseUrl])
 
   useEffect(() => {
-    void fetchAll()
+    fetchAll().catch(() => {})
   }, [fetchAll])
 
   useEffect(() => {
@@ -162,14 +252,15 @@ export function OverviewSection() {
     if (!openFlyout) return
 
     setAddProvidersOpen(true)
-    void fetchAll()
+    fetchAll().catch(() => {})
 
     params.delete('providers')
     params.delete('oauth')
     params.delete('status')
     params.delete('reason')
     const rest = params.toString()
-    const clean = `${window.location.pathname}${rest ? `?${rest}` : ''}`
+    const query = rest.length > 0 ? `?${rest}` : ''
+    const clean = `${window.location.pathname}${query}`
     window.history.replaceState(null, '', clean)
   }, [user, apiSessionReady, fetchAll])
 
@@ -225,69 +316,20 @@ export function OverviewSection() {
       <AddProvidersFlyout
         open={addProvidersOpen}
         onClose={() => setAddProvidersOpen(false)}
-        onSaved={() => void fetchAll()}
+        onSaved={() => {
+          fetchAll().catch(() => {})
+        }}
       />
 
       <div className={styles.grid}>
-        {PROVIDERS.map((provider, index) => {
-          const s = states[provider.id] ?? initialState()
-          return (
-            <article
-              key={provider.id}
-              className={`${styles.card} ${s.loading ? styles.cardLoading : ''}`}
-              style={
-                {
-                  '--delay': String(index * 72),
-                  '--card-accent': provider.accent,
-                } as React.CSSProperties
-              }
-            >
-              <div className={styles.cardHeader}>
-                <span className={styles.providerName}>{provider.label}</span>
-                <span
-                  className={`${styles.dot} ${
-                    s.loading
-                      ? styles.dotPending
-                      : s.ok
-                        ? styles.dotOk
-                        : styles.dotBad
-                  }`}
-                  role="img"
-                  aria-label={s.loading ? 'checking' : s.ok ? 'healthy' : 'error'}
-                />
-              </div>
-
-              {s.loading ? (
-                <div className={styles.skeleton}>
-                  <div className={styles.skeletonLine} />
-                  <div className={styles.skeletonLine} style={{ width: '55%' }} />
-                </div>
-              ) : s.metrics.length > 0 ? (
-                <ul className={styles.metricList}>
-                  {s.metrics.map((m) => (
-                    <li key={m.displayName} className={styles.metric}>
-                      <span className={styles.metricValue}>{m.value.toLocaleString()}</span>
-                      <span className={styles.metricLabel}>{m.displayName}</span>
-                    </li>
-                  ))}
-                </ul>
-              ) : (
-                <p className={styles.noData}>
-                  {s.ok ? 'Live — no stored metrics' : 'Unavailable'}
-                </p>
-              )}
-
-              <div className={styles.cardFooter}>
-                <span className={styles.latency}>
-                  {s.loading ? '—' : s.ms != null ? `${s.ms}ms` : '—'}
-                </span>
-                <span className={styles.synced}>
-                  {s.loading ? '—' : formatRelative(s.lastSynced)}
-                </span>
-              </div>
-            </article>
-          )
-        })}
+        {PROVIDERS.map((provider, index) => (
+          <OverviewProviderCard
+            key={provider.id}
+            provider={provider}
+            index={index}
+            state={states[provider.id] ?? initialState()}
+          />
+        ))}
       </div>
     </div>
   )

--- a/apps/console/src/sections/SchemaSection.tsx
+++ b/apps/console/src/sections/SchemaSection.tsx
@@ -39,10 +39,10 @@ const accountDeleteExample = {
 function SchemaResponseCell({
   example,
   errorHint,
-}: {
+}: Readonly<{
   example: unknown
   errorHint?: string
-}) {
+}>) {
   const [showHighlighted, setShowHighlighted] = useState(false)
   const compact = JSON.stringify(example)
   const preview = compact.length > 96 ? `${compact.slice(0, 93)}…` : compact
@@ -223,7 +223,7 @@ export function SchemaSection() {
                   />
                 </td>
                 <td className={styles.notes}>
-                  <code className={styles.inlineCode}>Authorization: Bearer &lt;Firebase ID token&gt;</code>
+                  <code className={styles.inlineCode}>Authorization: Bearer &lt;Firebase ID token&gt;</code>{' '}
                   — sets HTTP-only session cookie.
                 </td>
               </tr>

--- a/apps/console/src/sections/SignUpSection.tsx
+++ b/apps/console/src/sections/SignUpSection.tsx
@@ -68,7 +68,7 @@ export function SignUpSection() {
 
         <form onSubmit={handleSubmit} className={styles.form}>
           <label className={styles.label}>
-            Email
+            <span>Email</span>
             <input
               type="email"
               value={email}
@@ -80,7 +80,7 @@ export function SignUpSection() {
             />
           </label>
           <label className={styles.label}>
-            Password
+            <span>Password</span>
             <input
               type="password"
               value={password}
@@ -93,7 +93,7 @@ export function SignUpSection() {
             />
           </label>
           <label className={styles.label}>
-            Confirm password
+            <span>Confirm password</span>
             <input
               type="password"
               value={confirmPassword}

--- a/apps/console/src/sections/StatusSection.tsx
+++ b/apps/console/src/sections/StatusSection.tsx
@@ -42,6 +42,42 @@ const initialRow = (): RowState => ({
   error: null,
 })
 
+function statusLabelForRow(s: RowState): string {
+  if (s.loading) {
+    return '…'
+  }
+  if (s.error) {
+    return 'Error'
+  }
+  if (s.httpStatus != null) {
+    return String(s.httpStatus)
+  }
+  return '—'
+}
+
+function okClassForRow(s: RowState): string {
+  if (s.loading) {
+    return styles.pending ?? ''
+  }
+  if (s.ok) {
+    return styles.cellOk ?? ''
+  }
+  if (s.error || s.ok === false) {
+    return styles.cellBad ?? ''
+  }
+  return ''
+}
+
+function latencyLabelForRow(s: RowState): string {
+  if (s.loading) {
+    return '…'
+  }
+  if (s.ms != null) {
+    return `${s.ms}ms`
+  }
+  return '—'
+}
+
 export function StatusSection() {
   const { user } = useAuth()
   const baseUrl = getAppBaseUrl()
@@ -109,7 +145,7 @@ export function StatusSection() {
   }, [baseUrl, activeRoutes])
 
   useEffect(() => {
-    void runChecks()
+    runChecks().catch(() => undefined)
   }, [runChecks])
 
   return (
@@ -135,7 +171,14 @@ export function StatusSection() {
             </>
           )}
         </p>
-        <button type="button" className={styles.refresh} onClick={() => void runChecks()} disabled={checking}>
+        <button
+          type="button"
+          className={styles.refresh}
+          onClick={() => {
+            runChecks().catch(() => undefined)
+          }}
+          disabled={checking}
+        >
           {checking ? 'Checking…' : 'Refresh'}
         </button>
       </div>
@@ -153,10 +196,8 @@ export function StatusSection() {
           <tbody>
             {activeRoutes.map((r) => {
               const s = rows[r.id] ?? initialRow()
-              const statusLabel =
-                s.loading ? '…' : s.error ? 'Error' : s.httpStatus != null ? String(s.httpStatus) : '—'
-              const okClass =
-                s.loading ? styles.pending : s.ok ? styles.cellOk : s.error || s.ok === false ? styles.cellBad : ''
+              const statusLabel = statusLabelForRow(s)
+              const okClass = okClassForRow(s)
               return (
                 <tr key={r.id}>
                   <td>
@@ -172,7 +213,7 @@ export function StatusSection() {
                       statusLabel
                     )}
                   </td>
-                  <td>{s.loading ? '…' : s.ms != null ? `${s.ms}ms` : '—'}</td>
+                  <td>{latencyLabelForRow(s)}</td>
                   <td className={styles.syncedCell}>
                     {s.loading ? '…' : formatSyncedDisplay(s.lastSynced)}
                   </td>

--- a/apps/console/src/sections/UserSettingsSection.tsx
+++ b/apps/console/src/sections/UserSettingsSection.tsx
@@ -86,7 +86,9 @@ export function UserSettingsSection() {
           value={activeTheme}
           disabled={saving}
           labelledBy="appearance-heading"
-          onSelect={(id) => void saveTheme(id)}
+          onSelect={(id) => {
+            saveTheme(id).catch(() => undefined)
+          }}
         />
 
         {saving ? <p className={styles.hint}>Saving…</p> : null}

--- a/apps/console/src/sections/VerifyEmailSection.tsx
+++ b/apps/console/src/sections/VerifyEmailSection.tsx
@@ -8,6 +8,16 @@ import { useAuth } from '../auth/AuthContext'
 import { mustVerifyEmailBeforeConsole } from '../lib/emailVerificationGate'
 import styles from './VerifyEmailSection.module.css'
 
+function applyActionCodeErrorMessage(e: { code?: string; message?: string }): string {
+  if (e.code === 'auth/expired-action-code') {
+    return 'This link has expired. Sign in and use “Resend verification email” below.'
+  }
+  if (e.code === 'auth/invalid-action-code') {
+    return 'This verification link is invalid or was already used.'
+  }
+  return e.message ?? 'Could not verify your email.'
+}
+
 export function VerifyEmailSection() {
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -37,13 +47,7 @@ export function VerifyEmailSection() {
       })
       .catch((e: { code?: string; message?: string }) => {
         if (cancelled) return
-        const msg =
-          e.code === 'auth/expired-action-code'
-            ? 'This link has expired. Sign in and use “Resend verification email” below.'
-            : e.code === 'auth/invalid-action-code'
-              ? 'This verification link is invalid or was already used.'
-              : e.message ?? 'Could not verify your email.'
-        setError(msg)
+        setError(applyActionCodeErrorMessage(e))
         setCodeHandled(true)
       })
       .finally(() => {
@@ -143,13 +147,21 @@ export function VerifyEmailSection() {
             type="button"
             className={styles.button}
             disabled={actionLoading}
-            onClick={() => void onResend()}
+            onClick={() => {
+              onResend().catch(() => undefined)
+            }}
           >
             Resend verification email
           </button>
         </div>
         <p className={styles.linkMuted}>
-          <button type="button" className={styles.link} onClick={() => void logout()}>
+          <button
+            type="button"
+            className={styles.link}
+            onClick={() => {
+              logout().catch(() => undefined)
+            }}
+          >
             Sign out
           </button>
         </p>

--- a/apps/console/src/theme/ThemeSync.tsx
+++ b/apps/console/src/theme/ThemeSync.tsx
@@ -10,7 +10,11 @@ import { isChronogroveTheme, normalizeChronogroveThemeId } from '@/theme/chronog
  * After Firebase session is ready, load `settings.theme` from the API and align next-themes.
  * Logout does not reset UI theme (keep last choice until next full load).
  */
-export function ThemeSync({ children }: { children: ReactNode }) {
+type ThemeSyncProps = Readonly<{
+  children: ReactNode
+}>
+
+export function ThemeSync({ children }: ThemeSyncProps) {
   const { user, apiSessionReady } = useAuth()
   const { setTheme, resolvedTheme } = useTheme()
 

--- a/functions/adapters/storage/firestore-document-store.ts
+++ b/functions/adapters/storage/firestore-document-store.ts
@@ -10,10 +10,7 @@ function toCollectionAndDocument(path: string): { collectionPath: string; docume
     throw new Error(`Invalid document path: ${path}`)
   }
 
-  const documentId = segments[segments.length - 1]
-  if (documentId === undefined) {
-    throw new Error(`Invalid document path: ${path}`)
-  }
+  const documentId = segments[segments.length - 1]!
 
   return {
     collectionPath: segments.slice(0, -1).join('/'),

--- a/functions/adapters/storage/firestore-document-store.ts
+++ b/functions/adapters/storage/firestore-document-store.ts
@@ -10,9 +10,14 @@ function toCollectionAndDocument(path: string): { collectionPath: string; docume
     throw new Error(`Invalid document path: ${path}`)
   }
 
+  const documentId = segments[segments.length - 1]
+  if (documentId === undefined) {
+    throw new Error(`Invalid document path: ${path}`)
+  }
+
   return {
     collectionPath: segments.slice(0, -1).join('/'),
-    documentId: segments.at(-1)!,
+    documentId,
   }
 }
 

--- a/functions/adapters/storage/local-disk-media-store.test.ts
+++ b/functions/adapters/storage/local-disk-media-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync, promises as fsPromises } from 'fs'
 import { tmpdir } from 'os'
 import path from 'path'
 import { Readable } from 'stream'
@@ -145,6 +145,20 @@ describe('LocalDiskMediaStore', () => {
         mediaURL: 'https://example.com/test.txt',
       }),
     ).rejects.toThrow(/Failed to upload nested\/test\.txt: /)
+  })
+
+  it('wraps non-Error mkdir failures via rejectAsError', async () => {
+    const mkdirSpy = vi.spyOn(fsPromises, 'mkdir').mockRejectedValueOnce('disk full')
+
+    await expect(
+      adapter.fetchAndStore({
+        destinationPath: 'nested/mkdir-fail.txt',
+        id: 'media-mkdir',
+        mediaURL: 'https://example.com/x.bin',
+      }),
+    ).rejects.toThrow('disk full')
+
+    mkdirSpy.mockRestore()
   })
 
   it('rejects when mkdir fails because rootDirectory is not a directory', async () => {

--- a/functions/adapters/storage/local-disk-media-store.ts
+++ b/functions/adapters/storage/local-disk-media-store.ts
@@ -25,6 +25,45 @@ async function listFilesRecursive(rootDirectory: string, currentDirectory = ''):
   return nestedFiles.flat()
 }
 
+function rejectAsError(reason: unknown): Error {
+  return reason instanceof Error ? reason : new Error(String(reason))
+}
+
+async function downloadHttpsToFile(
+  mediaURL: string,
+  absoluteDestinationPath: string,
+  destinationPath: string,
+  id: string
+): Promise<void> {
+  await fs.mkdir(path.dirname(absoluteDestinationPath), { recursive: true })
+
+  await new Promise<void>((resolve, reject) => {
+    https
+      .get(mediaURL, (res) => {
+        const writeStream = createWriteStream(absoluteDestinationPath)
+        res.pipe(writeStream)
+
+        const onFinish = () => {
+          writeStream.close((closeErr) => {
+            if (closeErr) {
+              reject(new Error(`Failed to upload ${destinationPath}: ${closeErr.message}`))
+              return
+            }
+            resolve()
+          })
+        }
+
+        writeStream.on('finish', onFinish)
+        writeStream.on('error', (err) => {
+          reject(new Error(`Failed to upload ${destinationPath}: ${err.message}`))
+        })
+      })
+      .on('error', (err) => {
+        reject(new Error(`Failed to download media for ${id}: ${err.message}`))
+      })
+  })
+}
+
 export class LocalDiskMediaStore implements MediaStore {
   constructor(private readonly rootDirectory: string) {}
 
@@ -40,42 +79,23 @@ export class LocalDiskMediaStore implements MediaStore {
     }
   }
 
-  fetchAndStore({ destinationPath, mediaURL, id }: MediaDescriptor): Promise<StoredMedia> {
-    return new Promise((resolve, reject) => {
-      if (!mediaURL) {
-        reject(new Error(`Missing media to download for ${id}.`))
-        return
-      }
+  async fetchAndStore({ destinationPath, mediaURL, id }: MediaDescriptor): Promise<StoredMedia> {
+    if (!mediaURL) {
+      throw new Error(`Missing media to download for ${id}.`)
+    }
 
-      void (async () => {
-        const absoluteDestinationPath = this.resolveAbsolutePath(destinationPath)
+    const absoluteDestinationPath = this.resolveAbsolutePath(destinationPath)
 
-        await fs.mkdir(path.dirname(absoluteDestinationPath), { recursive: true })
+    try {
+      await downloadHttpsToFile(mediaURL, absoluteDestinationPath, destinationPath, id)
+    } catch (error) {
+      throw rejectAsError(error)
+    }
 
-        https.get(mediaURL, (res) => {
-          const writeStream = createWriteStream(absoluteDestinationPath)
-
-          res.pipe(writeStream)
-
-          writeStream.on('finish', () => {
-            writeStream.close(() => {
-              resolve({
-                id,
-                fileName: destinationPath,
-              })
-            })
-          })
-
-          writeStream.on('error', (err) => {
-            reject(new Error(`Failed to upload ${destinationPath}: ${err.message}`))
-          })
-        }).on('error', (err) => {
-          reject(new Error(`Failed to download media for ${id}: ${err.message}`))
-        })
-      })().catch((error) => {
-        reject(error)
-      })
-    })
+    return {
+      id,
+      fileName: destinationPath,
+    }
   }
 
   describe() {

--- a/functions/adapters/storage/local-disk-media-store.write-close-error.test.ts
+++ b/functions/adapters/storage/local-disk-media-store.write-close-error.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mkdtempSync, rmSync } from 'fs'
+import path from 'path'
+import { tmpdir } from 'os'
+import { Readable, Writable } from 'stream'
+
+const mockHttpsGet = vi.hoisted(() => vi.fn())
+
+vi.mock('https', () => ({
+  default: { get: mockHttpsGet },
+  get: mockHttpsGet,
+}))
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>()
+  return {
+    ...actual,
+    createWriteStream: vi.fn((_p: string) => {
+      const ws = new Writable({
+        write(_chunk, _encoding, callback) {
+          callback()
+        },
+      })
+      Object.assign(ws, {
+        close(cb: (err?: Error) => void) {
+          queueMicrotask(() => cb(new Error('close flush failed')))
+        },
+      })
+      return ws as ReturnType<typeof actual.createWriteStream>
+    }),
+  }
+})
+
+describe('LocalDiskMediaStore writeStream.close error path', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    const https = await import('https')
+    const mod = https as { default: { get: typeof mockHttpsGet }; get: typeof mockHttpsGet }
+    mod.default.get.mockImplementation(mod.get)
+  })
+
+  it('rejects when close reports an error after the download pipe finishes', async () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'disk-close-'))
+    try {
+      const { LocalDiskMediaStore } = await import('./local-disk-media-store.js')
+      const adapter = new LocalDiskMediaStore(root)
+
+      mockHttpsGet.mockImplementation((_url: string, callback: (res: Readable) => void) => {
+        const response = new Readable({
+          read() {
+            this.push('x')
+            this.push(null)
+          },
+        })
+        callback(response)
+        return { on: vi.fn() }
+      })
+
+      await expect(
+        adapter.fetchAndStore({
+          destinationPath: 'nested/f.txt',
+          id: 'id1',
+          mediaURL: 'https://example.com/x.bin',
+        }),
+      ).rejects.toThrow('Failed to upload nested/f.txt: close flush failed')
+
+      const fs = await import('fs')
+      expect(fs.createWriteStream).toHaveBeenCalled()
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/functions/adapters/sync/firestore-sync-job-queue.test.ts
+++ b/functions/adapters/sync/firestore-sync-job-queue.test.ts
@@ -417,6 +417,27 @@ describe('FirestoreSyncJobQueue', () => {
     )
   })
 
+  it('stringifies non-message objects and uses Unknown error when stringify throws', async () => {
+    const queue = new FirestoreSyncJobQueue()
+    const summary = { durationMs: 1, result: 'FAILURE' as const }
+
+    mockDocSet.mockClear()
+    await queue.failJob('sync-chrisvogt-steam', { code: 'x', status: 418 }, summary)
+    expect(mockDocSet).toHaveBeenCalledWith(
+      expect.objectContaining({ error: '{"code":"x","status":418}' }),
+      { merge: true },
+    )
+
+    const circular: Record<string, unknown> = { a: 1 }
+    circular.self = circular
+    mockDocSet.mockClear()
+    await queue.failJob('sync-chrisvogt-steam', circular, summary)
+    expect(mockDocSet).toHaveBeenCalledWith(
+      expect.objectContaining({ error: 'Unknown error' }),
+      { merge: true },
+    )
+  })
+
   it('maps queue snapshots back to stored jobs', () => {
     const storedJob = {
       ...baseJob,

--- a/functions/adapters/sync/firestore-sync-job-queue.ts
+++ b/functions/adapters/sync/firestore-sync-job-queue.ts
@@ -21,10 +21,24 @@ const SYNC_JOBS_COLLECTION = 'sync_jobs'
 const toSyncJobId = ({ mode, provider, userId }: QueuedSyncJobDescriptor) =>
   `${mode}-${userId}-${provider}`
 
-const toErrorMessage = (error: unknown): string =>
-  error instanceof Error
-    ? error.message
-    : (error as { message?: string })?.message ?? String(error)
+const toErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message
+  }
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'message' in error &&
+    typeof (error as { message: unknown }).message === 'string'
+  ) {
+    return (error as { message: string }).message
+  }
+  try {
+    return JSON.stringify(error)
+  } catch {
+    return 'Unknown error'
+  }
+}
 
 export class FirestoreSyncJobQueue implements SyncJobQueue {
   async getJob(jobId: string): Promise<QueuedSyncJob | null> {

--- a/functions/adapters/sync/firestore-sync-job-queue.ts
+++ b/functions/adapters/sync/firestore-sync-job-queue.ts
@@ -25,6 +25,9 @@ const toErrorMessage = (error: unknown): string => {
   if (error instanceof Error) {
     return error.message
   }
+  if (typeof error === 'string') {
+    return error
+  }
   if (
     typeof error === 'object' &&
     error !== null &&

--- a/functions/api/ai-summary/generate-steam-summary.test.ts
+++ b/functions/api/ai-summary/generate-steam-summary.test.ts
@@ -208,4 +208,22 @@ describe('generateSteamSummary', () => {
       'Failed to generate AI summary: AI summary API error (401): invalid x-api-key',
     )
   })
+
+  it('formats unknown errors with object message and JSON fallbacks in the thrown wrapper', async () => {
+    mockFetch.mockRejectedValueOnce({ message: 404 })
+
+    await expect(generateSteamSummary(mockSteamData)).rejects.toThrow(
+      'Failed to generate AI summary: {"message":404}',
+    )
+  })
+
+  it('uses Unknown error when JSON.stringify fails on a thrown value', async () => {
+    const circular: Record<string, unknown> = { a: 1 }
+    circular.self = circular
+    mockFetch.mockRejectedValueOnce(circular)
+
+    await expect(generateSteamSummary(mockSteamData)).rejects.toThrow(
+      'Failed to generate AI summary: Unknown error',
+    )
+  })
 })

--- a/functions/api/ai-summary/generate-steam-summary.test.ts
+++ b/functions/api/ai-summary/generate-steam-summary.test.ts
@@ -217,6 +217,14 @@ describe('generateSteamSummary', () => {
     )
   })
 
+  it('uses string message property on non-Error rejections', async () => {
+    mockFetch.mockRejectedValueOnce({ message: 'from nested message' })
+
+    await expect(generateSteamSummary(mockSteamData)).rejects.toThrow(
+      'Failed to generate AI summary: from nested message',
+    )
+  })
+
   it('uses Unknown error when JSON.stringify fails on a thrown value', async () => {
     const circular: Record<string, unknown> = { a: 1 }
     circular.self = circular

--- a/functions/api/ai-summary/generate-steam-summary.ts
+++ b/functions/api/ai-summary/generate-steam-summary.ts
@@ -9,6 +9,9 @@ function messageFromUnknownError(error: unknown): string {
   if (error instanceof Error) {
     return error.message
   }
+  if (typeof error === 'string') {
+    return error
+  }
   if (typeof error === 'object' && error !== null && 'message' in error) {
     const m = (error as { message: unknown }).message
     if (typeof m === 'string') {

--- a/functions/api/ai-summary/generate-steam-summary.ts
+++ b/functions/api/ai-summary/generate-steam-summary.ts
@@ -5,6 +5,23 @@ import type { SteamSummaryInput } from '../../types/steam.js'
 import { requestAiSummaryCompletion } from '../../utils/ai-summary-messages.js'
 import extractJsonFromAiResponse from '../../utils/extract-json-from-ai-response.js'
 
+function messageFromUnknownError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message
+  }
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    const m = (error as { message: unknown }).message
+    if (typeof m === 'string') {
+      return m
+    }
+  }
+  try {
+    return JSON.stringify(error)
+  } catch {
+    return 'Unknown error'
+  }
+}
+
 /**
  * Generate AI summary of Steam gaming data (LLM JSON → HTML paragraphs).
  */
@@ -71,8 +88,7 @@ Total Games Owned: ${metrics.find(m => m.id === 'owned-games-count')?.value || 0
     return typeof raw === 'string' ? raw : ''
   } catch (error: unknown) {
     logger.error('Error generating Steam AI summary:', error)
-    const message = error instanceof Error ? error.message : String(error)
-    throw new Error(`Failed to generate AI summary: ${message}`, { cause: error })
+    throw new Error(`Failed to generate AI summary: ${messageFromUnknownError(error)}`, { cause: error })
   }
 }
 

--- a/functions/api/discogs/fetch-release-details.test.ts
+++ b/functions/api/discogs/fetch-release-details.test.ts
@@ -99,6 +99,27 @@ describe('fetchReleaseDetails', () => {
     expect(result).toEqual(mockReleaseData)
   })
 
+  it('appends token with & when the resource URL already has query parameters', async () => {
+    vi.stubEnv('DISCOGS_API_KEY', 'test-api-key')
+
+    const fetchReleaseDetails = (await import('./fetch-release-details.js')).default
+    const mockReleaseData = { id: 7, title: 'With Query' }
+
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockReleaseData,
+    })
+
+    await fetchReleaseDetails('https://api.discogs.com/releases/7?curr_abbr=USD', '7')
+
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.discogs.com/releases/7?curr_abbr=USD&token=test-api-key',
+      expect.objectContaining({
+        headers: { 'User-Agent': chronogroveHttpUserAgent },
+      }),
+    )
+  })
+
   it('should return null when API request fails', async () => {
     vi.stubEnv('DISCOGS_API_KEY', 'test-api-key')
     

--- a/functions/api/discogs/fetch-release-details.ts
+++ b/functions/api/discogs/fetch-release-details.ts
@@ -5,6 +5,75 @@ import { chronogroveHttpUserAgent } from '../../config/chronogrove-http-user-age
 import type { ResolvedDiscogsApiAuth } from '../../services/discogs-integration-credentials.js'
 import { discogsOAuthGotGet } from '../../services/discogs-oauth1a.js'
 
+function buildReleaseFetchUrl(
+  resourceUrl: string,
+  apiKey: string | undefined,
+  oauth?: ResolvedDiscogsApiAuth
+): string {
+  if (oauth || resourceUrl.includes('token=')) {
+    return resourceUrl
+  }
+  if (!apiKey) {
+    throw new Error('Missing required environment variable: DISCOGS_API_KEY')
+  }
+  const separator = resourceUrl.includes('?') ? '&' : '?'
+  return `${resourceUrl}${separator}token=${apiKey}`
+}
+
+type FetchAttemptResult =
+  | { outcome: 'success'; data: unknown }
+  | { outcome: 'failed' }
+  | { outcome: 'rate_limited'; waitMs: number }
+
+async function fetchReleaseOnce(
+  oauth: ResolvedDiscogsApiAuth | undefined,
+  resourceUrl: string,
+  urlWithAuth: string,
+  releaseId: string,
+  attempt: number,
+  maxRetries: number
+): Promise<FetchAttemptResult> {
+  if (oauth) {
+    const { body } = await discogsOAuthGotGet(resourceUrl, {
+      consumerKey: oauth.consumerKey,
+      consumerSecret: oauth.consumerSecret,
+      oauthToken: oauth.oauthToken,
+      oauthTokenSecret: oauth.oauthTokenSecret,
+    })
+    const resourceData = JSON.parse(body)
+    logger.debug(`Successfully fetched release resource for ${releaseId}`)
+    return { outcome: 'success', data: resourceData }
+  }
+
+  const response = await fetch(urlWithAuth, {
+    headers: {
+      'User-Agent': chronogroveHttpUserAgent,
+    },
+  })
+
+  if (response.status === 429) {
+    const waitTime = Math.pow(2, attempt) * 3000
+    logger.warn(`Rate limited for release ${releaseId}, waiting ${waitTime}ms before retry ${attempt}/${maxRetries}`)
+
+    if (attempt < maxRetries) {
+      return { outcome: 'rate_limited', waitMs: waitTime }
+    }
+
+    logger.error(`Max retries reached for release ${releaseId} due to rate limiting`)
+    return { outcome: 'failed' }
+  }
+
+  if (!response.ok) {
+    logger.warn(`Failed to fetch release resource for ${releaseId}: ${response.status} ${response.statusText}`)
+    return { outcome: 'failed' }
+  }
+
+  const resourceData = await response.json()
+  logger.debug(`Successfully fetched release resource for ${releaseId}`)
+
+  return { outcome: 'success', data: resourceData }
+}
+
 /**
  * Fetches detailed release resource data from Discogs API with retry logic
  * @param resourceUrl - The resource_url to fetch
@@ -24,10 +93,7 @@ const fetchReleaseDetails = async (
     throw new Error('Missing required environment variable: DISCOGS_API_KEY')
   }
 
-  const urlWithAuth =
-    oauth || resourceUrl.includes('token=')
-      ? resourceUrl
-      : `${resourceUrl}${resourceUrl.includes('?') ? '&' : '?'}token=${apiKey}`
+  const urlWithAuth = buildReleaseFetchUrl(resourceUrl, apiKey, oauth)
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
@@ -35,46 +101,18 @@ const fetchReleaseDetails = async (
         `Fetching release resource for ${releaseId} (attempt ${attempt}/${maxRetries})${oauth ? ' (OAuth)' : ''}`
       )
 
-      if (oauth) {
-        const { body } = await discogsOAuthGotGet(resourceUrl, {
-          consumerKey: oauth.consumerKey,
-          consumerSecret: oauth.consumerSecret,
-          oauthToken: oauth.oauthToken,
-          oauthTokenSecret: oauth.oauthTokenSecret,
-        })
-        const resourceData = JSON.parse(body as string) as unknown
-        logger.debug(`Successfully fetched release resource for ${releaseId}`)
-        return resourceData
+      const result = await fetchReleaseOnce(oauth, resourceUrl, urlWithAuth, releaseId, attempt, maxRetries)
+
+      if (result.outcome === 'success') {
+        return result.data
       }
 
-      const response = await fetch(urlWithAuth, {
-        headers: {
-          'User-Agent': chronogroveHttpUserAgent,
-        },
-      })
-
-      if (response.status === 429) {
-        const waitTime = Math.pow(2, attempt) * 3000
-        logger.warn(`Rate limited for release ${releaseId}, waiting ${waitTime}ms before retry ${attempt}/${maxRetries}`)
-
-        if (attempt < maxRetries) {
-          await new Promise((resolve) => setTimeout(resolve, waitTime))
-          continue
-        } else {
-          logger.error(`Max retries reached for release ${releaseId} due to rate limiting`)
-          return null
-        }
+      if (result.outcome === 'rate_limited') {
+        await new Promise((resolve) => setTimeout(resolve, result.waitMs))
+        continue
       }
 
-      if (!response.ok) {
-        logger.warn(`Failed to fetch release resource for ${releaseId}: ${response.status} ${response.statusText}`)
-        return null
-      }
-
-      const resourceData = await response.json()
-      logger.debug(`Successfully fetched release resource for ${releaseId}`)
-
-      return resourceData
+      return null
     } catch (error) {
       logger.error(`Error fetching release resource for ${releaseId} (attempt ${attempt}/${maxRetries}):`, error)
 

--- a/functions/api/discogs/fetch-release-details.ts
+++ b/functions/api/discogs/fetch-release-details.ts
@@ -13,11 +13,8 @@ function buildReleaseFetchUrl(
   if (oauth || resourceUrl.includes('token=')) {
     return resourceUrl
   }
-  if (!apiKey) {
-    throw new Error('Missing required environment variable: DISCOGS_API_KEY')
-  }
   const separator = resourceUrl.includes('?') ? '&' : '?'
-  return `${resourceUrl}${separator}token=${apiKey}`
+  return `${resourceUrl}${separator}token=${apiKey as string}`
 }
 
 type FetchAttemptResult =

--- a/functions/api/discogs/fetch-releases.ts
+++ b/functions/api/discogs/fetch-releases.ts
@@ -87,7 +87,7 @@ async function fetchDiscogsReleasesOAuth(oauth: ResolvedDiscogsApiAuth): Promise
 
     const signing = { consumerKey, consumerSecret, oauthToken, oauthTokenSecret }
     const { body } = await discogsOAuthGotGet(url, signing)
-    const data = JSON.parse(body as string) as {
+    const data = JSON.parse(body) as {
       releases: DiscogsCollectionReleaseItem[]
       pagination: { page: number; pages: number }
     }

--- a/functions/api/flickr/fetch-photos.test.ts
+++ b/functions/api/flickr/fetch-photos.test.ts
@@ -259,7 +259,7 @@ describe('fetchPhotos', () => {
       thumbnailUrl: undefined,
       mediumUrl: undefined,
       largeUrl: undefined,
-      link: 'https://www.flickr.com/photos/test-flickr-user-id/null',
+      link: 'https://www.flickr.com/photos/test-flickr-user-id/',
     })
   })
 }) 

--- a/functions/api/flickr/fetch-photos.test.ts
+++ b/functions/api/flickr/fetch-photos.test.ts
@@ -225,6 +225,81 @@ describe('fetchPhotos', () => {
     expect(mockLogger.error).toHaveBeenCalledWith('Error fetching Flickr photos (OAuth):', err)
   })
 
+  it('stringifies numeric or boolean Flickr fields for URLs and ids', async () => {
+    mockGot.mockResolvedValue({
+      body: {
+        photos: {
+          photo: [
+            {
+              id: 42,
+              title: true,
+              description: { _content: '' },
+              datetaken: 2024,
+              ownername: false,
+              url_q: 'q.jpg',
+              url_m: 'm.jpg',
+              url_l: 'l.jpg',
+            },
+          ],
+          total: 1,
+          page: 1,
+          pages: 1,
+        },
+      },
+    })
+
+    const result = await fetchPhotos()
+
+    expect(result.photos[0]).toEqual({
+      id: '42',
+      title: 'true',
+      description: '',
+      dateTaken: '2024',
+      ownerName: 'false',
+      thumbnailUrl: 'q.jpg',
+      mediumUrl: 'm.jpg',
+      largeUrl: 'l.jpg',
+      link: 'https://www.flickr.com/photos/test-flickr-user-id/42',
+    })
+  })
+
+  it('drops non-primitive Flickr field values', async () => {
+    mockGot.mockResolvedValue({
+      body: {
+        photos: {
+          photo: [
+            {
+              id: { not: 'serializable' },
+              title: ['array', 'title'],
+              description: { _content: 'ok' },
+              datetaken: {},
+              ownername: [],
+              url_q: 'q.jpg',
+              url_m: 'm.jpg',
+              url_l: 'l.jpg',
+            },
+          ],
+          total: 1,
+          page: 1,
+          pages: 1,
+        },
+      },
+    })
+
+    const result = await fetchPhotos()
+
+    expect(result.photos[0]).toEqual(
+      expect.objectContaining({
+        id: undefined,
+        title: undefined,
+        dateTaken: undefined,
+        ownerName: undefined,
+        description: 'ok',
+        link: 'https://www.flickr.com/photos/test-flickr-user-id/',
+      }),
+    )
+  })
+
   it('maps photos with nullish optional fields using defaults', async () => {
     mockGot.mockResolvedValue({
       body: {

--- a/functions/api/flickr/fetch-photos.ts
+++ b/functions/api/flickr/fetch-photos.ts
@@ -91,6 +91,17 @@ async function fetchPhotosOAuth(auth: ResolvedFlickrApiAuth): Promise<FlickrPhot
   }
 }
 
+function flickrFieldString(value: unknown): string | undefined {
+  if (value == null) {
+    return undefined
+  }
+  const t = typeof value
+  if (t === 'string' || t === 'number' || t === 'boolean') {
+    return String(value)
+  }
+  return undefined
+}
+
 function normalizePhotosResponse(
   body: unknown,
   canonicalUserId: string
@@ -109,16 +120,17 @@ function normalizePhotosResponse(
 
   const photos: FlickrPhoto[] = res.photos.photo.map((photo) => {
     const desc = photo.description as { _content?: string } | undefined
+    const idStr = flickrFieldString(photo.id)
     return {
-      id: photo.id != null ? String(photo.id) : undefined,
-      title: photo.title != null ? String(photo.title) : undefined,
+      id: idStr,
+      title: flickrFieldString(photo.title),
       description: desc?._content ?? '',
-      dateTaken: photo.datetaken != null ? String(photo.datetaken) : undefined,
-      ownerName: photo.ownername != null ? String(photo.ownername) : undefined,
-      thumbnailUrl: photo.url_q != null ? String(photo.url_q) : undefined,
-      mediumUrl: photo.url_m != null ? String(photo.url_m) : undefined,
-      largeUrl: photo.url_l != null ? String(photo.url_l) : undefined,
-      link: `https://www.flickr.com/photos/${canonicalUserId}/${photo.id}`,
+      dateTaken: flickrFieldString(photo.datetaken),
+      ownerName: flickrFieldString(photo.ownername),
+      thumbnailUrl: flickrFieldString(photo.url_q),
+      mediumUrl: flickrFieldString(photo.url_m),
+      largeUrl: flickrFieldString(photo.url_l),
+      link: `https://www.flickr.com/photos/${canonicalUserId}/${idStr ?? ''}`,
     }
   })
 

--- a/functions/api/goodreads/fetch-full-read-shelf-for-ai.test.ts
+++ b/functions/api/goodreads/fetch-full-read-shelf-for-ai.test.ts
@@ -122,6 +122,16 @@ describe('fetchFullReadShelfForAi', () => {
     await expect(fetchFullReadShelfForAi()).rejects.toThrow('invalid xml')
   })
 
+  it('wraps non-Error parse failures as Error', async () => {
+    vi.mocked(parseStringMock).mockImplementationOnce((body, cb) => {
+      cb('not an Error instance', undefined)
+    })
+
+    vi.mocked(got).mockResolvedValueOnce({ body: '<x/>' } as never)
+
+    await expect(fetchFullReadShelfForAi()).rejects.toThrow('not an Error instance')
+  })
+
   it('drops reviews with no identifiable book and uses date_added when read_at is too short', async () => {
     const body = `<GoodreadsResponse><reviews>
       <review><read_at>n/a</read_at><date_added>2019-07-04</date_added><rating>5</rating>

--- a/functions/api/goodreads/fetch-full-read-shelf-for-ai.ts
+++ b/functions/api/goodreads/fetch-full-read-shelf-for-ai.ts
@@ -61,12 +61,12 @@ const reviewToAiEntry = (review: Record<string, unknown>): GoodreadsAiReadShelfE
 
   const readAt = getXmlTextOrUndefined(review.read_at)
   const dateAdded = getXmlTextOrUndefined(review.date_added)
-  const finishedOrAddedDate =
-    readAt && readAt.length > 3
-      ? readAt
-      : dateAdded && dateAdded.length > 3
-        ? dateAdded
-        : null
+  let finishedOrAddedDate: string | null = null
+  if (readAt && readAt.length > 3) {
+    finishedOrAddedDate = readAt
+  } else if (dateAdded && dateAdded.length > 3) {
+    finishedOrAddedDate = dateAdded
+  }
 
   const rating = getXmlTextOrUndefined(review.rating)
 
@@ -83,7 +83,7 @@ const parseReviewListPage = (body: string): Promise<GoodreadsAiReadShelfEntry[]>
   new Promise((resolve, reject) => {
     parseString(body, (error, response) => {
       if (error) {
-        reject(error)
+        reject(error instanceof Error ? error : new Error(String(error)))
         return
       }
 

--- a/functions/api/goodreads/fetch-recently-read-books.test.ts
+++ b/functions/api/goodreads/fetch-recently-read-books.test.ts
@@ -1181,6 +1181,61 @@ describe('fetchRecentlyReadBooks', () => {
     delete process.env.GOOGLE_BOOKS_API_KEY
   })
 
+  it('treats 429 with Quota exceeded message as quota without RESOURCE_EXHAUSTED status', async () => {
+    process.env.GOOGLE_BOOKS_API_KEY = 'test-google-books-api-key'
+    mockGot
+      .mockResolvedValueOnce({
+        body: '<GoodreadsResponse><reviews><review><read_at>2023-01-01</read_at><book><title>Quota Style</title><isbn13>9799999999999</isbn13></book><rating>4</rating></review></reviews></GoodreadsResponse>',
+      })
+      .mockRejectedValueOnce({
+        response: {
+          statusCode: 429,
+          body: JSON.stringify({
+            error: {
+              code: 429,
+              message: 'Quota exceeded for Queries per day',
+            },
+          }),
+        },
+      })
+    mockParseString.mockImplementation((xml, callback) => {
+      callback(null, {
+        GoodreadsResponse: {
+          reviews: [
+            {
+              review: [
+                {
+                  read_at: ['2023-01-01'],
+                  book: [{ title: ['Quota Style'], isbn13: ['9799999999999'] }],
+                  rating: ['4'],
+                },
+              ],
+            },
+          ],
+        },
+      })
+    })
+    mockPMap.mockImplementation(async (items, mapper, options) => {
+      if (options?.concurrency === 3) {
+        const results = []
+        for (let i = 0; i < items.length; i++) results.push(await mapper(items[i], i))
+        return results
+      }
+      return []
+    })
+    mockFetchBookFromGoogle.mockResolvedValue(null)
+    mockListStoredMedia.mockResolvedValue([])
+
+    const result = await fetchRecentlyReadBooks()
+
+    expect(result.books).toEqual([])
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'Daily quota exceeded for Google Books API. Title/author fallback skipped.',
+      { message: 'Quota exceeded for Queries per day' },
+    )
+    delete process.env.GOOGLE_BOOKS_API_KEY
+  })
+
   it('handles invalid JSON string error body from Google Books volumes API during title fallback', async () => {
     process.env.GOOGLE_BOOKS_API_KEY = 'test-google-books-api-key'
     mockGot

--- a/functions/api/goodreads/fetch-recently-read-books.test.ts
+++ b/functions/api/goodreads/fetch-recently-read-books.test.ts
@@ -1128,4 +1128,108 @@ describe('fetchRecentlyReadBooks', () => {
     expect(mockLogger.warn).toHaveBeenCalledWith('Book not found by ISBN or title/author fallback: "Fail Book"')
     delete process.env.GOOGLE_BOOKS_API_KEY
   })
+
+  it('handles non-string error body from Google Books volumes API during title fallback', async () => {
+    process.env.GOOGLE_BOOKS_API_KEY = 'test-google-books-api-key'
+    mockGot
+      .mockResolvedValueOnce({
+        body: '<GoodreadsResponse><reviews><review><read_at>2023-01-01</read_at><book><title>Obj Body</title><isbn13>9787777777777</isbn13></book><rating>4</rating></review></reviews></GoodreadsResponse>',
+      })
+      .mockRejectedValueOnce({
+        response: {
+          statusCode: 500,
+          body: { error: { message: 'Server object body' } },
+        },
+      })
+    mockParseString.mockImplementation((xml, callback) => {
+      callback(null, {
+        GoodreadsResponse: {
+          reviews: [
+            {
+              review: [
+                {
+                  read_at: ['2023-01-01'],
+                  book: [{ title: ['Obj Body'], isbn13: ['9787777777777'] }],
+                  rating: ['4'],
+                },
+              ],
+            },
+          ],
+        },
+      })
+    })
+    mockPMap.mockImplementation(async (items, mapper, options) => {
+      if (options?.concurrency === 3) {
+        const results = []
+        for (let i = 0; i < items.length; i++) results.push(await mapper(items[i], i))
+        return results
+      }
+      return []
+    })
+    mockFetchBookFromGoogle.mockResolvedValue(null)
+    mockListStoredMedia.mockResolvedValue([])
+
+    const result = await fetchRecentlyReadBooks()
+
+    expect(result.books).toEqual([])
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'Error fetching book by title for recently read "Obj Body" after retries:',
+      expect.objectContaining({
+        response: expect.objectContaining({ statusCode: 500 }),
+      }),
+    )
+    delete process.env.GOOGLE_BOOKS_API_KEY
+  })
+
+  it('handles invalid JSON string error body from Google Books volumes API during title fallback', async () => {
+    process.env.GOOGLE_BOOKS_API_KEY = 'test-google-books-api-key'
+    mockGot
+      .mockResolvedValueOnce({
+        body: '<GoodreadsResponse><reviews><review><read_at>2023-01-01</read_at><book><title>Bad JSON Err</title><isbn13>9788888888888</isbn13></book><rating>4</rating></review></reviews></GoodreadsResponse>',
+      })
+      .mockRejectedValueOnce({
+        response: {
+          statusCode: 500,
+          body: '{truncated-json',
+        },
+      })
+    mockParseString.mockImplementation((xml, callback) => {
+      callback(null, {
+        GoodreadsResponse: {
+          reviews: [
+            {
+              review: [
+                {
+                  read_at: ['2023-01-01'],
+                  book: [{ title: ['Bad JSON Err'], isbn13: ['9788888888888'] }],
+                  rating: ['4'],
+                },
+              ],
+            },
+          ],
+        },
+      })
+    })
+    mockPMap.mockImplementation(async (items, mapper, options) => {
+      if (options?.concurrency === 3) {
+        const results = []
+        for (let i = 0; i < items.length; i++) results.push(await mapper(items[i], i))
+        return results
+      }
+      return []
+    })
+    mockFetchBookFromGoogle.mockResolvedValue(null)
+    mockListStoredMedia.mockResolvedValue([])
+
+    const result = await fetchRecentlyReadBooks()
+
+    expect(result.books).toEqual([])
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'Error fetching book by title for recently read "Bad JSON Err" after retries:',
+      expect.objectContaining({
+        response: expect.objectContaining({ statusCode: 500 }),
+      }),
+    )
+    delete process.env.GOOGLE_BOOKS_API_KEY
+  })
 }) 

--- a/functions/api/goodreads/fetch-recently-read-books.ts
+++ b/functions/api/goodreads/fetch-recently-read-books.ts
@@ -32,6 +32,87 @@ import { sortGoodreadsRecentlyReadBooksByReadAtDesc } from '../../utils/sort-goo
 
 const toBookMediaDestinationPath = id => `books/${id}-thumbnail.jpg`
 
+type GotLikeError = {
+  response?: { statusCode?: number; body?: unknown }
+  statusCode?: number
+}
+
+function parseGoogleBooksApiErrorBody(error: unknown): unknown | null {
+  const gotErr = error as GotLikeError
+  const raw = gotErr.response?.body
+  if (raw == null) {
+    return null
+  }
+  return typeof raw === 'string' ? JSON.parse(raw) : raw
+}
+
+async function fetchGoogleBookByTitleFallback(
+  book: GoodreadsReviewListBookSource,
+): Promise<GoogleBooksFetchByIsbnResult | null> {
+  if (!book.title) {
+    return null
+  }
+  const searchQuery = book.authorName
+    ? `intitle:${book.title} inauthor:${book.authorName}`
+    : `intitle:${book.title}`
+  const maxRetries = 3
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    try {
+      const googleBooksAPIKey = getGoogleBooksApiKey()
+      const { body } = await got('https://www.googleapis.com/books/v1/volumes', {
+        searchParams: {
+          q: searchQuery,
+          key: googleBooksAPIKey,
+          country: 'US',
+        },
+      })
+      const parsed: unknown = JSON.parse(body)
+      const foundBook: GoogleBooksVolumeSubset | undefined =
+        isGoogleBooksVolumesResponseSubset(parsed) ? parsed.items?.[0] : undefined
+
+      if (foundBook) {
+        logger.info(
+          `Found book by ${book.authorName ? 'title/author' : 'title'} for recently read: ${book.title}`,
+        )
+        return {
+          book: foundBook,
+          rating: book.rating,
+        }
+      }
+    } catch (error: unknown) {
+      const gotErr = error as GotLikeError
+      const statusCode = gotErr.response?.statusCode ?? gotErr.statusCode
+      const errorBody = parseGoogleBooksApiErrorBody(error) as {
+        error?: { status?: string; code?: number; message?: string }
+      } | null
+      const isQuotaExceeded =
+        errorBody?.error?.status === 'RESOURCE_EXHAUSTED' ||
+        (errorBody?.error?.code === 429 && Boolean(errorBody?.error?.message?.includes('Quota exceeded')))
+      if (isQuotaExceeded) {
+        logger.error('Daily quota exceeded for Google Books API. Title/author fallback skipped.', {
+          message: errorBody?.error?.message,
+        })
+        break
+      }
+      if ((statusCode === 429 || statusCode === 503) && attempt < maxRetries) {
+        const waitTime = Math.pow(2, attempt) * 1000
+        logger.warn(
+          `Rate limited (${statusCode}) for title search "${book.title}", waiting ${waitTime}ms before retry ${attempt}/${maxRetries}`,
+        )
+        await new Promise((resolve) => setTimeout(resolve, waitTime))
+        continue
+      }
+      const mode = book.authorName ? 'title/author' : 'title'
+      logger.error(
+        `Error fetching book by ${mode} for recently read "${book.title}" after retries:`,
+        error,
+      )
+      break
+    }
+  }
+  return null
+}
+
 type TransformBookDataInput = GoodreadsRecentlyReadBookFromGoogle
 
 const transformBookData = (book: TransformBookDataInput): GoodreadsRecentlyReadBook => {
@@ -92,7 +173,8 @@ export default async () => {
   const bookReviews = await new Promise<GoodreadsReviewListBookSource[]>((resolve, reject) => {
     parseString(body, (error, response) => {
       if (error) {
-        reject(error)
+        reject(error instanceof Error ? error : new Error(String(error)))
+        return
       }
 
       const reviewsResponseUnknown =
@@ -183,72 +265,16 @@ export default async () => {
       
       let result: GoogleBooksFetchByIsbnResult | null = await fetchBookFromGoogle(book)
 
-      // If ISBN lookup failed, try searching by title and/or author
-      if ((!result || !result.book) && book.title) {
-        const searchQuery = book.authorName
-          ? `intitle:${book.title} inauthor:${book.authorName}`
-          : `intitle:${book.title}`
-        const maxRetries = 3
-        for (let attempt = 1; attempt <= maxRetries; attempt++) {
-          try {
-            const googleBooksAPIKey = getGoogleBooksApiKey()
-            const { body } = await got('https://www.googleapis.com/books/v1/volumes', {
-              searchParams: {
-                q: searchQuery,
-                key: googleBooksAPIKey,
-                country: 'US'
-              }
-            })
-            const parsed: unknown = JSON.parse(body)
-            const foundBook: GoogleBooksVolumeSubset | undefined =
-              isGoogleBooksVolumesResponseSubset(parsed) ? parsed.items?.[0] : undefined
-
-            if (foundBook) {
-              result = {
-                book: foundBook,
-                rating: book.rating,
-              }
-              logger.info(
-                `Found book by ${book.authorName ? 'title/author' : 'title'} for recently read: ${book.title}`
-              )
-              break
-            }
-          } catch (error) {
-            const statusCode = error.response?.statusCode || error.statusCode
-            const errorBody = error.response?.body
-              ? (typeof error.response.body === 'string' ? JSON.parse(error.response.body) : error.response.body)
-              : null
-            const isQuotaExceeded =
-              errorBody?.error?.status === 'RESOURCE_EXHAUSTED' ||
-              (errorBody?.error?.code === 429 && errorBody?.error?.message?.includes('Quota exceeded'))
-            if (isQuotaExceeded) {
-              logger.error(
-                'Daily quota exceeded for Google Books API. Title/author fallback skipped.',
-                { message: errorBody?.error?.message }
-              )
-              break
-            }
-            if ((statusCode === 429 || statusCode === 503) && attempt < maxRetries) {
-              const waitTime = Math.pow(2, attempt) * 1000
-              logger.warn(
-                `Rate limited (${statusCode}) for title search "${book.title}", waiting ${waitTime}ms before retry ${attempt}/${maxRetries}`
-              )
-              await new Promise(resolve => setTimeout(resolve, waitTime))
-              continue
-            }
-            logger.error(
-              `Error fetching book by ${book.authorName ? 'title/author' : 'title'} for recently read "${book.title}" after retries:`,
-              error
-            )
-            break
-          }
+      if (!result?.book && book.title) {
+        const fallback = await fetchGoogleBookByTitleFallback(book)
+        if (fallback) {
+          result = fallback
         }
       }
 
-      if (!result || !result.book) {
-        logger.warn(
-          `Book not found by ISBN or title/author fallback: ${book.title ? `"${book.title}"` : `ISBN ${book.isbn}`}`
-        )
+      if (!result?.book) {
+        const label = book.title ? `"${book.title}"` : `ISBN ${book.isbn}`
+        logger.warn(`Book not found by ISBN or title/author fallback: ${label}`)
       }
 
       return {
@@ -287,8 +313,7 @@ export default async () => {
 
   const storedMediaFileNames = await listStoredMedia()
 
-  // TODO: update the filters to use the same source of truth as data being saved
-  // to the db.
+  // Media skip list uses filenames from storage; widget payloads use the same paths from transformBookData.
   const mediaToDownload = books
     .filter(({ mediaDestinationPath, thumbnail }) => {
       if (!thumbnail) return false // I've found at least 1 book that doesn't contain a thumbnail

--- a/functions/api/goodreads/fetch-recently-read-books.ts
+++ b/functions/api/goodreads/fetch-recently-read-books.ts
@@ -43,7 +43,14 @@ function parseGoogleBooksApiErrorBody(error: unknown): unknown | null {
   if (raw == null) {
     return null
   }
-  return typeof raw === 'string' ? JSON.parse(raw) : raw
+  if (typeof raw !== 'string') {
+    return raw
+  }
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return null
+  }
 }
 
 async function fetchGoogleBookByTitleFallback(

--- a/functions/api/goodreads/fetch-recently-read-books.ts
+++ b/functions/api/goodreads/fetch-recently-read-books.ts
@@ -56,9 +56,6 @@ function parseGoogleBooksApiErrorBody(error: unknown): unknown | null {
 async function fetchGoogleBookByTitleFallback(
   book: GoodreadsReviewListBookSource,
 ): Promise<GoogleBooksFetchByIsbnResult | null> {
-  if (!book.title) {
-    return null
-  }
   const searchQuery = book.authorName
     ? `intitle:${book.title} inauthor:${book.authorName}`
     : `intitle:${book.title}`

--- a/functions/api/goodreads/generate-goodreads-summary.test.ts
+++ b/functions/api/goodreads/generate-goodreads-summary.test.ts
@@ -252,6 +252,24 @@ describe('generateGoodreadsSummary', () => {
     })
   })
 
+  it('formats wrapped errors with JSON and Unknown fallbacks like other AI summaries', async () => {
+    mockFetch.mockRejectedValueOnce({ message: false })
+
+    await expect(
+      generateGoodreadsSummary({ collections: { recentlyReadBooks: [] }, profile: {} }),
+    ).rejects.toThrow('Failed to generate AI summary: {"message":false}')
+  })
+
+  it('uses Unknown error in the wrapper when JSON.stringify fails', async () => {
+    const circular: Record<string, unknown> = { x: 1 }
+    circular.self = circular
+    mockFetch.mockRejectedValueOnce(circular)
+
+    await expect(
+      generateGoodreadsSummary({ collections: { recentlyReadBooks: [] }, profile: {} }),
+    ).rejects.toThrow('Failed to generate AI summary: Unknown error')
+  })
+
   it('should handle response missing required fields', async () => {
     const mockGoodreadsData = {
       collections: { recentlyReadBooks: [] },
@@ -324,6 +342,18 @@ describe('generateGoodreadsSummary', () => {
     })
 
     expect(result).toBe('Plain fallback copy.')
+  })
+
+  it('warns when the model returns exactly one paragraph tag', async () => {
+    mockAiSummaryText('{"response": "<p>Only one paragraph.</p>", "debug": {}}')
+
+    const result = await generateGoodreadsSummary({
+      collections: { recentlyReadBooks: [] },
+      profile: { displayName: 'Chris Vogt' },
+    })
+
+    expect(result).toBe('<p>Only one paragraph.</p>')
+    expect(logger.warn).toHaveBeenCalledWith('Goodreads AI summary contained only one <p>.')
   })
 
   it('keeps all <p> elements when the model returns two or three paragraphs', async () => {

--- a/functions/api/goodreads/generate-goodreads-summary.test.ts
+++ b/functions/api/goodreads/generate-goodreads-summary.test.ts
@@ -252,6 +252,14 @@ describe('generateGoodreadsSummary', () => {
     })
   })
 
+  it('uses string message field on third-party style error objects (matches Steam / sync queue helpers)', async () => {
+    mockFetch.mockRejectedValueOnce({ message: 'Upstream rate limit' })
+
+    await expect(
+      generateGoodreadsSummary({ collections: { recentlyReadBooks: [] }, profile: {} }),
+    ).rejects.toThrow('Failed to generate AI summary: Upstream rate limit')
+  })
+
   it('formats wrapped errors with JSON and Unknown fallbacks like other AI summaries', async () => {
     mockFetch.mockRejectedValueOnce({ message: false })
 

--- a/functions/api/goodreads/generate-goodreads-summary.ts
+++ b/functions/api/goodreads/generate-goodreads-summary.ts
@@ -7,6 +7,20 @@ import extractJsonFromAiResponse from '../../utils/extract-json-from-ai-response
 import type { GoodreadsAiReadShelfEntry } from '../../types/goodreads.js'
 import type { GoodreadsWidgetDocument } from '../../types/widget-content.js'
 
+function formatUnknownSummaryError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message
+  }
+  if (typeof error === 'string') {
+    return error
+  }
+  try {
+    return JSON.stringify(error)
+  } catch {
+    return 'Unknown error'
+  }
+}
+
 export type GenerateGoodreadsSummaryOptions = {
   /** Full read shelf from Goodreads XML only; drives long-tail context in the prompt */
   fullReadShelf?: GoodreadsAiReadShelfEntry[]
@@ -111,8 +125,9 @@ Goodreads Profile: ${profile?.name || profile?.username || 'Chris Vogt'}
     return normalizeParagraphSummary(sanitizedResponse)
   } catch (error: unknown) {
     logger.error('Error generating Goodreads AI summary:', error)
-    const message = error instanceof Error ? error.message : String(error)
-    throw new Error(`Failed to generate AI summary: ${message}`, { cause: error })
+    throw new Error(`Failed to generate AI summary: ${formatUnknownSummaryError(error)}`, {
+      cause: error,
+    })
   }
 }
 

--- a/functions/api/goodreads/generate-goodreads-summary.ts
+++ b/functions/api/goodreads/generate-goodreads-summary.ts
@@ -14,6 +14,12 @@ function formatUnknownSummaryError(error: unknown): string {
   if (typeof error === 'string') {
     return error
   }
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    const m = (error as { message: unknown }).message
+    if (typeof m === 'string') {
+      return m
+    }
+  }
   try {
     return JSON.stringify(error)
   } catch {

--- a/functions/api/google-books/fetch-book.test.ts
+++ b/functions/api/google-books/fetch-book.test.ts
@@ -331,6 +331,27 @@ describe('fetchBook', () => {
     expect(result).toBeNull()
   })
 
+  it('treats invalid JSON in a Google Books error body as absent quota metadata', async () => {
+    const bookInput = {
+      isbn: '9780143127550',
+      rating: '4',
+    }
+
+    const badJsonError = {
+      response: {
+        statusCode: 500,
+        body: '{not-json',
+      },
+    }
+
+    mockGot.mockRejectedValueOnce(badJsonError)
+
+    const result = await fetchBook(bookInput)
+
+    expect(mockLogger.error).toHaveBeenCalledWith('Error fetching data Google Books API.', badJsonError)
+    expect(result).toBeNull()
+  })
+
   it('should handle malformed JSON response', async () => {
     const bookInput = {
       isbn: '9780143127550',

--- a/functions/api/google-books/fetch-book.test.ts
+++ b/functions/api/google-books/fetch-book.test.ts
@@ -257,6 +257,50 @@ describe('fetchBook', () => {
     })
   })
 
+  it('treats 429 with Quota exceeded message as daily quota even without RESOURCE_EXHAUSTED status', async () => {
+    const bookInput = {
+      isbn: '9780143127550',
+      rating: '4',
+    }
+
+    const quotaStyle429 = {
+      response: {
+        statusCode: 429,
+        body: JSON.stringify({
+          error: {
+            code: 429,
+            message: 'Quota exceeded for metric',
+          },
+        }),
+      },
+    }
+
+    mockGot.mockRejectedValueOnce(quotaStyle429)
+
+    const result = await fetchBook(bookInput)
+
+    expect(mockGot).toHaveBeenCalledTimes(1)
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      'Daily quota exceeded for Google Books API. ISBN 9780143127550 will not be fetched.',
+      expect.objectContaining({ message: 'Quota exceeded for metric' }),
+    )
+    expect(result).toBeNull()
+  })
+
+  it('returns null from error body parser when response has no body', async () => {
+    const bookInput = {
+      isbn: '9780143127550',
+      rating: '4',
+    }
+
+    mockGot.mockRejectedValueOnce({ response: { statusCode: 500 } })
+
+    const result = await fetchBook(bookInput)
+
+    expect(mockLogger.error).toHaveBeenCalledWith('Error fetching data Google Books API.', expect.anything())
+    expect(result).toBeNull()
+  })
+
   it('should not retry on daily quota exceeded errors', async () => {
     const bookInput = {
       isbn: '9780143127550',

--- a/functions/api/google-books/fetch-book.ts
+++ b/functions/api/google-books/fetch-book.ts
@@ -13,6 +13,42 @@ import {
   isGoogleBooksVolumesResponseSubset as isVolumesResponseSubset,
 } from '../../types/google-books.js'
 
+type GoogleBooksApiErrorBody = {
+  error?: {
+    status?: string
+    code?: number
+    message?: string
+    details?: Array<{ metadata?: { quota_limit_value?: unknown } }>
+  }
+}
+
+type GotLike = {
+  response?: { statusCode?: number; body?: string }
+  statusCode?: number
+}
+
+function parseGoogleBooksVolumeErrorBody(error: unknown): GoogleBooksApiErrorBody | null {
+  const e = error as GotLike
+  if (!e.response?.body) {
+    return null
+  }
+  try {
+    return JSON.parse(e.response.body) as GoogleBooksApiErrorBody
+  } catch {
+    return null
+  }
+}
+
+function isGoogleBooksDailyQuotaExceeded(errorBody: GoogleBooksApiErrorBody | null): boolean {
+  if (!errorBody?.error) {
+    return false
+  }
+  return (
+    errorBody.error.status === 'RESOURCE_EXHAUSTED' ||
+    (errorBody.error.code === 429 && Boolean(errorBody.error.message?.includes('Quota exceeded')))
+  )
+}
+
 const fetchBook = async (
   book: GoogleBooksFetchByIsbnInput,
   maxRetries = 3,
@@ -26,55 +62,48 @@ const fetchBook = async (
 
   const googleBooksVolumeURL = `https://www.googleapis.com/books/v1/volumes?q=isbn:${isbn}&key=${googleBooksAPIKey}&country=US`
 
-  // Retry with exponential backoff on rate limit errors
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
       const { body } = await got(googleBooksVolumeURL)
       const parsed: unknown = JSON.parse(body)
-      const items = isVolumesResponseSubset(parsed)
-        ? parsed.items
-        : undefined
-      const book: GoogleBooksVolumeSubset | undefined = items?.[0]
+      const items = isVolumesResponseSubset(parsed) ? parsed.items : undefined
+      const volume: GoogleBooksVolumeSubset | undefined = items?.[0]
 
-      if (!book) {
+      if (!volume) {
         logger.info(`No result from Google Books for ISBN: ${isbn}; title/author fallback may be used.`)
       }
 
       return {
-        book,
+        book: volume,
         rating,
       }
-    } catch (error) {
-      const statusCode = error.response?.statusCode || error.statusCode
-      const errorBody = error.response?.body ? JSON.parse(error.response.body) : null
-      const isQuotaExceeded = errorBody?.error?.status === 'RESOURCE_EXHAUSTED' || 
-                              errorBody?.error?.code === 429 && 
-                              errorBody?.error?.message?.includes('Quota exceeded')
-      
-      // Don't retry on daily quota exceeded - it won't help
-      if (isQuotaExceeded) {
+    } catch (error: unknown) {
+      const e = error as GotLike
+      const statusCode = e.response?.statusCode ?? e.statusCode
+      const errorBody = parseGoogleBooksVolumeErrorBody(error)
+
+      if (isGoogleBooksDailyQuotaExceeded(errorBody)) {
         logger.error(`Daily quota exceeded for Google Books API. ISBN ${isbn} will not be fetched.`, {
           message: errorBody?.error?.message,
-          quota_limit: errorBody?.error?.details?.[0]?.metadata?.quota_limit_value
+          quota_limit: errorBody?.error?.details?.[0]?.metadata?.quota_limit_value,
         })
         return null
       }
-      
-      // Retry on 429 (rate limit) or 503 (Service Unavailable) - but not quota exceeded
+
       if ((statusCode === 429 || statusCode === 503) && attempt < maxRetries) {
-        const waitTime = Math.pow(2, attempt) * 1000 // Exponential backoff: 2s, 4s, 8s
-        logger.warn(`Rate limited (${statusCode}) for ISBN ${isbn}, waiting ${waitTime}ms before retry ${attempt}/${maxRetries}`)
-        await new Promise(resolve => setTimeout(resolve, waitTime))
+        const waitTime = Math.pow(2, attempt) * 1000
+        logger.warn(
+          `Rate limited (${statusCode}) for ISBN ${isbn}, waiting ${waitTime}ms before retry ${attempt}/${maxRetries}`,
+        )
+        await new Promise((resolve) => setTimeout(resolve, waitTime))
         continue
       }
-      
-      // For other errors or max retries reached, log and return null
+
       if (attempt === maxRetries) {
         logger.error(`Error fetching data Google Books API for ISBN ${isbn} after ${maxRetries} attempts.`, error)
         return null
       }
-      
-      // For non-rate-limit errors, don't retry
+
       logger.error('Error fetching data Google Books API.', error)
       return null
     }

--- a/functions/api/steam/get-player-summary.ts
+++ b/functions/api/steam/get-player-summary.ts
@@ -22,7 +22,7 @@ const getPlayerSummary = async (
   const response = (body as { response?: { players?: SteamPlayerSummary[] } })?.response
   const players = response?.players ?? []
   const player = players[0]
-  return player ? player : []
+  return player ?? []
 }
 
 export default getPlayerSummary

--- a/functions/app/create-express-app.manual-sync-helpers.test.ts
+++ b/functions/app/create-express-app.manual-sync-helpers.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'vitest'
+import type { Request } from 'express'
+
+import {
+  formatUnknownFailureMessage,
+  isInfrastructurePublicWidgetHostname,
+  normalizeExpressPathParam,
+  parseManualSyncProviderSegmentFromRequest,
+  resolveManualSyncProvider,
+} from './create-express-app.js'
+
+describe('isInfrastructurePublicWidgetHostname', () => {
+  it('treats empty host and IPv4-mapped loopback forms as infrastructure', () => {
+    expect(isInfrastructurePublicWidgetHostname('')).toBe(true)
+    expect(isInfrastructurePublicWidgetHostname('::1')).toBe(true)
+    expect(isInfrastructurePublicWidgetHostname('[::1]')).toBe(true)
+    expect(isInfrastructurePublicWidgetHostname('::ffff:127.0.0.1')).toBe(true)
+    expect(isInfrastructurePublicWidgetHostname('[::ffff:127.0.0.1]')).toBe(true)
+  })
+
+  it('treats normal tenant hostnames as non-infrastructure', () => {
+    expect(isInfrastructurePublicWidgetHostname('api.example.com')).toBe(false)
+  })
+})
+
+describe('formatUnknownFailureMessage', () => {
+  it('returns message for Error instances', () => {
+    expect(formatUnknownFailureMessage(new Error('boom'))).toBe('boom')
+  })
+
+  it('returns string message field when present', () => {
+    expect(formatUnknownFailureMessage({ message: 'from object' })).toBe('from object')
+  })
+
+  it('JSON-stringifies plain objects when message is absent or non-string', () => {
+    expect(formatUnknownFailureMessage({ code: 418 })).toBe('{"code":418}')
+    expect(formatUnknownFailureMessage({ message: 99 })).toBe('{"message":99}')
+  })
+
+  it('falls back to String when JSON.stringify fails', () => {
+    const circular: Record<string, unknown> = { a: 1 }
+    circular.self = circular
+    expect(formatUnknownFailureMessage(circular)).toBe('[object Object]')
+  })
+})
+
+describe('normalizeExpressPathParam', () => {
+  it('accepts string params and first string array element', () => {
+    expect(normalizeExpressPathParam('spotify')).toBe('spotify')
+    expect(normalizeExpressPathParam(['flickr', 'extra'])).toBe('flickr')
+  })
+
+  it('returns undefined for non-string first array element or other shapes', () => {
+    expect(normalizeExpressPathParam([123, 'x'])).toBeUndefined()
+    expect(normalizeExpressPathParam({ x: 1 })).toBeUndefined()
+    expect(normalizeExpressPathParam(null)).toBeUndefined()
+  })
+})
+
+describe('parseManualSyncProviderSegmentFromRequest', () => {
+  const req = (partial: Partial<Request>): Request => partial as Request
+
+  it('reads provider from req.path for json and stream routes', () => {
+    expect(
+      parseManualSyncProviderSegmentFromRequest(
+        req({ path: '/api/widgets/sync/steam' }),
+        'json',
+      ),
+    ).toBe('steam')
+    expect(
+      parseManualSyncProviderSegmentFromRequest(
+        req({ path: '/api/widgets/sync/goodreads/stream' }),
+        'stream',
+      ),
+    ).toBe('goodreads')
+  })
+
+  it('falls back to originalUrl when path is empty or missing a match', () => {
+    expect(
+      parseManualSyncProviderSegmentFromRequest(
+        req({
+          path: '',
+          originalUrl: '/prefix/api/widgets/sync/discogs/stream?x=1',
+        }),
+        'stream',
+      ),
+    ).toBe('discogs')
+  })
+
+  it('ignores malformed originalUrl and returns undefined', () => {
+    expect(
+      parseManualSyncProviderSegmentFromRequest(
+        req({
+          path: '',
+          url: 'http://example.com:bad port/api/widgets/sync/steam/stream',
+          originalUrl: undefined,
+        }),
+        'stream',
+      ),
+    ).toBeUndefined()
+  })
+})
+
+describe('resolveManualSyncProvider', () => {
+  const req = (partial: Partial<Request>): Request => partial as Request
+
+  it('prefers a valid sync id from the URL over bogus params', () => {
+    expect(
+      resolveManualSyncProvider(
+        req({
+          params: { provider: 'stream' },
+          path: '/api/widgets/sync/flickr/stream',
+        }),
+        'stream',
+      ),
+    ).toBe('flickr')
+  })
+
+  it('uses params when path segment is not a sync id but params are', () => {
+    expect(
+      resolveManualSyncProvider(
+        req({
+          params: { provider: 'spotify' },
+          path: '/api/widgets/sync/not-a-provider/stream',
+        }),
+        'stream',
+      ),
+    ).toBe('spotify')
+  })
+
+  it('returns the param segment when neither side is a known sync provider', () => {
+    expect(
+      resolveManualSyncProvider(
+        req({
+          params: { provider: 'aaa' },
+          path: '/api/widgets/sync/bbb/stream',
+        }),
+        'stream',
+      ),
+    ).toBe('aaa')
+  })
+})

--- a/functions/app/create-express-app.route-coverage.test.ts
+++ b/functions/app/create-express-app.route-coverage.test.ts
@@ -534,6 +534,56 @@ describe('createExpressApp route coverage', () => {
     )
   })
 
+  it('resolves manual sync stream provider when path includes Functions / emulator mount prefix', async () => {
+    const { runSyncForProvider } = await import('../services/sync-manual.js')
+    vi.mocked(runSyncForProvider).mockResolvedValueOnce({
+      afterJob: { jobId: 'j1', status: 'completed' },
+      beforeJob: { jobId: 'j1', status: 'queued' },
+      enqueue: { jobId: 'j1', status: 'enqueued' },
+      worker: { jobId: 'j1', result: 'SUCCESS' },
+    })
+
+    const { createExpressApp } = await import('./create-express-app.js')
+    const app = createExpressApp({
+      authService,
+      documentStore,
+      ensureRuntimeConfigApplied,
+      getClientAuthConfig,
+      logger,
+      resolveMediaStore: () => new LocalDiskMediaStore('/tmp/metrics-unused-route-coverage'),
+      syncJobQueue,
+    })
+
+    const streamHandler = findRouteHandler(app, 'get', '/api/widgets/sync/:provider/stream')
+    const response = {
+      setHeader: vi.fn(),
+      write: vi.fn(),
+      end: vi.fn(),
+    }
+
+    const prefixedPath =
+      '/personal-stats-chrisvogt/us-central1/app/api/widgets/sync/flickr/stream'
+
+    await streamHandler(
+      {
+        params: {},
+        path: prefixedPath,
+        originalUrl: `${prefixedPath}?x=1`,
+      },
+      response,
+    )
+
+    expect(runSyncForProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'flickr',
+      }),
+    )
+    expect(response.setHeader).toHaveBeenCalledWith(
+      'Content-Type',
+      'text/event-stream; charset=utf-8',
+    )
+  })
+
   it('prefers path-derived provider when req.params is a bogus non-syncable string (e.g. stream)', async () => {
     const { runSyncForProvider } = await import('../services/sync-manual.js')
     vi.mocked(runSyncForProvider).mockResolvedValueOnce({

--- a/functions/app/create-express-app.route-coverage.test.ts
+++ b/functions/app/create-express-app.route-coverage.test.ts
@@ -441,7 +441,20 @@ describe('createExpressApp route coverage', () => {
     )
   })
 
-  it('returns 400 for manual sync stream when provider param is not a string', async () => {
+  it('accepts array-shaped provider param on manual sync SSE (Express 5)', async () => {
+    const { runSyncForProvider } = await import('../services/sync-manual.js')
+    vi.mocked(runSyncForProvider).mockImplementationOnce(
+      async ({ onProgress }: { onProgress?: (e: { phase: string; message: string }) => void }) => {
+        onProgress?.({ phase: 'unit.test', message: 'array param' })
+        return {
+          afterJob: { jobId: 'j1', status: 'completed' },
+          beforeJob: { jobId: 'j1', status: 'queued' },
+          enqueue: { jobId: 'j1', status: 'enqueued' },
+          worker: { jobId: 'j1', result: 'SUCCESS' },
+        }
+      }
+    )
+
     const { createExpressApp } = await import('./create-express-app.js')
     const app = createExpressApp({
       authService,
@@ -455,16 +468,113 @@ describe('createExpressApp route coverage', () => {
 
     const streamHandler = findRouteHandler(app, 'get', '/api/widgets/sync/:provider/stream')
     const response = {
-      status: vi.fn().mockReturnThis(),
-      send: vi.fn(),
+      setHeader: vi.fn(),
+      write: vi.fn(),
+      end: vi.fn(),
     }
 
     await streamHandler({ params: { provider: ['spotify'] as unknown as string } }, response)
 
-    expect(logger.info).toHaveBeenCalledWith(
-      'Attempted to sync stream for an unrecognized provider: undefined',
+    expect(runSyncForProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'spotify',
+      }),
     )
-    expect(response.status).toHaveBeenCalledWith(400)
+    expect(response.setHeader).toHaveBeenCalledWith(
+      'Content-Type',
+      'text/event-stream; charset=utf-8',
+    )
+  })
+
+  it('resolves manual sync stream provider from path when params are empty (proxy / Express edge case)', async () => {
+    const { runSyncForProvider } = await import('../services/sync-manual.js')
+    vi.mocked(runSyncForProvider).mockImplementationOnce(
+      async ({ onProgress }: { onProgress?: (e: { phase: string; message: string }) => void }) => {
+        onProgress?.({ phase: 'unit.test', message: 'path fallback' })
+        return {
+          afterJob: { jobId: 'j1', status: 'completed' },
+          beforeJob: { jobId: 'j1', status: 'queued' },
+          enqueue: { jobId: 'j1', status: 'enqueued' },
+          worker: { jobId: 'j1', result: 'SUCCESS' },
+        }
+      }
+    )
+
+    const { createExpressApp } = await import('./create-express-app.js')
+    const app = createExpressApp({
+      authService,
+      documentStore,
+      ensureRuntimeConfigApplied,
+      getClientAuthConfig,
+      logger,
+      resolveMediaStore: () => new LocalDiskMediaStore('/tmp/metrics-unused-route-coverage'),
+      syncJobQueue,
+    })
+
+    const streamHandler = findRouteHandler(app, 'get', '/api/widgets/sync/:provider/stream')
+    const response = {
+      setHeader: vi.fn(),
+      write: vi.fn(),
+      end: vi.fn(),
+    }
+
+    await streamHandler(
+      { params: {}, path: '/api/widgets/sync/flickr/stream', originalUrl: '/api/widgets/sync/flickr/stream' },
+      response
+    )
+
+    expect(runSyncForProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'flickr',
+      }),
+    )
+    expect(response.setHeader).toHaveBeenCalledWith(
+      'Content-Type',
+      'text/event-stream; charset=utf-8',
+    )
+  })
+
+  it('prefers path-derived provider when req.params is a bogus non-syncable string (e.g. stream)', async () => {
+    const { runSyncForProvider } = await import('../services/sync-manual.js')
+    vi.mocked(runSyncForProvider).mockResolvedValueOnce({
+      afterJob: { jobId: 'j1', status: 'completed' },
+      beforeJob: { jobId: 'j1', status: 'queued' },
+      enqueue: { jobId: 'j1', status: 'enqueued' },
+      worker: { jobId: 'j1', result: 'SUCCESS' },
+    })
+
+    const { createExpressApp } = await import('./create-express-app.js')
+    const app = createExpressApp({
+      authService,
+      documentStore,
+      ensureRuntimeConfigApplied,
+      getClientAuthConfig,
+      logger,
+      resolveMediaStore: () => new LocalDiskMediaStore('/tmp/metrics-unused-route-coverage'),
+      syncJobQueue,
+    })
+
+    const streamHandler = findRouteHandler(app, 'get', '/api/widgets/sync/:provider/stream')
+    const response = {
+      setHeader: vi.fn(),
+      write: vi.fn(),
+      end: vi.fn(),
+    }
+
+    await streamHandler(
+      {
+        params: { provider: 'stream' },
+        path: '/api/widgets/sync/flickr/stream',
+        originalUrl: '/api/widgets/sync/flickr/stream',
+      },
+      response,
+    )
+
+    expect(runSyncForProvider).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'flickr',
+      }),
+    )
   })
 
   it('returns 400 for manual sync stream when provider param is missing', async () => {
@@ -488,7 +598,8 @@ describe('createExpressApp route coverage', () => {
     await streamHandler({ params: {} }, response)
 
     expect(logger.info).toHaveBeenCalledWith(
-      'Attempted to sync stream for an unrecognized provider: undefined',
+      'Attempted to sync stream for an unrecognized provider',
+      expect.objectContaining({ provider: undefined }),
     )
     expect(response.status).toHaveBeenCalledWith(400)
     expect(response.send).toHaveBeenCalledWith('Unrecognized or unsupported provider.')
@@ -515,7 +626,8 @@ describe('createExpressApp route coverage', () => {
     await streamHandler({ params: { provider: 'github' } }, response)
 
     expect(logger.info).toHaveBeenCalledWith(
-      'Attempted to sync stream for an unrecognized provider: github',
+      'Attempted to sync stream for an unrecognized provider',
+      expect.objectContaining({ provider: 'github' }),
     )
     expect(response.status).toHaveBeenCalledWith(400)
     expect(response.send).toHaveBeenCalledWith('Unrecognized or unsupported provider.')

--- a/functions/app/create-express-app.test.ts
+++ b/functions/app/create-express-app.test.ts
@@ -855,7 +855,8 @@ describe('createExpressApp auth and session branches', () => {
     )
   })
 
-  it('treats array sync provider params as unsupported', async () => {
+  it('accepts array-shaped sync provider params (uses first segment; Express 5)', async () => {
+    const { runSyncForProvider } = await import('../services/sync-manual.js')
     const app = await buildApp()
     const syncRouteLayer = app.router.stack.find(
       (layer) => layer.route?.path === '/api/widgets/sync/:provider'
@@ -876,11 +877,11 @@ describe('createExpressApp auth and session branches', () => {
 
     await syncHandler?.(req, res)
 
-    expect(logger.info).toHaveBeenCalledWith(
-      'Attempted to sync an unrecognized provider: undefined'
+    expect(runSyncForProvider).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: 'discogs' }),
     )
-    expect(res.status).toHaveBeenCalledWith(400)
-    expect(res.send).toHaveBeenCalledWith('Unrecognized or unsupported provider.')
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(res.send).toHaveBeenCalled()
   })
 
   it('widget GET rateLimit keyGenerator includes request path', async () => {

--- a/functions/app/create-express-app.test.ts
+++ b/functions/app/create-express-app.test.ts
@@ -680,6 +680,37 @@ describe('createExpressApp auth and session branches', () => {
       }
     })
 
+    it('honors x-chronogrove-public-host when Host is a Cloud Run hostname (SSR probe)', async () => {
+      const prev = process.env.WIDGET_USER_ID_BY_HOSTNAME
+      process.env.WIDGET_USER_ID_BY_HOSTNAME = JSON.stringify({
+        'widgets.run.example': 'run-tenant-user',
+      })
+      try {
+        const app = await buildApp()
+        const { getWidgetContent } = await import('../widgets/get-widget-content.js')
+        vi.mocked(getWidgetContent).mockClear()
+
+        await request(app)
+          .get('/api/widgets/spotify')
+          .set('Host', 'my-service-abc123-uc.a.run.app')
+          .set('x-chronogrove-public-host', 'widgets.run.example')
+          .expect(200)
+
+        expect(vi.mocked(getWidgetContent)).toHaveBeenCalledWith(
+          'spotify',
+          'run-tenant-user',
+          documentStore,
+          expect.anything(),
+        )
+      } finally {
+        if (prev === undefined) {
+          delete process.env.WIDGET_USER_ID_BY_HOSTNAME
+        } else {
+          process.env.WIDGET_USER_ID_BY_HOSTNAME = prev
+        }
+      }
+    })
+
     it('returns 404 when uid query is invalid', async () => {
       const app = await buildApp()
 

--- a/functions/app/create-express-app.ts
+++ b/functions/app/create-express-app.ts
@@ -160,30 +160,33 @@ function normalizeExpressPathParam(param: unknown): string | undefined {
   return undefined
 }
 
-const MANUAL_SYNC_PROVIDER_FROM_PATH_JSON =
-  /^\/api\/widgets\/sync\/([^/]+)\/?$/u
-const MANUAL_SYNC_PROVIDER_FROM_PATH_STREAM =
-  /^\/api\/widgets\/sync\/([^/]+)\/stream\/?$/u
+/** Match pathname suffix so provider still resolves when `req.path` includes a mount prefix (e.g. Functions emulator). */
+const MANUAL_SYNC_PROVIDER_FROM_PATH_JSON = /\/api\/widgets\/sync\/([^/]+)\/?$/u
+const MANUAL_SYNC_PROVIDER_FROM_PATH_STREAM = /\/api\/widgets\/sync\/([^/]+)\/stream\/?$/u
 
 function parseManualSyncProviderSegmentFromRequest(
   req: express.Request,
   route: 'json' | 'stream',
 ): string | undefined {
   const re = route === 'stream' ? MANUAL_SYNC_PROVIDER_FROM_PATH_STREAM : MANUAL_SYNC_PROVIDER_FROM_PATH_JSON
-  const pathStr = (req.path ?? '').split('?')[0] ?? ''
-  let m = pathStr.match(re)
-  let segment = m?.[1]?.trim()
-  if (segment) {
-    return segment.toLowerCase()
+  const tryPathname = (pathname: string): string | undefined => {
+    const pathStr = pathname.split('?')[0] ?? ''
+    const m = pathStr.match(re)
+    const segment = m?.[1]?.trim()
+    return segment ? segment.toLowerCase() : undefined
+  }
+
+  const fromReqPath = tryPathname(req.path ?? '')
+  if (fromReqPath) {
+    return fromReqPath
   }
   const orig = req.originalUrl ?? req.url
   if (orig) {
     try {
       const u = new URL(orig, 'http://localhost')
-      m = u.pathname.match(re)
-      segment = m?.[1]?.trim()
-      if (segment) {
-        return segment.toLowerCase()
+      const fromOrig = tryPathname(u.pathname)
+      if (fromOrig) {
+        return fromOrig
       }
     } catch {
       /* ignore malformed URL */

--- a/functions/app/create-express-app.ts
+++ b/functions/app/create-express-app.ts
@@ -80,12 +80,24 @@ const buildSuccessResponse = <TPayload>(
     payload,
   })
 
+function formatUnknownFailureMessage(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message
+  }
+  const message = (err as { message?: unknown })?.message
+  if (typeof message === 'string') {
+    return message
+  }
+  try {
+    return JSON.stringify(err)
+  } catch {
+    return String(err)
+  }
+}
+
 const buildFailureResponse = (err: unknown = {}): { ok: false; error: string } => ({
   ok: false,
-  error:
-    err instanceof Error
-      ? err.message
-      : (err as { message?: string })?.message ?? String(err),
+  error: err instanceof Error ? err.message : formatUnknownFailureMessage(err),
 })
 
 /** Production gate: revisit domain allowlist, MFA, and Firebase Auth policies before a public launch. */
@@ -134,6 +146,17 @@ function hostPortFirst(hostOrHostPort: string): string {
   const colon = hostOrHostPort.indexOf(':')
   const host = colon === -1 ? hostOrHostPort : hostOrHostPort.slice(0, colon)
   return host.toLowerCase()
+}
+
+function normalizeExpressPathParam(param: unknown): string | undefined {
+  if (typeof param === 'string') {
+    return param
+  }
+  if (Array.isArray(param)) {
+    const first = param[0]
+    return typeof first === 'string' ? first : undefined
+  }
+  return undefined
 }
 
 /**
@@ -232,7 +255,7 @@ export const requireVerifiedEmail: express.RequestHandler = (req, res, next) => 
 }
 
 export function getSessionAuthError(authHeader: string | undefined): string | null {
-  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+  if (!authHeader?.startsWith('Bearer ')) {
     return 'No valid authorization token provided'
   }
   const token = extractBearerToken(authHeader) ?? ''
@@ -254,8 +277,58 @@ export function createExpressApp({
   const sessionCookieBaseOptions = {
     httpOnly: true,
     secure: isProductionEnvironment(),
-    sameSite: (isProductionEnvironment() ? 'strict' : 'lax') as 'strict' | 'lax',
+    sameSite: isProductionEnvironment() ? ('strict' as const) : ('lax' as const),
     path: '/',
+  }
+
+  const verifySessionClaimsFromCookie = async (
+    sessionCookie: string | undefined,
+    logVerificationDetails: boolean
+  ): Promise<AuthClaims | null> => {
+    if (!sessionCookie) {
+      return null
+    }
+    try {
+      const claims = await authService.verifySessionCookie(sessionCookie)
+      if (logVerificationDetails) {
+        logger.info('Session cookie verified successfully')
+      }
+      return claims
+    } catch (error: unknown) {
+      if (logVerificationDetails) {
+        logger.error('Session cookie verification failed', {
+          error: error instanceof Error ? error.message : '',
+          code: (error as { code?: string }).code,
+          stack: error instanceof Error ? error.stack : undefined,
+        })
+      }
+      return null
+    }
+  }
+
+  const verifyBearerClaimsFromHeader = async (
+    bearerToken: string | null,
+    logVerificationDetails: boolean,
+    requestPath: string
+  ): Promise<AuthClaims | null> => {
+    if (!bearerToken) {
+      return null
+    }
+    try {
+      const claims = await authService.verifyIdToken(bearerToken)
+      if (logVerificationDetails) {
+        logger.info('Bearer token verified', { path: requestPath })
+      }
+      return claims
+    } catch (error: unknown) {
+      if (logVerificationDetails) {
+        logger.error('JWT token verification failed', {
+          error: error instanceof Error ? error.message : '',
+          code: (error as { code?: string }).code,
+        })
+      }
+      return null
+    }
   }
 
   /**
@@ -275,40 +348,10 @@ export function createExpressApp({
     const sessionCookie = req.cookies?.session
     const bearerToken = extractBearerToken(req.headers.authorization)
 
-    let sessionClaims: AuthClaims | null = null
-    if (sessionCookie) {
-      try {
-        sessionClaims = await authService.verifySessionCookie(sessionCookie)
-        if (logVerificationDetails) {
-          logger.info('Session cookie verified successfully')
-        }
-      } catch (error) {
-        if (logVerificationDetails) {
-          logger.error('Session cookie verification failed', {
-            error: error instanceof Error ? error.message : '',
-            code: (error as { code?: string }).code,
-            stack: error instanceof Error ? error.stack : undefined,
-          })
-        }
-      }
-    }
-
-    let bearerClaims: AuthClaims | null = null
-    if (bearerToken) {
-      try {
-        bearerClaims = await authService.verifyIdToken(bearerToken)
-        if (logVerificationDetails) {
-          logger.info('Bearer token verified', { path: req.path })
-        }
-      } catch (error) {
-        if (logVerificationDetails) {
-          logger.error('JWT token verification failed', {
-            error: error instanceof Error ? error.message : '',
-            code: (error as { code?: string }).code,
-          })
-        }
-      }
-    }
+    const [sessionClaims, bearerClaims] = await Promise.all([
+      verifySessionClaimsFromCookie(sessionCookie, logVerificationDetails),
+      verifyBearerClaimsFromHeader(bearerToken, logVerificationDetails, req.path ?? ''),
+    ])
 
     const mismatch =
       sessionClaims !== null &&
@@ -646,13 +689,7 @@ export function createExpressApp({
       keyGenerator: (req) => `${getRateLimitKey(req)}:${req.path}`,
     }),
     async (req, res) => {
-      const providerParam = req.params.provider
-      const provider =
-        typeof providerParam === 'string'
-          ? providerParam
-          : Array.isArray(providerParam)
-            ? providerParam[0]
-            : undefined
+      const provider = normalizeExpressPathParam(req.params.provider)
 
       if (!provider || !isWidgetId(provider)) {
         res.status(404).json(
@@ -902,7 +939,11 @@ export function createExpressApp({
           return
         }
 
-        const token = extractBearerToken(req.headers.authorization)!
+        const token = extractBearerToken(req.headers.authorization)
+        if (!token) {
+          res.status(401).json({ ok: false, error: 'No token' })
+          return
+        }
         const decodedToken = await authService.verifyIdToken(token)
 
         if (!isAllowedEmail(decodedToken.email)) {

--- a/functions/app/create-express-app.ts
+++ b/functions/app/create-express-app.ts
@@ -148,6 +148,7 @@ function hostPortFirst(hostOrHostPort: string): string {
   return host.toLowerCase()
 }
 
+/** Express 5 may surface a captured segment as `string[]`; using only `typeof x === 'string'` yields undefined and false 400s on sync routes. */
 function normalizeExpressPathParam(param: unknown): string | undefined {
   if (typeof param === 'string') {
     return param
@@ -157,6 +158,60 @@ function normalizeExpressPathParam(param: unknown): string | undefined {
     return typeof first === 'string' ? first : undefined
   }
   return undefined
+}
+
+const MANUAL_SYNC_PROVIDER_FROM_PATH_JSON =
+  /^\/api\/widgets\/sync\/([^/]+)\/?$/u
+const MANUAL_SYNC_PROVIDER_FROM_PATH_STREAM =
+  /^\/api\/widgets\/sync\/([^/]+)\/stream\/?$/u
+
+function parseManualSyncProviderSegmentFromRequest(
+  req: express.Request,
+  route: 'json' | 'stream',
+): string | undefined {
+  const re = route === 'stream' ? MANUAL_SYNC_PROVIDER_FROM_PATH_STREAM : MANUAL_SYNC_PROVIDER_FROM_PATH_JSON
+  const pathStr = (req.path ?? '').split('?')[0] ?? ''
+  let m = pathStr.match(re)
+  let segment = m?.[1]?.trim()
+  if (segment) {
+    return segment.toLowerCase()
+  }
+  const orig = req.originalUrl ?? req.url
+  if (orig) {
+    try {
+      const u = new URL(orig, 'http://localhost')
+      m = u.pathname.match(re)
+      segment = m?.[1]?.trim()
+      if (segment) {
+        return segment.toLowerCase()
+      }
+    } catch {
+      /* ignore malformed URL */
+    }
+  }
+  return undefined
+}
+
+/**
+ * Resolves `:provider` for manual sync routes even when `req.params` is missing or oddly shaped
+ * (Express 5 / emulator / proxy edge cases). Prefers a **path-derived** segment when it is a valid
+ * sync provider so a bogus `req.params.provider` (e.g. a literal `stream` segment) cannot override
+ * the URL the client actually requested — a pattern that can look like a strict 50/50 in dev.
+ */
+function resolveManualSyncProvider(
+  req: express.Request,
+  route: 'json' | 'stream',
+): string | undefined {
+  const fromPath = parseManualSyncProviderSegmentFromRequest(req, route)
+  const fromParams = normalizeExpressPathParam(req.params?.provider)?.trim().toLowerCase() || undefined
+
+  if (fromPath && isSyncProviderId(fromPath)) {
+    return fromPath
+  }
+  if (fromParams && isSyncProviderId(fromParams)) {
+    return fromParams
+  }
+  return fromParams ?? fromPath
 }
 
 /**
@@ -610,11 +665,15 @@ export function createExpressApp({
     authenticateUser,
     requireVerifiedEmail,
     async (req, res) => {
-      const providerParam = req.params.provider
-      const provider = typeof providerParam === 'string' ? providerParam : undefined
+      const provider = resolveManualSyncProvider(req, 'stream')
 
       if (!provider || !isSyncProviderId(provider)) {
-        logger.info(`Attempted to sync stream for an unrecognized provider: ${provider}`)
+        logger.info('Attempted to sync stream for an unrecognized provider', {
+          provider,
+          path: req.path,
+          originalUrl: req.originalUrl,
+          params: req.params,
+        })
         res.status(400).send('Unrecognized or unsupported provider.')
         return
       }
@@ -659,11 +718,15 @@ export function createExpressApp({
     authenticateUser,
     requireVerifiedEmail,
     async (req, res) => {
-      const providerParam = req.params.provider
-      const provider = typeof providerParam === 'string' ? providerParam : undefined
+      const provider = resolveManualSyncProvider(req, 'json')
 
       if (!provider || !isSyncProviderId(provider)) {
-        logger.info(`Attempted to sync an unrecognized provider: ${provider}`)
+        logger.info('Attempted to sync an unrecognized provider', {
+          provider,
+          path: req.path,
+          originalUrl: req.originalUrl,
+          params: req.params,
+        })
         res.status(400).send('Unrecognized or unsupported provider.')
         return
       }

--- a/functions/app/create-express-app.ts
+++ b/functions/app/create-express-app.ts
@@ -80,7 +80,7 @@ const buildSuccessResponse = <TPayload>(
     payload,
   })
 
-function formatUnknownFailureMessage(err: unknown): string {
+export function formatUnknownFailureMessage(err: unknown): string {
   if (err instanceof Error) {
     return err.message
   }
@@ -149,7 +149,7 @@ function hostPortFirst(hostOrHostPort: string): string {
 }
 
 /** Express 5 may surface a captured segment as `string[]`; using only `typeof x === 'string'` yields undefined and false 400s on sync routes. */
-function normalizeExpressPathParam(param: unknown): string | undefined {
+export function normalizeExpressPathParam(param: unknown): string | undefined {
   if (typeof param === 'string') {
     return param
   }
@@ -164,7 +164,7 @@ function normalizeExpressPathParam(param: unknown): string | undefined {
 const MANUAL_SYNC_PROVIDER_FROM_PATH_JSON = /\/api\/widgets\/sync\/([^/]+)\/?$/u
 const MANUAL_SYNC_PROVIDER_FROM_PATH_STREAM = /\/api\/widgets\/sync\/([^/]+)\/stream\/?$/u
 
-function parseManualSyncProviderSegmentFromRequest(
+export function parseManualSyncProviderSegmentFromRequest(
   req: express.Request,
   route: 'json' | 'stream',
 ): string | undefined {
@@ -201,7 +201,7 @@ function parseManualSyncProviderSegmentFromRequest(
  * sync provider so a bogus `req.params.provider` (e.g. a literal `stream` segment) cannot override
  * the URL the client actually requested — a pattern that can look like a strict 50/50 in dev.
  */
-function resolveManualSyncProvider(
+export function resolveManualSyncProvider(
   req: express.Request,
   route: 'json' | 'stream',
 ): string | undefined {
@@ -223,7 +223,8 @@ function resolveManualSyncProvider(
  * SSR status probes call the Functions URL directly; there the Host is infrastructure-only,
  * so the console-sent probe header is applied.
  */
-function isInfrastructurePublicWidgetHostname(hostname: string): boolean {
+/** @internal Exported for tests — loopback / empty labels gate `x-chronogrove-public-host`. */
+export function isInfrastructurePublicWidgetHostname(hostname: string): boolean {
   const h = hostname.toLowerCase()
   if (!h) {
     return true

--- a/functions/app/create-express-app.ts
+++ b/functions/app/create-express-app.ts
@@ -1005,11 +1005,7 @@ export function createExpressApp({
           return
         }
 
-        const token = extractBearerToken(req.headers.authorization)
-        if (!token) {
-          res.status(401).json({ ok: false, error: 'No token' })
-          return
-        }
+        const token = extractBearerToken(req.headers.authorization) as string
         const decodedToken = await authService.verifyIdToken(token)
 
         if (!isAllowedEmail(decodedToken.email)) {

--- a/functions/app/oauth-github.ts
+++ b/functions/app/oauth-github.ts
@@ -105,6 +105,77 @@ function expiresAtFromGithub(expiresInSeconds: number | undefined): string | und
   return new Date(Date.now() + expiresInSeconds * 1000).toISOString()
 }
 
+type GitHubOAuthCfgReady = {
+  clientId: string
+  clientSecret: string
+  callbackUrl: string
+}
+
+async function completeGitHubOAuthLink(params: {
+  documentStore: DocumentStore
+  usersPath: string
+  oauthCfg: GitHubOAuthCfgReady
+  uid: string
+  pendingPath: string
+  code: string
+  validatedReturnTo: string | null
+  req: express.Request
+  res: express.Response
+  logger: LoggerLike
+}): Promise<void> {
+  const {
+    documentStore,
+    usersPath,
+    oauthCfg,
+    uid,
+    pendingPath,
+    code,
+    validatedReturnTo,
+    req,
+    res,
+    logger,
+  } = params
+
+  const token = await exchangeGitHubOAuthCode({
+    clientId: oauthCfg.clientId,
+    clientSecret: oauthCfg.clientSecret,
+    code,
+    redirectUri: oauthCfg.callbackUrl,
+  })
+
+  const login = await fetchGitHubViewerLogin(token.access_token)
+
+  const credPayload: GitHubOAuthCredentialPayload = {
+    accessToken: token.access_token,
+    refreshToken: token.refresh_token,
+    expiresAt: expiresAtFromGithub(token.expires_in),
+  }
+  const envelope = encryptJsonEnvelope(uid, credPayload)
+
+  const integrationPath = `${usersPath}/${uid}/${USER_INTEGRATIONS_SEGMENT}/${GITHUB_INTEGRATION_ID}`
+  await documentStore.setDocument(integrationPath, {
+    providerId: GITHUB_INTEGRATION_ID,
+    status: 'connected',
+    githubUsername: login,
+    credentialEnvelope: envelope,
+    oauthCompletedAt: toStoredDateTime(),
+    updatedAt: toStoredDateTime(),
+  })
+
+  if (documentStore.deleteDocument) {
+    await documentStore.deleteDocument(pendingPath)
+  }
+
+  logger.info('GitHub OAuth completed', { uid, login })
+
+  const cfg = getGitHubOAuthConfig()
+  const successPath =
+    validatedReturnTo != null
+      ? withGitHubOAuthFlash(validatedReturnTo, 'success')
+      : cfg.appSuccessRedirect
+  res.redirect(302, resolveGitHubOAuthRedirectUrl(req, successPath))
+}
+
 export interface RegisterGitHubOAuthOptions {
   expressApp: express.Express
   authenticateUser: express.RequestHandler
@@ -288,10 +359,15 @@ export function registerGitHubOAuthRoutes(opts: RegisterGitHubOAuthOptions): voi
       }
 
       const uid = pending.uid
-      const oauthCfg = getGitHubOAuthConfig()
-      if (!oauthCfg.clientId || !oauthCfg.clientSecret || !oauthCfg.callbackUrl) {
+      const oauthCfgRaw = getGitHubOAuthConfig()
+      if (!oauthCfgRaw.clientId || !oauthCfgRaw.clientSecret || !oauthCfgRaw.callbackUrl) {
         failRedirect('server_misconfigured')
         return
+      }
+      const oauthCfg: GitHubOAuthCfgReady = {
+        clientId: oauthCfgRaw.clientId,
+        clientSecret: oauthCfgRaw.clientSecret,
+        callbackUrl: oauthCfgRaw.callbackUrl,
       }
 
       let encryptionReady = true
@@ -307,44 +383,18 @@ export function registerGitHubOAuthRoutes(opts: RegisterGitHubOAuthOptions): voi
       }
 
       try {
-        const token = await exchangeGitHubOAuthCode({
-          clientId: oauthCfg.clientId,
-          clientSecret: oauthCfg.clientSecret,
+        await completeGitHubOAuthLink({
+          documentStore,
+          usersPath,
+          oauthCfg,
+          uid,
+          pendingPath,
           code,
-          redirectUri: oauthCfg.callbackUrl,
+          validatedReturnTo,
+          req,
+          res,
+          logger,
         })
-
-        const login = await fetchGitHubViewerLogin(token.access_token)
-
-        const credPayload: GitHubOAuthCredentialPayload = {
-          accessToken: token.access_token,
-          refreshToken: token.refresh_token,
-          expiresAt: expiresAtFromGithub(token.expires_in),
-        }
-        const envelope = encryptJsonEnvelope(uid, credPayload)
-
-        const integrationPath = `${usersPath}/${uid}/${USER_INTEGRATIONS_SEGMENT}/${GITHUB_INTEGRATION_ID}`
-        await documentStore.setDocument(integrationPath, {
-          providerId: GITHUB_INTEGRATION_ID,
-          status: 'connected',
-          githubUsername: login,
-          credentialEnvelope: envelope,
-          oauthCompletedAt: toStoredDateTime(),
-          updatedAt: toStoredDateTime(),
-        })
-
-        if (documentStore.deleteDocument) {
-          await documentStore.deleteDocument(pendingPath)
-        }
-
-        logger.info('GitHub OAuth completed', { uid, login })
-
-        const cfg = getGitHubOAuthConfig()
-        const successPath =
-          validatedReturnTo != null
-            ? withGitHubOAuthFlash(validatedReturnTo, 'success')
-            : cfg.appSuccessRedirect
-        res.redirect(302, resolveGitHubOAuthRedirectUrl(req, successPath))
       } catch (err) {
         logger.error('GitHub OAuth callback failed', { uid, error: err })
         failRedirect('token_exchange_failed')

--- a/functions/app/onboarding-progress.ts
+++ b/functions/app/onboarding-progress.ts
@@ -142,7 +142,7 @@ export function buildClientPayloadFromFirestore(params: {
 
   const noOnboardingDoc =
     doc == null ||
-    !Object.prototype.hasOwnProperty.call(doc, 'onboarding') ||
+    !Object.hasOwn(doc as object, 'onboarding') ||
     rawOnboarding === null ||
     typeof rawOnboarding !== 'object'
 
@@ -162,11 +162,14 @@ export function buildClientPayloadFromFirestore(params: {
     ? (legacy.currentStep ?? userOnboarding.currentStep)
     : userOnboarding.currentStep
 
-  const completedSteps = noOnboardingDoc
-    ? legacy.completedSteps ?? userOnboarding.completedSteps
-    : userOnboarding.completedSteps.length > 0
-      ? userOnboarding.completedSteps
-      : (legacy.completedSteps ?? base.completedSteps)
+  let completedSteps: OnboardingWizardStep[]
+  if (noOnboardingDoc) {
+    completedSteps = legacy.completedSteps ?? userOnboarding.completedSteps
+  } else if (userOnboarding.completedSteps.length > 0) {
+    completedSteps = userOnboarding.completedSteps
+  } else {
+    completedSteps = legacy.completedSteps ?? base.completedSteps
+  }
 
   const customDomain =
     tenantHostnameFromUserDoc(doc) ?? legacy.customDomain ?? base.customDomain
@@ -200,6 +203,44 @@ export function normalizeOnboardingProgress(
   })
 }
 
+function parseOptionalUsername(
+  un: unknown,
+): { ok: true; value: string | null } | { ok: false; error: string } {
+  let username: string | null = null
+  if (un !== null && un !== undefined) {
+    if (typeof un !== 'string') {
+      return { ok: false, error: 'Invalid username' }
+    }
+    if (un.length > 0) {
+      const lowered = un.toLowerCase()
+      if (!ONBOARDING_USERNAME_PATTERN.test(lowered)) {
+        return { ok: false, error: 'Invalid username format' }
+      }
+      username = lowered
+    }
+  }
+  return { ok: true, value: username }
+}
+
+function parseOptionalCustomDomain(
+  cd: unknown,
+): { ok: true; value: string | null } | { ok: false; error: string } {
+  let customDomain: string | null = null
+  if (cd !== null && cd !== undefined) {
+    if (typeof cd !== 'string') {
+      return { ok: false, error: 'Invalid customDomain' }
+    }
+    const t = cd.toLowerCase().trim()
+    if (t.length > 0) {
+      if (t.length > 253 || !DOMAIN_FORMAT.test(t)) {
+        return { ok: false, error: 'Invalid domain' }
+      }
+      customDomain = t
+    }
+  }
+  return { ok: true, value: customDomain }
+}
+
 export function parseOnboardingProgressBody(
   body: unknown
 ): { ok: true; value: OnboardingProgressPayload } | { ok: false; error: string } {
@@ -218,19 +259,9 @@ export function parseOnboardingProgressBody(
   const completedSteps = compRaw.filter(
     (x): x is OnboardingWizardStep => typeof x === 'string' && isWizardStep(x),
   )
-  const un = o.username
-  let username: string | null = null
-  if (un !== null && un !== undefined) {
-    if (typeof un !== 'string') {
-      return { ok: false, error: 'Invalid username' }
-    }
-    if (un.length > 0) {
-      const lowered = un.toLowerCase()
-      if (!ONBOARDING_USERNAME_PATTERN.test(lowered)) {
-        return { ok: false, error: 'Invalid username format' }
-      }
-      username = lowered
-    }
+  const usernameResult = parseOptionalUsername(o.username)
+  if (!usernameResult.ok) {
+    return usernameResult
   }
   const cp = o.connectedProviderIds
   if (!Array.isArray(cp)) {
@@ -241,28 +272,18 @@ export function parseOnboardingProgressBody(
       typeof x === 'string' &&
       (ONBOARDING_OAUTH_PROVIDER_IDS as readonly string[]).includes(x),
   )
-  const cd = o.customDomain
-  let customDomain: string | null = null
-  if (cd !== null && cd !== undefined) {
-    if (typeof cd !== 'string') {
-      return { ok: false, error: 'Invalid customDomain' }
-    }
-    const t = cd.toLowerCase().trim()
-    if (t.length > 0) {
-      if (t.length > 253 || !DOMAIN_FORMAT.test(t)) {
-        return { ok: false, error: 'Invalid domain' }
-      }
-      customDomain = t
-    }
+  const customDomainResult = parseOptionalCustomDomain(o.customDomain)
+  if (!customDomainResult.ok) {
+    return customDomainResult
   }
   return {
     ok: true,
     value: {
       currentStep: currentStepRaw,
       completedSteps,
-      username,
+      username: usernameResult.value,
       connectedProviderIds,
-      customDomain,
+      customDomain: customDomainResult.value,
       updatedAt: toStoredDateTime(),
     },
   }

--- a/functions/app/onboarding-progress.ts
+++ b/functions/app/onboarding-progress.ts
@@ -260,8 +260,8 @@ export function parseOnboardingProgressBody(
     (x): x is OnboardingWizardStep => typeof x === 'string' && isWizardStep(x),
   )
   const usernameResult = parseOptionalUsername(o.username)
-  if (!usernameResult.ok) {
-    return usernameResult
+  if (usernameResult.ok === false) {
+    return { ok: false, error: usernameResult.error }
   }
   const cp = o.connectedProviderIds
   if (!Array.isArray(cp)) {
@@ -273,8 +273,8 @@ export function parseOnboardingProgressBody(
       (ONBOARDING_OAUTH_PROVIDER_IDS as readonly string[]).includes(x),
   )
   const customDomainResult = parseOptionalCustomDomain(o.customDomain)
-  if (!customDomainResult.ok) {
-    return customDomainResult
+  if (customDomainResult.ok === false) {
+    return { ok: false, error: customDomainResult.error }
   }
   return {
     ok: true,

--- a/functions/app/resolve-widget-data-user-id.ts
+++ b/functions/app/resolve-widget-data-user-id.ts
@@ -20,13 +20,31 @@ export function firstQueryString(value: unknown): string | undefined {
   return undefined
 }
 
+async function resolveUserIdFromUsernameClaim(
+  loweredUsername: string,
+  documentStore: DocumentStore,
+): Promise<{ userId: string } | 'not_found'> {
+  const claimPath = `${TENANT_USERNAMES_COLLECTION}/${loweredUsername}`
+  const claim = await documentStore.getDocument<{ uid?: unknown }>(claimPath)
+  if (claim?.uid != null && typeof claim.uid === 'string' && claim.uid.length > 0) {
+    return { userId: claim.uid }
+  }
+  if (documentStore.legacyUsernameOwnerUid) {
+    const owner = await documentStore.legacyUsernameOwnerUid(getUsersCollectionPath(), loweredUsername)
+    if (owner) {
+      return { userId: owner }
+    }
+  }
+  return 'not_found'
+}
+
 /**
  * Optional `uid` or `username` on public widget reads. `uid` wins when both are present.
  * Returns `skip` to fall back to hostname-based resolution.
  */
 export async function resolveWidgetDataUserIdFromPublicQuery(
   req: Request,
-  documentStore: DocumentStore
+  documentStore: DocumentStore,
 ): Promise<'skip' | { userId: string } | 'not_found'> {
   const query = req.query && typeof req.query === 'object' ? req.query : {}
   const uidParam = firstQueryString(query.uid)
@@ -44,18 +62,7 @@ export async function resolveWidgetDataUserIdFromPublicQuery(
     if (!ONBOARDING_USERNAME_PATTERN.test(lowered)) {
       return 'not_found'
     }
-    const claimPath = `${TENANT_USERNAMES_COLLECTION}/${lowered}`
-    const claim = await documentStore.getDocument<{ uid?: unknown }>(claimPath)
-    if (claim && typeof claim.uid === 'string' && claim.uid.length > 0) {
-      return { userId: claim.uid }
-    }
-    if (documentStore.legacyUsernameOwnerUid) {
-      const owner = await documentStore.legacyUsernameOwnerUid(getUsersCollectionPath(), lowered)
-      if (owner) {
-        return { userId: owner }
-      }
-    }
-    return 'not_found'
+    return resolveUserIdFromUsernameClaim(lowered, documentStore)
   }
 
   return 'skip'

--- a/functions/index.test.ts
+++ b/functions/index.test.ts
@@ -258,7 +258,7 @@ describe('index.js', () => {
         })
       })
 
-      it('should handle getWidgetContent rejecting with value that has no .message (buildFailureResponse String fallback)', async () => {
+      it('should handle getWidgetContent rejecting with value that has no .message (buildFailureResponse JSON fallback)', async () => {
         const { getWidgetContent } = await import('./widgets/get-widget-content.js')
         vi.mocked(getWidgetContent).mockRejectedValueOnce({ code: 'UNKNOWN' })
 
@@ -267,7 +267,7 @@ describe('index.js', () => {
           .expect(500)
 
         expect(response.body.ok).toBe(false)
-        expect(response.body.error).toBe('[object Object]')
+        expect(response.body.error).toBe('{"code":"UNKNOWN"}')
       })
 
       it('should use default widget user for api.chronogrove.com when host is not mapped', async () => {

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -113,5 +113,5 @@ export const handleUserCreation = registerFirebaseUserCreationTrigger(async (eve
 export const app = registerFirebaseHttpFunction(async (req, res) => {
   const { ensureRuntimeConfigApplied } = getBackendBootstrap()
   await ensureRuntimeConfigApplied()
-  expressApp(req as Parameters<typeof expressApp>[0], res as Parameters<typeof expressApp>[1])
+  expressApp(req, res)
 }, runtimeSecrets)

--- a/functions/index.ts
+++ b/functions/index.ts
@@ -113,5 +113,5 @@ export const handleUserCreation = registerFirebaseUserCreationTrigger(async (eve
 export const app = registerFirebaseHttpFunction(async (req, res) => {
   const { ensureRuntimeConfigApplied } = getBackendBootstrap()
   await ensureRuntimeConfigApplied()
-  expressApp(req, res)
+  expressApp(req as ExpressRequest, res as ExpressResponse)
 }, runtimeSecrets)

--- a/functions/jobs/sync-discogs-data.ts
+++ b/functions/jobs/sync-discogs-data.ts
@@ -85,6 +85,29 @@ const getMediaReducer = (storedMediaFileNames: string[] = []) =>
     return acc
   }
 
+function logDiscogsFirestorePayloadSize(
+  logger: ReturnType<typeof getLogger>,
+  documentToSave: Record<string, unknown>,
+  enhancedReleases: DiscogsEnhancedRelease[],
+): void {
+  const documentSizeBytes = Buffer.byteLength(JSON.stringify(documentToSave), 'utf8')
+  const documentSizeKB = Math.round(documentSizeBytes / 1024)
+  const documentSizeMB = Math.round((documentSizeBytes / (1024 * 1024)) * 100) / 100
+
+  logger.info(
+    `Document size before saving: ${documentSizeBytes} bytes (${documentSizeKB} KB, ${documentSizeMB} MB)`,
+    {
+      totalReleases: enhancedReleases.length,
+      releasesWithResource: enhancedReleases.filter((r) => r.resource).length,
+      releasesWithoutResource: enhancedReleases.filter((r) => !r.resource).length,
+      firestoreLimit: 1048576,
+      exceedsLimit: documentSizeBytes > 1048576,
+      sizeReduction:
+        documentSizeBytes > 1048576 ? 'Filtered resource data to reduce size' : 'No filtering needed',
+    },
+  )
+}
+
 const syncDiscogsData = async (
   documentStore: DocumentStore,
   options: SyncJobExecutionOptions = {}
@@ -142,18 +165,7 @@ const syncDiscogsData = async (
       fetchedAt: toStoredDateTime(),
     }
     
-    const documentSizeBytes = Buffer.byteLength(JSON.stringify(documentToSave), 'utf8')
-    const documentSizeKB = Math.round(documentSizeBytes / 1024)
-    const documentSizeMB = Math.round(documentSizeBytes / (1024 * 1024) * 100) / 100
-    
-    logger.info(`Document size before saving: ${documentSizeBytes} bytes (${documentSizeKB} KB, ${documentSizeMB} MB)`, {
-      totalReleases: enhancedReleases.length,
-      releasesWithResource: enhancedReleases.filter(r => r.resource).length,
-      releasesWithoutResource: enhancedReleases.filter(r => !r.resource).length,
-      firestoreLimit: 1048576, // 1MB in bytes
-      exceedsLimit: documentSizeBytes > 1048576,
-      sizeReduction: documentSizeBytes > 1048576 ? 'Filtered resource data to reduce size' : 'No filtering needed',
-    })
+    logDiscogsFirestorePayloadSize(logger, documentToSave, enhancedReleases)
 
     onProgress?.({
       phase: 'discogs.save_raw',

--- a/functions/jobs/sync-goodreads-data.ts
+++ b/functions/jobs/sync-goodreads-data.ts
@@ -121,12 +121,7 @@ const processUpdatesWithMedia = async (
   const updatesWithMedia: GoodreadsUpdateWithMedia[] = updates.map((update): GoodreadsUpdateWithMedia => {
     // Get ISBN from the update's book
     let isbn: string | null = null
-    if (update.type === 'userstatus' && update.book) {
-      const isbn13 = getXmlTextOrNull(update.book.isbn13)
-      const isbn10 = getXmlTextOrNull(update.book.isbn)
-      isbn = isbn13 ?? isbn10
-    } else if (update.type === 'review' && update.book) {
-      // Review updates might not have ISBN, but check anyway
+    if ((update.type === 'userstatus' || update.type === 'review') && update.book) {
       const isbn13 = getXmlTextOrNull(update.book.isbn13)
       const isbn10 = getXmlTextOrNull(update.book.isbn)
       isbn = isbn13 ?? isbn10
@@ -135,7 +130,7 @@ const processUpdatesWithMedia = async (
     // If we have ISBN, try to match with existing books
     if (isbn) {
       const matchingBook = booksByISBN.get(isbn) || booksByISBN.get(isbn.replace(/-/g, ''))
-      if (matchingBook && matchingBook.cdnMediaURL) {
+      if (matchingBook?.cdnMediaURL) {
         // Book already exists, use its CDN URL
         const updateWithMedia: GoodreadsUpdateWithMedia = { ...update }
         updateWithMedia.cdnMediaURL = matchingBook.cdnMediaURL
@@ -169,7 +164,7 @@ const processUpdatesWithMedia = async (
     >()
     updatesNeedingBooks.forEach(({ update, isbn }) => {
       const book = update.book
-      if (!book || !book.title) return
+      if (!book?.title) return
       
       // Use ISBN as key if available, otherwise use title
       const key = isbn ? `isbn:${isbn}` : `title:${book.title.toLowerCase().trim()}`


### PR DESCRIPTION
## Summary

Collected **console** and **Cloud Functions** fixes: Sonar-style cleanups, accessibility, safer error handling, test alignment, and manual sync route hardening. Touches **63 files** (~1.9k insertions / ~0.9k deletions vs `main`).

## Console (`apps/console`)

- Sonar-driven updates: `Readonly<>` props, reduced nesting (e.g. auth error messages), complexity refactors where flagged.
- **Accessibility**: theme picker as real radios + focus styles; user menu theme group as `<fieldset>`; mobile nav overlay as a focusable `<button>` with screen-reader label; label text wrapped in `<span>` where inputs sit inside labels; `<dialog>` for add-providers flyout with UA style resets.
- **Async hygiene**: replace bare `void promise` with `.catch(() => {})` where appropriate in handlers.
- **Three.js / visuals**: `SonoranDuskScene` disposal helpers; `StarryNightBrush` structure + Bezier spec objects.
- **Next**: `next-env.d.ts` routes import path updated for dev (`.next/dev/types/routes.d.ts`).

## Functions (`functions`)

- Broad **Sonar / lint** refactors across jobs, OAuth, Goodreads/Google Books/Steam/Discogs/Flickr paths, storage adapters, sync job queue—optional chaining, smaller functions, explicit `Error` throws, JSON-safe parsing (e.g. Goodreads API error bodies with guarded `JSON.parse`).
- **`buildFailureResponse` / tests**: unknown errors use `JSON.stringify` instead of `[object Object]`; Vitest expectations updated.
- **Express / manual sync**: `normalizeExpressPathParam`, `resolveManualSyncProvider` (path vs params, valid sync provider preference), structured logging on bad provider; **suffix-based** path regex so provider still resolves when pathname includes an emulator/mount prefix (`376c5f6`); expanded route coverage tests.
- **TypeScript build**: onboarding progress discriminated unions; `index.ts` handler typing for Express.
- Misc: `generate-steam-summary` string errors, Firestore sync queue rejection typing, etc.

## Commits (newest first)

- `376c5f6` — fix(functions): parse manual sync provider from path suffix
- `92c6121` — fix(functions): harden manual sync provider resolution and dev build
- `977dc8b` — fix(functions): address Sonar issues and align tests
- `c2f84ff` — fix: Sonar cleanups, safer errors, overview status dot a11y
- `3197832` — fix(console): polish sections for Sonar and dialog flyout UA styles
- `7f330a9` — fix(console): resolve Sonar accessibility and complexity findings
- `92963c7` — fix(console): address Sonar issues (a11y, readonly props, complexity)

## Known follow-up (not closed by this PR)

Intermittent **400** on manual widget sync (sometimes every other request) is **reproduced on `main`**; tracked separately in #310. Path-suffix parsing here is a partial hardening attempt; further logging / root cause still TBD.

## Testing

- `pnpm --filter chronogrove-functions vitest run` (or workspace `turbo run test`) recommended before merge.
- Console: spot-check theme picker, mobile nav overlay, add-providers flyout, user settings / delete account flows.
