### PR TITLE
feat(functions): first-person AI summaries; Steam parse-failure logging (v0.30.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Package-specific changes:
 
 ### Changed
 
+- **Workspace** — **Functions 0.30.9**: Goodreads and Steam widget AI summaries use **first-person** prompts; Steam adds structured **Cloud Logging** on JSON parse failure (**`head`** / **`tail`** / indices). See **[functions/CHANGELOG.md](functions/CHANGELOG.md)**.
+
 - **Workspace** — **Functions 0.30.8**: Spotify **`me/top/tracks`** sync requests **`limit: 24`** instead of **12**, so the widget can surface more short-term top tracks after the next sync. See **[functions/CHANGELOG.md](functions/CHANGELOG.md)**.
 
 - **Workspace** — **Functions 0.30.7** and **Console 0.6.27**: Steam AI summary prompt slimmed so default Anthropic **`max_tokens`** no longer truncates JSON in production; console **`SettingsProfileIdentity`** clear-username test hardened for CI; functions release also includes CORS allowlist tweak for **`chrisvogt.me`**, emulator **`prestart` → `build`**, and AI summary **`jsonrepair`** / logging adjustments documented in **[functions/CHANGELOG.md](functions/CHANGELOG.md)**. See [functions/CHANGELOG.md](functions/CHANGELOG.md) and [apps/console/CHANGELOG.md](apps/console/CHANGELOG.md).

--- a/functions/CHANGELOG.md
+++ b/functions/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.9] - 2026-05-11
+
+### Changed
+
+- **Goodreads / Steam AI summaries** — Prompts request **first person** (Chris Vogt’s voice, aligned with chrisvogt.me editorial tone) while keeping **two or three** `<p>` paragraphs and existing JSON / HTML constraints.
+- **Steam AI summary** — When **`extractJsonFromAiResponse`** cannot parse the assistant reply, **`logger.error`** logs structured fields (**`charLength`**, **`trimmedLength`**, **`firstCurlyIndex`** / **`lastCurlyIndex`**, **`hasMarkdownFence`**, **`head`**, optional **`tail`** for long text) before throwing, to debug production-only parse failures.
+
+### Tests
+
+- **`generate-steam-summary.test.ts`** — Covers parse-failure log payload and **`tail`** when assistant text exceeds the head + tail threshold.
+
 ## [0.30.8] - 2026-05-11
 
 ### Changed
@@ -826,6 +837,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _This changelog was started with v0.8.0._
 
+[0.30.9]: https://github.com/chrisvogt/chronogrove/compare/v0.30.8...v0.30.9
 [0.30.8]: https://github.com/chrisvogt/chronogrove/compare/v0.30.7...v0.30.8
 [0.30.3]: https://github.com/chrisvogt/chronogrove/compare/v0.30.2...v0.30.3
 [0.30.2]: https://github.com/chrisvogt/chronogrove/compare/v0.30.1...v0.30.2

