### PR TITLE
fix(goodreads): sanitize titles for Google Books volume search (v0.30.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Package-specific changes:
 
 ### Changed
 
+- **Workspace** — **Functions 0.30.10**: Goodreads Google Books title/author search **sanitizes** series parentheticals in **`intitle:`** queries to avoid **400** from the Books API. See **[functions/CHANGELOG.md](functions/CHANGELOG.md)**.
+
 - **Workspace** — **Functions 0.30.9**: Goodreads and Steam widget AI summaries use **first-person** prompts; Steam adds structured **Cloud Logging** on JSON parse failure (**`head`** / **`tail`** / indices). See **[functions/CHANGELOG.md](functions/CHANGELOG.md)**.
 
 - **Workspace** — **Functions 0.30.8**: Spotify **`me/top/tracks`** sync requests **`limit: 24`** instead of **12**, so the widget can surface more short-term top tracks after the next sync. See **[functions/CHANGELOG.md](functions/CHANGELOG.md)**.

--- a/functions/CHANGELOG.md
+++ b/functions/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Tests
 
 - **`simplify-title-for-google-books-query.test.ts`** — Parenthetical strip, **`#n`** suffix, length cap, whitespace.
+- **`fetch-recently-read-books.test.ts`** / **`sync-goodreads-data.test.ts`** — Assert **`intitle:`** uses simplified titles and **`||`** fallback when simplification yields an empty string (Codecov patch coverage).
 
 ## [0.30.9] - 2026-05-11
 

--- a/functions/CHANGELOG.md
+++ b/functions/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.10] - 2026-05-12
+
+### Fixed
+
+- **Goodreads + Google Books** — Title/author fallback volume search uses **`simplifyTitleForGoogleBooksQuery`** so Goodreads-style series/volume suffixes (e.g. `(The Book of Dust, #2)`) are stripped before building **`intitle:`** / **`inauthor:`** queries. The Books API often returns **400 Bad Request** for those characters in **`q`**, even when the web UI accepts the same title. Wired from **`fetch-recently-read-books`** and **`sync-goodreads-data`**.
+
+### Tests
+
+- **`simplify-title-for-google-books-query.test.ts`** — Parenthetical strip, **`#n`** suffix, length cap, whitespace.
+
 ## [0.30.9] - 2026-05-11
 
 ### Changed
@@ -837,6 +847,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _This changelog was started with v0.8.0._
 
+[0.30.10]: https://github.com/chrisvogt/chronogrove/compare/v0.30.9...v0.30.10
 [0.30.9]: https://github.com/chrisvogt/chronogrove/compare/v0.30.8...v0.30.9
 [0.30.8]: https://github.com/chrisvogt/chronogrove/compare/v0.30.7...v0.30.8
 [0.30.3]: https://github.com/chrisvogt/chronogrove/compare/v0.30.2...v0.30.3

