### PR TITLE
release(functions): 0.30.8 — fetch 24 Spotify top tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Package-specific changes:
 
 ### Changed
 
+- **Workspace** — **Functions 0.30.8**: Spotify **`me/top/tracks`** sync requests **`limit: 24`** instead of **12**, so the widget can surface more short-term top tracks after the next sync. See **[functions/CHANGELOG.md](functions/CHANGELOG.md)**.
+
 - **Workspace** — **Functions 0.30.7** and **Console 0.6.27**: Steam AI summary prompt slimmed so default Anthropic **`max_tokens`** no longer truncates JSON in production; console **`SettingsProfileIdentity`** clear-username test hardened for CI; functions release also includes CORS allowlist tweak for **`chrisvogt.me`**, emulator **`prestart` → `build`**, and AI summary **`jsonrepair`** / logging adjustments documented in **[functions/CHANGELOG.md](functions/CHANGELOG.md)**. See [functions/CHANGELOG.md](functions/CHANGELOG.md) and [apps/console/CHANGELOG.md](apps/console/CHANGELOG.md).
 
 - **Workspace** — **Console 0.6.25**: **Next.js** pinned to exact **`16.2.4`** so Firebase App Hosting’s **`@apphosting/adapter-nextjs`** CVE version check receives a valid semver (ranges like **`^16.2.4`** were mis-rejected and blocked deploy). Documented in **[docs/APP_HOSTING.md](docs/APP_HOSTING.md)** and **[apps/console/README.md](apps/console/README.md)**. See [apps/console/CHANGELOG.md](apps/console/CHANGELOG.md).

--- a/functions/CHANGELOG.md
+++ b/functions/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.8] - 2026-05-11
+
+### Changed
+
+- **Spotify widget sync** — **`api/spotify/get-top-tracks`** passes **`limit: 24`** (was **12**) to **`GET me/top/tracks`** with **`time_range: short_term`**, so **`collections.topTracks`** can persist up to 24 tracks per successful sync (Spotify allows up to **50** per request). Unit test expectations and **`top-tracks.mock.json`** pagination metadata updated.
+
 ## [0.30.7] - 2026-05-10
 
 ### Fixed
@@ -820,6 +826,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _This changelog was started with v0.8.0._
 
+[0.30.8]: https://github.com/chrisvogt/chronogrove/compare/v0.30.7...v0.30.8
 [0.30.3]: https://github.com/chrisvogt/chronogrove/compare/v0.30.2...v0.30.3
 [0.30.2]: https://github.com/chrisvogt/chronogrove/compare/v0.30.1...v0.30.2
 [0.30.1]: https://github.com/chrisvogt/chronogrove/compare/v0.30.0...v0.30.1

--- a/functions/api/spotify/get-top-tracks.test.ts
+++ b/functions/api/spotify/get-top-tracks.test.ts
@@ -52,7 +52,7 @@ describe('getTopTracks', () => {
       headers: { Authorization: 'Bearer test-access-token' },
       searchParams: {
         time_range: 'short_term',
-        limit: 12
+        limit: 24
       }
     })
 

--- a/functions/api/spotify/get-top-tracks.ts
+++ b/functions/api/spotify/get-top-tracks.ts
@@ -11,7 +11,7 @@ const getTopTracks = async accessToken => {
     },
     searchParams: {
       time_range: 'short_term',
-      limit: 12
+      limit: 24
     }
   })
   const { items } = body

--- a/functions/api/spotify/top-tracks.mock.json
+++ b/functions/api/spotify/top-tracks.mock.json
@@ -2662,9 +2662,9 @@
     }
   ],
   "total": 50,
-  "limit": 12,
+  "limit": 24,
   "offset": 0,
-  "href": "https://api.spotify.com/v1/me/top/tracks?limit=12&offset=0",
+  "href": "https://api.spotify.com/v1/me/top/tracks?limit=24&offset=0",
   "previous": null,
-  "next": "https://api.spotify.com/v1/me/top/tracks?limit=12&offset=12"
+  "next": "https://api.spotify.com/v1/me/top/tracks?limit=24&offset=24"
 }

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chronogrove-functions",
-  "version": "0.30.7",
+  "version": "0.30.8",
   "license": "Apache-2.0",
   "description": "Chronogrove server: Firebase Cloud Functions for the public widget API, authenticated admin routes, and provider sync jobs.",
   "type": "module",


### PR DESCRIPTION
## Summary

Raises the Spotify **`me/top/tracks`** request **`limit`** from **12** to **24** (still **`short_term`**), so widget sync can persist more top tracks per run. Spotify allows up to **50** per request, so **24** is within API limits.

## Changes

- **`functions/api/spotify/get-top-tracks.ts`** — `limit: 24`
- **Tests** — `get-top-tracks.test.ts` expectation updated
- **Fixture** — `top-tracks.mock.json` pagination metadata (`limit` / `href` / `next`)
- **Release** — `chronogrove-functions` **0.30.8**; entries in **`functions/CHANGELOG.md`** and root **`CHANGELOG.md`**

## Note

Existing Firestore widget content keeps the previous track count until the next successful Spotify sync after deploy.

Made with [Cursor](https://cursor.com)