--- a/functions/api/ai-summary/generate-steam-summary.test.ts
+++ b/functions/api/ai-summary/generate-steam-summary.test.ts
@@ -106,6 +106,7 @@ describe('generateSteamSummary', () => {
     const prompt = JSON.parse(init.body as string).messages[0].content as string
     expect(prompt).toMatch(/"playTime2Weeks"\s*:\s*0/)
     expect(prompt).toMatch(/"playTimeForever"\s*:\s*0/)
+    expect(prompt).toContain('First person')
   })
 
   it('should handle empty collections gracefully', async () => {
@@ -155,6 +156,61 @@ describe('generateSteamSummary', () => {
       'Error generating Steam AI summary:',
       expect.any(Error),
     )
+  })
+
+  it('logs structured assistant fields when JSON extraction fails', async () => {
+    const { logger } = await import('firebase-functions')
+    const assistantText = 'Plain prose with no parseable JSON object in sight.'
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => assistantJson(assistantText),
+    })
+
+    await expect(generateSteamSummary(mockSteamData)).rejects.toMatchObject({
+      cause: {
+        message: 'Model response was not valid JSON (no markdown block or raw JSON)',
+      },
+    })
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Steam AI summary: assistant text could not be parsed as JSON (see head/tail/indices).',
+      expect.objectContaining({
+        charLength: assistantText.length,
+        trimmedLength: assistantText.trim().length,
+        firstCurlyIndex: -1,
+        lastCurlyIndex: -1,
+        hasMarkdownFence: false,
+        head: assistantText,
+      }),
+    )
+  })
+
+  it('includes tail in parse-failure log when assistant text is longer than head plus tail', async () => {
+    const { logger } = await import('firebase-functions')
+    const longNonsense = 'b'.repeat(4000)
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => assistantJson(longNonsense),
+    })
+
+    await expect(generateSteamSummary(mockSteamData)).rejects.toMatchObject({
+      cause: {
+        message: 'Model response was not valid JSON (no markdown block or raw JSON)',
+      },
+    })
+
+    const parseFailCall = (logger.error as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call) =>
+        call[0] ===
+        'Steam AI summary: assistant text could not be parsed as JSON (see head/tail/indices).',
+    )
+    expect(parseFailCall).toBeDefined()
+    const payload = parseFailCall![1] as { head: string; tail: string; charLength: number }
+    expect(payload.charLength).toBe(4000)
+    expect(payload.head).toBe(longNonsense.slice(0, 2400))
+    expect(payload.tail).toBe(longNonsense.slice(-700))
   })
 
   it('should rethrow when fenced JSON is empty (unparseable object)', async () => {

--- a/functions/api/ai-summary/generate-steam-summary.ts
+++ b/functions/api/ai-summary/generate-steam-summary.ts
@@ -5,6 +5,29 @@ import type { SteamSummaryInput } from '../../types/steam.js'
 import { requestAiSummaryCompletion } from '../../utils/ai-summary-messages.js'
 import extractJsonFromAiResponse from '../../utils/extract-json-from-ai-response.js'
 
+/** Logged when `extractJsonFromAiResponse` fails — head/tail help diagnose truncation vs bad escaping. */
+const STEAM_AI_ASSISTANT_LOG_HEAD = 2400
+const STEAM_AI_ASSISTANT_LOG_TAIL = 700
+
+const buildSteamAssistantTextLogFields = (assistantText: string) => {
+  const charLength = assistantText.length
+  const trimmedLength = assistantText.trim().length
+  const head = assistantText.slice(0, STEAM_AI_ASSISTANT_LOG_HEAD)
+  const tail =
+    charLength > STEAM_AI_ASSISTANT_LOG_HEAD + STEAM_AI_ASSISTANT_LOG_TAIL
+      ? assistantText.slice(-STEAM_AI_ASSISTANT_LOG_TAIL)
+      : undefined
+  return {
+    charLength,
+    trimmedLength,
+    firstCurlyIndex: assistantText.indexOf('{'),
+    lastCurlyIndex: assistantText.lastIndexOf('}'),
+    hasMarkdownFence: /```(?:json)?/i.test(assistantText),
+    head,
+    ...(tail !== undefined ? { tail } : {}),
+  }
+}
+
 function messageFromUnknownError(error: unknown): string {
   if (error instanceof Error) {
     return error.message
@@ -38,30 +61,23 @@ const generateSteamSummary = async (steamData: SteamSummaryInput): Promise<strin
   const { collections, profile, metrics } = steamData
 
   const prompt = `
-Hi — please analyze the following Steam gaming data and return a natural-sounding summary in **valid JSON**.
+You are writing a short, reader-facing “AI play summary” for Chris Vogt’s Steam activity on his personal homepage (chrisvogt.me). It appears next to live tables of recent and lifetime play, so visitors already see hours and titles there.
 
-Use exactly this structure (one key only — do not echo game lists back into the JSON; the page already shows them):
+Return **valid JSON only** (no markdown fences, no commentary) using exactly this shape (one top-level key — do not echo game lists into the JSON; the page already shows them):
 {
-  "response": "<2-3 paragraphs in limited HTML with third-person summary of Chris Vogt's Steam activity. Mention recent games played, genre or playstyle trends, and any standout titles. Use natural and informative language.>"
+  "response": "<string: two or three HTML paragraphs, see rules below>"
 }
 
-Instructions:
-- Respond in HTML with each paragraph in a <p> tag
-- No need to wrap the response in a <div> tag or any other container tags
-– Try to generate 2 paragraphs, at most 3
-- You are encouraged to use HTML tags to format the text
-- Especially basic formatting like <b>, <i>, <strong>, <em> and other simple formatting tags
-- Please do not use hyperlinks
-– Your response will be rendered next to a table showing recent and total hours for each game...
-- ...so no need to mention the exact hours in your response
-- All provided time values are in **minutes**
-- If time > 60 minutes, convert to **hours**, rounded to 1 decimal (e.g. 75 → "1.3 hours")
-- If time < 60 minutes, keep in **minutes**
-- Exclude games with 0 total playtime
-- Refer to the player as “Chris”
-- Identify genre or gameplay patterns if possible (e.g. sandbox, survival, RPGs, base-building)
-- Return only **valid JSON** — no markdown or extra text
-- The **response** value is one JSON string: escape every ASCII double-quote (U+0022) inside it as a backslash plus double-quote. Do not use raw line breaks inside that string—keep the HTML on one line, or use a JSON-escaped newline (backslash followed by n). The full output must parse as JSON with no errors.
+Rules for the "response" string (strict — the UI is built for this):
+- **JSON-safe HTML:** escape every ASCII double-quote (U+0022) inside the **response** string as a backslash plus double-quote; do not use raw line breaks inside that string (one line of HTML, or JSON-escaped newline as backslash followed by n). The full payload must be valid JSON.
+- **Two or three** <p>...</p> elements, back-to-back, with nothing before, between, or after them (no wrapper <div>, no line breaks outside the tags).
+- **First person** only: Chris Vogt’s own words — **I**, **my**, **me**. Do not describe him in third person (“Chris…”, “he…”). Avoid pivoting to address the visitor as **you**; stay in first-person perspective throughout.
+- **Voice** (match chrisvogt.me editorial tone): calm, specific, a little editorial — like a sharp one-column blurb, not marketing. Lead with concrete play habits or through-lines when you can; avoid generic gamer openers and hype. No meta lines about this being an AI summary or a stats table. No thank-you sign-offs. At most one metaphor or framing detail per paragraph.
+- Summarize **recent** leanings from recentlyPlayedGames and **long-run** tendencies from topPlayedGames — genre or playstyle patterns (sandbox, survival, RPGs, base-building, etc.) and any standout titles, without re-listing every game.
+- The tables show hours — **do not** quote exact hour totals in the prose unless it serves a sharp point.
+- All provided time values in the data are **minutes** (for your reasoning only; do not recite them unless needed).
+- Exclude games with 0 total playtime from your thinking.
+- Optional sparse styling inside paragraphs: <strong>, <em>, <b>, <i>; no hyperlinks, lists, headings, or images.
 
 Steam Profile: ${profile.displayName}  
 Total Games Owned: ${metrics.find(m => m.id === 'owned-games-count')?.value || 0}
@@ -85,6 +101,10 @@ Total Games Owned: ${metrics.find(m => m.id === 'owned-games-count')?.value || 0
     const responseText = await requestAiSummaryCompletion({ apiKey, userMessage: prompt })
     const parsed = extractJsonFromAiResponse<{ response?: unknown }>(responseText)
     if (!parsed) {
+      logger.error(
+        'Steam AI summary: assistant text could not be parsed as JSON (see head/tail/indices).',
+        buildSteamAssistantTextLogFields(responseText),
+      )
       throw new Error('Model response was not valid JSON (no markdown block or raw JSON)')
     }
     const raw = parsed.response

--- a/functions/api/goodreads/generate-goodreads-summary.test.ts
+++ b/functions/api/goodreads/generate-goodreads-summary.test.ts
@@ -88,7 +88,7 @@ describe('generateGoodreadsSummary', () => {
 
     const mockResponseText = `\`\`\`json
 {
-  "response": "<p>Chris has been exploring a diverse range of literature lately.</p><p>Recent reads include both classic fiction and contemporary non-fiction.</p>",
+  "response": "<p>I have been pulling from a pretty wide shelf lately.</p><p>Recent picks skew both classic fiction and heavier non-fiction.</p>",
   "debug": {
     "recentlyReadBooks": [{"title": "The Great Gatsby", "authors": ["F. Scott Fitzgerald"], "rating": 4}],
     "readingPatterns": ["fiction", "non-fiction"]
@@ -101,7 +101,7 @@ describe('generateGoodreadsSummary', () => {
     const result = await generateGoodreadsSummary(mockGoodreadsData)
 
     expect(result).toBe(
-      '<p>Chris has been exploring a diverse range of literature lately.</p><p>Recent reads include both classic fiction and contemporary non-fiction.</p>',
+      '<p>I have been pulling from a pretty wide shelf lately.</p><p>Recent picks skew both classic fiction and heavier non-fiction.</p>',
     )
 
     expect(mockFetch).toHaveBeenCalledWith(
@@ -129,7 +129,7 @@ describe('generateGoodreadsSummary', () => {
 
     const mockResponseText = `\`\`\`json
 {
-  "response": "<p>Chris's reading activity data is currently unavailable.</p>",
+  "response": "<p>My reading activity data is currently unavailable.</p>",
   "debug": {
     "recentlyReadBooks": [],
     "readingPatterns": []
@@ -141,7 +141,7 @@ describe('generateGoodreadsSummary', () => {
 
     const result = await generateGoodreadsSummary(mockGoodreadsData)
 
-    expect(result).toBe('<p>Chris\'s reading activity data is currently unavailable.</p>')
+    expect(result).toBe('<p>My reading activity data is currently unavailable.</p>')
 
     const prompt = lastUserPrompt()
     expect(prompt).toContain('"recentlyReadBooksForWidget": []')
@@ -338,7 +338,7 @@ describe('generateGoodreadsSummary', () => {
 
     expect(promptCall).toContain('chrisvogt.me')
     expect(promptCall).toContain('Two or three')
-    expect(promptCall).toContain('Third person')
+    expect(promptCall).toContain('First person')
   })
 
   it('returns trimmed text when the model response has no paragraph tags', async () => {

--- a/functions/api/goodreads/generate-goodreads-summary.ts
+++ b/functions/api/goodreads/generate-goodreads-summary.ts
@@ -85,7 +85,7 @@ const generateGoodreadsSummary = async (
       })) ?? [])
 
   const prompt = `
-You are writing a short, reader-facing “AI reading summary” for Chris Vogt’s personal homepage (chrisvogt.me). It appears next to a live list of books he recently finished and what he is reading now, so visitors already see titles and ratings there.
+You are writing a short, reader-facing “AI reading summary” for Chris Vogt’s personal homepage (chrisvogt.me). It sits next to a live list of books he recently finished and what he is reading now, so visitors already see titles and ratings there.
 
 Return **valid JSON only** (no markdown fences, no commentary) using this shape:
 {
@@ -99,10 +99,10 @@ Return **valid JSON only** (no markdown fences, no commentary) using this shape:
 Rules for the "response" string (strict — the UI is built for this):
 - **JSON-safe HTML:** escape every ASCII double-quote (U+0022) inside the **response** string as a backslash plus double-quote; do not use raw line breaks inside that string (one line of HTML, or JSON-escaped newline as backslash followed by n). The full payload must be valid JSON.
 - **Two or three** <p>...</p> elements, back-to-back, with nothing before, between, or after them (no wrapper <div>, no line breaks outside the tags).
-- **Third person** only, referring to him as **Chris** (e.g. “Chris tends to…”, “He often…”). Never “I”, “you”, or “the reader”.
-- Tone: calm, specific, a little editorial — like a sharp one-column blurb in a magazine, not marketing fluff. Avoid generic openers (“Chris loves books”, “As an avid reader”).
+- **First person** only: Chris Vogt’s own words — **I**, **my**, **me**. Do not describe him in third person (“Chris…”, “he…”). Avoid pivoting to address the visitor as **you**; stay in first-person perspective throughout.
+- **Voice** (match chrisvogt.me editorial tone): calm, specific, a little editorial — like a sharp one-column blurb, not marketing. Prefer concrete habits, streaks, or a through-line over filler openers (“I love books”, “Reading has always been…”, “As an avid reader”). No meta lines about this being an AI summary, a widget, or how the page is laid out. No thank-you sign-offs. At most one metaphor or framing detail per paragraph; keep dates and titles accurate when you mention them.
 - **Do not** repeat or enumerate the book list; at most **one** quick nod to a title or theme if it sharpens a point. Ratings are visible elsewhere — mention them only if unusual or telling.
-- **completeReadShelf** is his full “read” shelf from Goodreads (title, authors, ISBN, his stars, finish or date-added). Use it for **long-run habits**: balance of fiction vs non-fiction, streaks, eras, breadth, how tastes shift over time.
+- **completeReadShelf** is his full “read” shelf from Goodreads (title, authors, ISBN, his stars, finish or date-added). Use it for **long-run habits**: balance of fiction vs non-fiction, streaks, eras, breadth, how his tastes shift over time.
 - **recentlyReadBooksForWidget** adds categories and page counts (via Google Books) for what the page actually shows — use it for **texture on what he’s been into lately** (subjects, chunkier vs slimmer books) without re-listing every title.
 
 Styling inside paragraphs (optional, sparse):

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chronogrove-functions",
-  "version": "0.30.8",
+  "version": "0.30.9",
   "license": "Apache-2.0",
   "description": "Chronogrove server: Firebase Cloud Functions for the public widget API, authenticated admin routes, and provider sync jobs.",
   "type": "module",


### PR DESCRIPTION
## Summary

Bumps **chronogrove-functions** to **0.30.9** and updates widget AI summary behavior for Goodreads and Steam.

### Changes
- **First-person prompts** for Goodreads and Steam summaries (aligned with chrisvogt.me editorial voice); structural rules unchanged (**two or three** `<p>` paragraphs, JSON-safe HTML in the `response` string).
- **Steam**: when `extractJsonFromAiResponse` cannot parse the Anthropic assistant text, **structured `logger.error`** records `head`, optional `tail` (long responses), lengths, brace indices, and fence detection—so production JSON failures are easier to debug in Cloud Logging.

### Tests / coverage
- New Steam unit tests for parse-failure logging (including long-text `tail` branch).
- `pnpm -C functions run test:coverage` passes repo thresholds.

### Changelog
- **functions/CHANGELOG.md** — `[0.30.9]` entry + compare link.
- **CHANGELOG.md** (root) — Unreleased workspace note for Functions 0.30.9.


Made with [Cursor](https://cursor.com)