--- a/functions/api/goodreads/fetch-recently-read-books.test.ts
+++ b/functions/api/goodreads/fetch-recently-read-books.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import fetchRecentlyReadBooks from './fetch-recently-read-books.js'
+import fetchRecentlyReadBooks, {
+  titleForGoogleBooksVolumeQuery,
+} from './fetch-recently-read-books.js'
 
 // Mock dependencies
 vi.mock('xml2js', () => ({
@@ -37,6 +39,24 @@ vi.mock('../../selectors/media-store.js', () => ({
 vi.mock('p-map', () => ({
   default: vi.fn()
 }))
+
+describe('titleForGoogleBooksVolumeQuery', () => {
+  it('returns empty when title is absent, null, undefined, or whitespace-only', () => {
+    expect(titleForGoogleBooksVolumeQuery({})).toBe('')
+    expect(titleForGoogleBooksVolumeQuery({ title: undefined })).toBe('')
+    expect(titleForGoogleBooksVolumeQuery({ title: null })).toBe('')
+    expect(titleForGoogleBooksVolumeQuery({ title: '   ' })).toBe('')
+  })
+
+  it('strips series parentheticals and applies fallback when simplify empties title', () => {
+    expect(
+      titleForGoogleBooksVolumeQuery({
+        title: 'The Secret Commonwealth (The Book of Dust, #2)',
+      }),
+    ).toBe('The Secret Commonwealth')
+    expect(titleForGoogleBooksVolumeQuery({ title: '(Paren Only)' })).toBe('(Paren Only)')
+  })
+})
 
 describe('fetchRecentlyReadBooks', () => {
   let mockParseString

--- a/functions/api/goodreads/fetch-recently-read-books.test.ts
+++ b/functions/api/goodreads/fetch-recently-read-books.test.ts
@@ -853,6 +853,120 @@ describe('fetchRecentlyReadBooks', () => {
     delete process.env.GOOGLE_BOOKS_API_KEY
   })
 
+  it('uses simplified intitle when Goodreads title has trailing series parenthetical', async () => {
+    process.env.GOOGLE_BOOKS_API_KEY = 'test-google-books-api-key'
+    const longTitle = 'The Secret Commonwealth (The Book of Dust, #2)'
+    const mockGoodreadsResponse = `<GoodreadsResponse><reviews><review><read_at>2023-01-01</read_at><book><title>${longTitle}</title><isbn13>9780000000001</isbn13><authors><author><name>Philip Pullman</name></author></authors></book><rating>4</rating></review></reviews></GoodreadsResponse>`
+    const mockGoogleBookFromTitleSearch = {
+      items: [{
+        id: 'dust-book-id',
+        volumeInfo: {
+          title: 'The Secret Commonwealth',
+          authors: ['Philip Pullman'],
+          imageLinks: { thumbnail: 'http://example.com/t.jpg' },
+        },
+      }],
+    }
+
+    mockGot
+      .mockResolvedValueOnce({ body: mockGoodreadsResponse })
+      .mockResolvedValueOnce({ body: JSON.stringify(mockGoogleBookFromTitleSearch) })
+    mockParseString.mockImplementation((xml, callback) => {
+      callback(null, {
+        GoodreadsResponse: {
+          reviews: [{
+            review: [{
+              read_at: ['2023-01-01'],
+              book: [{
+                title: [longTitle],
+                authors: [{ author: [{ name: ['Philip Pullman'] }] }],
+                isbn13: ['9780000000001'],
+              }],
+              rating: ['4'],
+            }],
+          }],
+        },
+      })
+    })
+    mockPMap.mockImplementation(async (items, mapper, options) => {
+      if (options?.concurrency === 3) {
+        const results = []
+        for (let i = 0; i < items.length; i++) {
+          results.push(await mapper(items[i], i))
+        }
+        return results
+      }
+      return []
+    })
+    mockFetchBookFromGoogle.mockResolvedValue(null)
+    mockListStoredMedia.mockResolvedValue([])
+
+    await fetchRecentlyReadBooks()
+
+    expect(mockGot).toHaveBeenCalledWith(
+      'https://www.googleapis.com/books/v1/volumes',
+      expect.objectContaining({
+        searchParams: {
+          q: 'intitle:The Secret Commonwealth inauthor:Philip Pullman',
+          key: 'test-google-books-api-key',
+          country: 'US',
+        },
+      }),
+    )
+    delete process.env.GOOGLE_BOOKS_API_KEY
+  })
+
+  it('uses raw Goodreads title when simplification strips to empty (parenthetical-only)', async () => {
+    process.env.GOOGLE_BOOKS_API_KEY = 'test-google-books-api-key'
+    const mockGoodreadsResponse =
+      '<GoodreadsResponse><reviews><review><read_at>2023-01-01</read_at><book><title>(Paren Only)</title><isbn13>9780000000002</isbn13></book><rating>4</rating></review></reviews></GoodreadsResponse>'
+    const mockGoogleBookFromTitleSearch = {
+      items: [{ id: 'p-id', volumeInfo: { title: 'X', imageLinks: { thumbnail: 'http://x.com/t.jpg' } } }],
+    }
+    mockGot
+      .mockResolvedValueOnce({ body: mockGoodreadsResponse })
+      .mockResolvedValueOnce({ body: JSON.stringify(mockGoogleBookFromTitleSearch) })
+    mockParseString.mockImplementation((xml, callback) => {
+      callback(null, {
+        GoodreadsResponse: {
+          reviews: [{
+            review: [{
+              read_at: ['2023-01-01'],
+              book: [{ title: ['(Paren Only)'], isbn13: ['9780000000002'] }],
+              rating: ['4'],
+            }],
+          }],
+        },
+      })
+    })
+    mockPMap.mockImplementation(async (items, mapper, options) => {
+      if (options?.concurrency === 3) {
+        const results = []
+        for (let i = 0; i < items.length; i++) {
+          results.push(await mapper(items[i], i))
+        }
+        return results
+      }
+      return []
+    })
+    mockFetchBookFromGoogle.mockResolvedValue(null)
+    mockListStoredMedia.mockResolvedValue([])
+
+    await fetchRecentlyReadBooks()
+
+    expect(mockGot).toHaveBeenCalledWith(
+      'https://www.googleapis.com/books/v1/volumes',
+      expect.objectContaining({
+        searchParams: {
+          q: 'intitle:(Paren Only)',
+          key: 'test-google-books-api-key',
+          country: 'US',
+        },
+      }),
+    )
+    delete process.env.GOOGLE_BOOKS_API_KEY
+  })
+
   it('should fall back to title-only search when ISBN fails and no author in Goodreads data', async () => {
     process.env.GOOGLE_BOOKS_API_KEY = 'test-google-books-api-key'
     const mockGoodreadsResponse = '<GoodreadsResponse><reviews><review><read_at>2023-01-01</read_at><book><title>No Author Book</title><isbn13>9780000000000</isbn13></book><rating>3</rating></review></reviews></GoodreadsResponse>'

--- a/functions/api/goodreads/fetch-recently-read-books.ts
+++ b/functions/api/goodreads/fetch-recently-read-books.ts
@@ -29,6 +29,7 @@ import type {
 
 import { getXmlTextOrUndefined } from '../../utils/goodreads-xml.js'
 import { sortGoodreadsRecentlyReadBooksByReadAtDesc } from '../../utils/sort-goodreads-recently-read-books.js'
+import { simplifyTitleForGoogleBooksQuery } from '../../utils/simplify-title-for-google-books-query.js'
 
 const toBookMediaDestinationPath = id => `books/${id}-thumbnail.jpg`
 
@@ -56,9 +57,11 @@ function parseGoogleBooksApiErrorBody(error: unknown): unknown | null {
 async function fetchGoogleBookByTitleFallback(
   book: GoodreadsReviewListBookSource,
 ): Promise<GoogleBooksFetchByIsbnResult | null> {
+  const titleForQuery =
+    simplifyTitleForGoogleBooksQuery(book.title ?? '') || (book.title ?? '').trim()
   const searchQuery = book.authorName
-    ? `intitle:${book.title} inauthor:${book.authorName}`
-    : `intitle:${book.title}`
+    ? `intitle:${titleForQuery} inauthor:${book.authorName}`
+    : `intitle:${titleForQuery}`
   const maxRetries = 3
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {

--- a/functions/api/goodreads/fetch-recently-read-books.ts
+++ b/functions/api/goodreads/fetch-recently-read-books.ts
@@ -31,6 +31,12 @@ import { getXmlTextOrUndefined } from '../../utils/goodreads-xml.js'
 import { sortGoodreadsRecentlyReadBooksByReadAtDesc } from '../../utils/sort-goodreads-recently-read-books.js'
 import { simplifyTitleForGoogleBooksQuery } from '../../utils/simplify-title-for-google-books-query.js'
 
+/** Exported for unit tests and Codecov (caller only invokes fallback when `book.title` is truthy). */
+export const titleForGoogleBooksVolumeQuery = (book: {
+  title?: string | null
+}): string =>
+  simplifyTitleForGoogleBooksQuery(book.title ?? '') || (book.title ?? '').trim()
+
 const toBookMediaDestinationPath = id => `books/${id}-thumbnail.jpg`
 
 type GotLikeError = {
@@ -57,8 +63,7 @@ function parseGoogleBooksApiErrorBody(error: unknown): unknown | null {
 async function fetchGoogleBookByTitleFallback(
   book: GoodreadsReviewListBookSource,
 ): Promise<GoogleBooksFetchByIsbnResult | null> {
-  const titleForQuery =
-    simplifyTitleForGoogleBooksQuery(book.title ?? '') || (book.title ?? '').trim()
+  const titleForQuery = titleForGoogleBooksVolumeQuery(book)
   const searchQuery = book.authorName
     ? `intitle:${titleForQuery} inauthor:${book.authorName}`
     : `intitle:${titleForQuery}`

--- a/functions/jobs/sync-goodreads-data.test.ts
+++ b/functions/jobs/sync-goodreads-data.test.ts
@@ -902,6 +902,133 @@ describe('syncGoodreadsData', () => {
       })
     })
 
+    it('should search with simplified title when book title has series parenthetical', async () => {
+      const mockUserData = {
+        profile: { displayName: 'Test User' },
+        updates: [
+          {
+            id: 'update1',
+            type: 'userstatus',
+            book: {
+              isbn13: '9780143127550',
+              title: 'The Secret Commonwealth (The Book of Dust, #2)',
+              author: { name: 'Philip Pullman' }
+            }
+          }
+        ],
+        jsonResponse: { user: 'data' }
+      }
+
+      const mockRecentlyReadData = {
+        books: [],
+        rawReviewsResponse: { reviews: 'data' }
+      }
+
+      const mockGoogleSearchResponse = {
+        items: [{
+          id: 'search-result-id',
+          volumeInfo: {
+            title: 'The Secret Commonwealth',
+            authors: ['Philip Pullman'],
+            imageLinks: {
+              thumbnail: 'http://books.google.com/thumb.jpg'
+            }
+          }
+        }]
+      }
+
+      fetchUser.mockResolvedValue(mockUserData)
+      fetchRecentlyReadBooks.mockResolvedValue(mockRecentlyReadData)
+      mockFetchBookFromGoogle.mockResolvedValue(null)
+      mockGot.mockResolvedValue({ body: JSON.stringify(mockGoogleSearchResponse) })
+      mockListStoredMedia.mockResolvedValue([])
+
+      mockPMap.mockImplementation(async (items, mapper) => {
+        const results = []
+        for (let i = 0; i < items.length; i++) {
+          const result = await mapper(items[i], i)
+          results.push(result)
+        }
+        return results
+      })
+
+      const resultPromise = syncGoodreadsData(documentStore)
+      await vi.runAllTimersAsync()
+      const result = await resultPromise
+
+      expect(result.result).toBe('SUCCESS')
+      expect(mockGot).toHaveBeenCalledWith('https://www.googleapis.com/books/v1/volumes', {
+        searchParams: {
+          q: 'intitle:The Secret Commonwealth inauthor:Philip Pullman',
+          key: 'test-google-books-api-key',
+          country: 'US'
+        }
+      })
+    })
+
+    it('should use raw title when simplification is empty for update title search', async () => {
+      const mockUserData = {
+        profile: { displayName: 'Test User' },
+        updates: [
+          {
+            id: 'update1',
+            type: 'userstatus',
+            book: {
+              isbn13: '9780143127550',
+              title: '(Paren Only)',
+              author: { name: 'Some Author' }
+            }
+          }
+        ],
+        jsonResponse: { user: 'data' }
+      }
+
+      const mockRecentlyReadData = {
+        books: [],
+        rawReviewsResponse: { reviews: 'data' }
+      }
+
+      const mockGoogleSearchResponse = {
+        items: [{
+          id: 'search-result-id',
+          volumeInfo: {
+            title: 'X',
+            imageLinks: {
+              thumbnail: 'http://books.google.com/thumb.jpg'
+            }
+          }
+        }]
+      }
+
+      fetchUser.mockResolvedValue(mockUserData)
+      fetchRecentlyReadBooks.mockResolvedValue(mockRecentlyReadData)
+      mockFetchBookFromGoogle.mockResolvedValue(null)
+      mockGot.mockResolvedValue({ body: JSON.stringify(mockGoogleSearchResponse) })
+      mockListStoredMedia.mockResolvedValue([])
+
+      mockPMap.mockImplementation(async (items, mapper) => {
+        const results = []
+        for (let i = 0; i < items.length; i++) {
+          const result = await mapper(items[i], i)
+          results.push(result)
+        }
+        return results
+      })
+
+      const resultPromise = syncGoodreadsData(documentStore)
+      await vi.runAllTimersAsync()
+      const result = await resultPromise
+
+      expect(result.result).toBe('SUCCESS')
+      expect(mockGot).toHaveBeenCalledWith('https://www.googleapis.com/books/v1/volumes', {
+        searchParams: {
+          q: 'intitle:(Paren Only) inauthor:Some Author',
+          key: 'test-google-books-api-key',
+          country: 'US'
+        }
+      })
+    })
+
     it('should search by title only when author is not available', async () => {
       const mockUserData = {
         profile: { displayName: 'Test User' },

--- a/functions/jobs/sync-goodreads-data.ts
+++ b/functions/jobs/sync-goodreads-data.ts
@@ -21,6 +21,7 @@ import { getLogger } from '../services/logger.js'
 import { toStoredDateTime } from '../utils/time.js'
 import { getXmlTextOrNull } from '../utils/goodreads-xml.js'
 import { sortGoodreadsRecentlyReadBooksByReadAtDesc } from '../utils/sort-goodreads-recently-read-books.js'
+import { simplifyTitleForGoogleBooksQuery } from '../utils/simplify-title-for-google-books-query.js'
 
 import type {
   GoogleBooksFetchByIsbnResult,
@@ -244,13 +245,13 @@ const processUpdatesWithMedia = async (
             // Try to get author name - different structure for review vs userstatus updates
             const authorName = book.author?.name || book.author?.displayName || book.author?.sortName
             
+            const titleForQuery =
+              simplifyTitleForGoogleBooksQuery(book.title) || book.title.trim()
             let searchQuery
             if (authorName) {
-              // Search by title and author
-              searchQuery = `intitle:${book.title} inauthor:${authorName}`
+              searchQuery = `intitle:${titleForQuery} inauthor:${authorName}`
             } else {
-              // Fallback: search by title only if no author name available
-              searchQuery = `intitle:${book.title}`
+              searchQuery = `intitle:${titleForQuery}`
             }
             
             try {

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chronogrove-functions",
-  "version": "0.30.9",
+  "version": "0.30.10",
   "license": "Apache-2.0",
   "description": "Chronogrove server: Firebase Cloud Functions for the public widget API, authenticated admin routes, and provider sync jobs.",
   "type": "module",

--- a/functions/utils/simplify-title-for-google-books-query.test.ts
+++ b/functions/utils/simplify-title-for-google-books-query.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { simplifyTitleForGoogleBooksQuery } from './simplify-title-for-google-books-query.js'
+
+describe('simplifyTitleForGoogleBooksQuery', () => {
+  it('removes trailing Goodreads-style series parenthetical and volume tag', () => {
+    expect(
+      simplifyTitleForGoogleBooksQuery(
+        'The Secret Commonwealth (The Book of Dust, #2)',
+      ),
+    ).toBe('The Secret Commonwealth')
+  })
+
+  it('removes nested-style trailing segment only', () => {
+    expect(simplifyTitleForGoogleBooksQuery('Smile (graphic novel)')).toBe('Smile')
+  })
+
+  it('strips trailing #n outside parentheses', () => {
+    expect(simplifyTitleForGoogleBooksQuery('Some Title #3')).toBe('Some Title')
+  })
+
+  it('truncates extremely long titles to avoid oversized q= parameters', () => {
+    const long = `${'a'.repeat(250)}`
+    expect(simplifyTitleForGoogleBooksQuery(long).length).toBe(200)
+  })
+
+  it('normalizes whitespace and leaves simple titles unchanged', () => {
+    expect(simplifyTitleForGoogleBooksQuery('  The Great Gatsby  ')).toBe('The Great Gatsby')
+  })
+})

--- a/functions/utils/simplify-title-for-google-books-query.ts
+++ b/functions/utils/simplify-title-for-google-books-query.ts
@@ -1,0 +1,20 @@
+/**
+ * Goodreads book titles often include parenthetical series/volume tags like
+ * "(The Book of Dust, #2)". The Google Books volumes API commonly returns
+ * **400 Bad Request** for `intitle:` queries that contain those characters,
+ * even though the same titles work in the web UI.
+ *
+ * Strip trailing parenthetical segments and volume markers so `intitle:` +
+ * `inauthor:` fallback searches stay within what the API accepts.
+ */
+export const simplifyTitleForGoogleBooksQuery = (raw: string): string => {
+  let t = raw.trim().replace(/\s+/g, ' ')
+  while (/\s*\([^)]+\)\s*$/.test(t)) {
+    t = t.replace(/\s*\([^)]+\)\s*$/, '').trim()
+  }
+  t = t.replace(/\s*#\d+\s*$/i, '').trim()
+  if (t.length > 200) {
+    t = t.slice(0, 200).trim()
+  }
+  return t
+}


### PR DESCRIPTION
## Summary

Google Books `volumes` **400** on `intitle:` when Goodreads titles include series parentheticals (e.g. **The Secret Commonwealth (The Book of Dust, #2)**).

## Changes

- New **`simplifyTitleForGoogleBooksQuery`** (`functions/utils/simplify-title-for-google-books-query.ts`) — strips trailing `(…)` segments, stray **`#n`**, caps length; unit tests.
- Wired into **`fetch-recently-read-books`** (title/author fallback) and **`sync-goodreads-data`** (update book fetch).

## Release

- **chronogrove-functions** **`0.30.10`** — see **`functions/CHANGELOG.md`**.

## Tests / coverage

- `pnpm -C functions run test:coverage` passes repo thresholds (**lines / statements / functions 100%** on full suite; **branches ~97.7%**). New util file covered by **`simplify-title-for-google-books-query.test.ts`**.


Made with [Cursor](https://cursor.com)