### PR TITLE
feat(functions): Spotify and Discogs AI widget summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Package-specific changes:
 
 ### Changed
 
+- **Workspace** — **Functions 0.31.0**: **Spotify** and **Discogs** widget syncs generate **Anthropic** AI summaries (**`aiSummary`** on **`widget-content`**, persisted to **`last-response_ai-summary`**), matching the Goodreads/Steam pattern; **Codecov** patch gate raised to **99%**. **Console 0.6.28**: schema examples include sample **`aiSummary`** for Spotify and Discogs payloads. See **[functions/CHANGELOG.md](functions/CHANGELOG.md)** and **[apps/console/CHANGELOG.md](apps/console/CHANGELOG.md)**.
+
 - **Workspace** — **Functions 0.30.10**: Goodreads Google Books title/author search **sanitizes** series parentheticals in **`intitle:`** queries to avoid **400** from the Books API. See **[functions/CHANGELOG.md](functions/CHANGELOG.md)**.
 
 - **Workspace** — **Functions 0.30.9**: Goodreads and Steam widget AI summaries use **first-person** prompts; Steam adds structured **Cloud Logging** on JSON parse failure (**`head`** / **`tail`** / indices). See **[functions/CHANGELOG.md](functions/CHANGELOG.md)**.

--- a/apps/console/CHANGELOG.md
+++ b/apps/console/CHANGELOG.md
@@ -7,6 +7,12 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.28] - 2026-05-11
+
+### Changed
+
+- **Schema examples** — **`widgetResponseExamples`** for **Spotify** and **Discogs** include sample **`aiSummary`** text matching the Functions widget document.
+
 ## [0.6.27] - 2026-05-10
 
 ### Fixed

--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "license": "Apache-2.0",
   "description": "Chronogrove operator console: Next.js admin UI (SSR on Firebase App Hosting) for schema, status, sync, and onboarding.",
-  "version": "0.6.27",
+  "version": "0.6.28",
   "engines": {
     "node": ">=24"
   },

--- a/apps/console/src/sections/schemaExamples.ts
+++ b/apps/console/src/sections/schemaExamples.ts
@@ -83,6 +83,8 @@ export const widgetResponseExamples = {
   discogs: {
     ok: true,
     payload: {
+      aiSummary:
+        'Mostly Japanese pressings from the 1970s–1980s; I still chase clean copies of fusion and city-pop titles.',
       meta: { synced: '2025-03-27T12:00:00.000Z' },
       metrics: { 'LPs Owned': 120 },
       profile: {
@@ -353,6 +355,8 @@ export const widgetResponseExamples = {
   spotify: {
     ok: true,
     payload: {
+      aiSummary:
+        'Lately I lean on curated mood playlists; my top tracks still orbit electronic and indie edges more than pop radio.',
       meta: {
         synced: '2025-03-27T12:00:00.000Z',
         totalUploadedMediaCount: 8,

--- a/codecov.yml
+++ b/codecov.yml
@@ -6,4 +6,4 @@ coverage:
         target: 93%
     patch:
       default:
-        target: 95%
+        target: 99%

--- a/functions/CHANGELOG.md
+++ b/functions/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.0] - 2026-05-11
+
+### Added
+
+- **Spotify + Discogs AI summaries** — On successful sync, **`generate-spotify-summary`** and **`generate-discogs-summary`** (Anthropic **`claude-sonnet-4-6`**, same JSON → HTML `<p>` contract as Goodreads/Steam) populate **`aiSummary`** on **`widget-content`** and save **`last-response_ai-summary`**. Spotify prompts use profile, metrics, **top tracks**, and playlist metadata; Discogs prompts use rollups (genres, styles, decades) plus the newest **72** releases (compact), derived from **`buildDiscogsSummaryInput`**.
+
+### Tests
+
+- **`generate-spotify-summary.test.ts`** / **`generate-discogs-summary.test.ts`** — Mirrors **`generate-steam-summary`**: API failures, unparseable assistant text (including **`head`** / **`tail`** logging), non-string **`response`**, and **`messageFromUnknownError`** branches; Discogs builder tests for large collections, invalid years/dates, and loose artist/format parsing.
+- **`sync-spotify-data.test.ts`** / **`sync-discogs-data.test.ts`** — Sync **continues** when AI generation throws; progress phases include **`spotify.ai`** and **`discogs.ai`**.
+
 ## [0.30.10] - 2026-05-12
 
 ### Fixed
@@ -848,6 +859,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _This changelog was started with v0.8.0._
 
+[0.31.0]: https://github.com/chrisvogt/chronogrove/compare/v0.30.10...v0.31.0
 [0.30.10]: https://github.com/chrisvogt/chronogrove/compare/v0.30.9...v0.30.10
 [0.30.9]: https://github.com/chrisvogt/chronogrove/compare/v0.30.8...v0.30.9
 [0.30.8]: https://github.com/chrisvogt/chronogrove/compare/v0.30.7...v0.30.8

--- a/functions/api/ai-summary/generate-discogs-summary.test.ts
+++ b/functions/api/ai-summary/generate-discogs-summary.test.ts
@@ -93,6 +93,39 @@ describe('buildDiscogsSummaryInput', () => {
     expect(input.recentReleases[0].artists).toContain('Valid')
     expect(input.recentReleases[0].formats).toContain('LP')
   })
+
+  it('handles null genre/style arrays, valid decades, and date sorting', () => {
+    const older: DiscogsTransformedRelease = {
+      basicInformation: {
+        artists: null as unknown as DiscogsTransformedRelease['basicInformation']['artists'],
+        formats: null as unknown as DiscogsTransformedRelease['basicInformation']['formats'],
+        genres: null as unknown as DiscogsTransformedRelease['basicInformation']['genres'],
+        styles: undefined,
+        title: 'Older',
+        year: 1995,
+      },
+      dateAdded: '2019-06-01T00:00:00.000Z',
+      id: 1,
+    }
+    const newer: DiscogsTransformedRelease = {
+      basicInformation: {
+        artists: [{ name: 'Z' }],
+        formats: [{ name: 'CD' }],
+        genres: ['Soul'],
+        styles: [],
+        title: 'Newer',
+        year: 2001,
+      },
+      dateAdded: '2020-01-01T00:00:00.000Z',
+      id: 2,
+    }
+    const input = buildDiscogsSummaryInput([older, newer], 2, undefined)
+    expect(input.decadeCounts['1990s']).toBe(1)
+    expect(input.decadeCounts['2000s']).toBe(1)
+    expect(input.genreCounts.Soul).toBe(1)
+    expect(input.recentReleases[0].title).toBe('Newer')
+    expect(input.recentReleases[1].title).toBe('Older')
+  })
 })
 
 describe('generateDiscogsSummary', () => {
@@ -115,6 +148,27 @@ describe('generateDiscogsSummary', () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch
+  })
+
+  it('parse-failure log omits tail for short assistant text', async () => {
+    const { logger } = await import('firebase-functions')
+    const shortText = 'plain short'
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => assistantJson(shortText),
+    })
+
+    await expect(generateDiscogsSummary(summaryInput)).rejects.toThrow()
+
+    const parseFailCall = (logger.error as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call) =>
+        call[0] ===
+        'Discogs AI summary: assistant text could not be parsed as JSON (see head/tail/indices).',
+    )
+    const payload = parseFailCall![1] as { tail?: string; charLength: number }
+    expect(payload.charLength).toBeLessThan(3100)
+    expect(payload.tail).toBeUndefined()
   })
 
   it('returns assistant HTML when the API responds with JSON', async () => {

--- a/functions/api/ai-summary/generate-discogs-summary.test.ts
+++ b/functions/api/ai-summary/generate-discogs-summary.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import generateDiscogsSummary, { buildDiscogsSummaryInput } from './generate-discogs-summary.js'
+import type { DiscogsTransformedRelease } from '../../types/discogs.js'
+
+type FetchCallInit = { body?: string }
+
+vi.mock('firebase-functions', () => ({
+  logger: { error: vi.fn() },
+}))
+
+const assistantJson = (text: string) =>
+  JSON.stringify({
+    id: 'msg_test',
+    type: 'message',
+    role: 'assistant',
+    content: [{ type: 'text', text }],
+  })
+
+const sampleRelease = (i: number): DiscogsTransformedRelease => ({
+  basicInformation: {
+    artists: [{ name: `Artist ${i}` }],
+    formats: [{ name: 'Vinyl, LP' }],
+    genres: ['Electronic'],
+    styles: ['Techno'],
+    title: `Album ${i}`,
+    year: 1990 + i,
+  },
+  dateAdded: `2024-${String(i + 1).padStart(2, '0')}-15T12:00:00.000Z`,
+  id: i,
+})
+
+describe('buildDiscogsSummaryInput', () => {
+  it('aggregates genres and sorts recent releases', () => {
+    const input = buildDiscogsSummaryInput([sampleRelease(1), sampleRelease(2)], 2, 'https://discogs.example/u')
+    expect(input.collectionTotal).toBe(2)
+    expect(input.genreCounts.Electronic).toBe(2)
+    expect(input.recentReleases.length).toBe(2)
+    expect(input.recentReleases[0].title).toBe('Album 2')
+  })
+
+  it('skips rows without basicInformation', () => {
+    const input = buildDiscogsSummaryInput(
+      [{ id: 9 } as DiscogsTransformedRelease, sampleRelease(1)],
+      2,
+      undefined,
+    )
+    expect(input.recentReleases.length).toBe(1)
+    expect(input.profileURL).toBeUndefined()
+  })
+
+  it('uses unknown decade for invalid years and caps recent list at 72', () => {
+    const many: DiscogsTransformedRelease[] = []
+    for (let n = 0; n < 80; n += 1) {
+      many.push({
+        basicInformation: {
+          artists: [{ name: 'X' }],
+          formats: [{ name: 'CD' }],
+          genres: ['Rock'],
+          styles: [],
+          title: `T${n}`,
+          year: n === 0 ? 0 : 1980,
+        },
+        dateAdded: `2025-01-${String((n % 28) + 1).padStart(2, '0')}T12:00:00.000Z`,
+        id: n,
+      })
+    }
+    const input = buildDiscogsSummaryInput(many, 80, undefined)
+    expect(input.decadeCounts.unknown).toBeGreaterThanOrEqual(1)
+    expect(input.recentReleases.length).toBe(72)
+  })
+
+  it('parses artists, formats, and tags loosely', () => {
+    const input = buildDiscogsSummaryInput(
+      [
+        {
+          basicInformation: {
+            artists: [{ name: '' }, 'oops' as unknown as { name: string }, { name: 'Valid' }],
+            formats: [{ name: 'LP' }, {} as { name: string }],
+            genres: ['  Jazz ', 3 as unknown as string],
+            styles: [' Dub '],
+            title: 'T',
+            year: undefined,
+          },
+          dateAdded: 'not-a-date' as unknown as string,
+          id: 1,
+        },
+      ],
+      1,
+      'https://example.com',
+    )
+    expect(input.genreCounts.Jazz).toBe(1)
+    expect(input.styleCounts.Dub).toBe(1)
+    expect(input.recentReleases[0].artists).toContain('Valid')
+    expect(input.recentReleases[0].formats).toContain('LP')
+  })
+})
+
+describe('generateDiscogsSummary', () => {
+  const mockFetch = vi.fn()
+  const originalFetch = globalThis.fetch
+
+  const summaryInput = buildDiscogsSummaryInput([sampleRelease(1)], 1, 'https://discogs.example/u')
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.ANTHROPIC_API_KEY = 'test-api-key'
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () =>
+        assistantJson('```json\n{"response": "<p>Mock collection summary.</p>"}\n```'),
+    })
+    globalThis.fetch = mockFetch as typeof fetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('returns assistant HTML when the API responds with JSON', async () => {
+    const result = await generateDiscogsSummary(summaryInput)
+    expect(result).toBe('<p>Mock collection summary.</p>')
+  })
+
+  it('throws when ANTHROPIC_API_KEY is not set', async () => {
+    delete process.env.ANTHROPIC_API_KEY
+
+    await expect(generateDiscogsSummary(summaryInput)).rejects.toThrow(
+      'ANTHROPIC_API_KEY environment variable is required',
+    )
+  })
+
+  it('includes decade rollups in the prompt', async () => {
+    await generateDiscogsSummary(summaryInput)
+    const init = mockFetch.mock.calls[0]?.[1] as FetchCallInit
+    const parsed = JSON.parse(init.body ?? '{}') as { messages?: { content?: string }[] }
+    const userMsg = parsed.messages?.[0]?.content ?? ''
+    expect(userMsg).toContain('decadeCounts')
+    expect(userMsg).toContain('recentReleases')
+  })
+
+  it('should rethrow API errors with cause', async () => {
+    const { logger } = await import('firebase-functions')
+    const apiError = new Error('rate limit')
+    mockFetch.mockRejectedValueOnce(apiError)
+
+    await expect(generateDiscogsSummary(summaryInput)).rejects.toMatchObject({
+      cause: apiError,
+    })
+    expect(logger.error).toHaveBeenCalledWith('Error generating Discogs AI summary:', apiError)
+  })
+
+  it('logs and throws when assistant text is not parseable JSON', async () => {
+    const { logger } = await import('firebase-functions')
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => assistantJson('no json here'),
+    })
+
+    await expect(generateDiscogsSummary(summaryInput)).rejects.toThrow(
+      'Failed to generate AI summary:',
+    )
+    expect(logger.error).toHaveBeenCalledWith(
+      'Discogs AI summary: assistant text could not be parsed as JSON (see head/tail/indices).',
+      expect.any(Object),
+    )
+  })
+
+  it('includes tail in parse-failure log for very long assistant text', async () => {
+    const { logger } = await import('firebase-functions')
+    const longNonsense = 'x'.repeat(4000)
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => assistantJson(longNonsense),
+    })
+
+    await expect(generateDiscogsSummary(summaryInput)).rejects.toThrow()
+
+    const parseFailCall = (logger.error as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call) =>
+        call[0] ===
+        'Discogs AI summary: assistant text could not be parsed as JSON (see head/tail/indices).',
+    )
+    const payload = parseFailCall![1] as { tail?: string; head: string }
+    expect(payload.head.length).toBe(2400)
+    expect(payload.tail).toBe(longNonsense.slice(-700))
+  })
+
+  it('returns empty string when response is not a string', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => assistantJson('```json\n{"response": 42}\n```'),
+    })
+
+    await expect(generateDiscogsSummary(summaryInput)).resolves.toBe('')
+  })
+
+  it('wraps string rejection from fetch', async () => {
+    mockFetch.mockRejectedValueOnce('offline')
+
+    await expect(generateDiscogsSummary(summaryInput)).rejects.toThrow(
+      'Failed to generate AI summary: offline',
+    )
+  })
+
+  it('uses nested string message on non-Error rejection', async () => {
+    mockFetch.mockRejectedValueOnce({ message: 'nested msg' })
+
+    await expect(generateDiscogsSummary(summaryInput)).rejects.toThrow(
+      'Failed to generate AI summary: nested msg',
+    )
+  })
+
+  it('stringifies object message when not a string', async () => {
+    mockFetch.mockRejectedValueOnce({ message: 404 })
+
+    await expect(generateDiscogsSummary(summaryInput)).rejects.toThrow(
+      'Failed to generate AI summary: {"message":404}',
+    )
+  })
+
+  it('uses Unknown error for circular rejection in outer catch', async () => {
+    const circular: Record<string, unknown> = { a: 1 }
+    circular.self = circular
+    mockFetch.mockRejectedValueOnce(circular)
+
+    await expect(generateDiscogsSummary(summaryInput)).rejects.toThrow(
+      'Failed to generate AI summary: Unknown error',
+    )
+  })
+})

--- a/functions/api/ai-summary/generate-discogs-summary.test.ts
+++ b/functions/api/ai-summary/generate-discogs-summary.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import generateDiscogsSummary, { buildDiscogsSummaryInput } from './generate-discogs-summary.js'
+import generateDiscogsSummary, { buildDiscogsSummaryInput, bump } from './generate-discogs-summary.js'
 import type { DiscogsTransformedRelease } from '../../types/discogs.js'
 
 type FetchCallInit = { body?: string }
@@ -30,6 +30,13 @@ const sampleRelease = (i: number): DiscogsTransformedRelease => ({
 })
 
 describe('buildDiscogsSummaryInput', () => {
+  it('ignores empty rollup keys from bump()', () => {
+    const counts: Record<string, number> = {}
+    bump(counts, '')
+    expect(counts).toEqual({})
+    bump(counts, 'k')
+    expect(counts.k).toBe(1)
+  })
   it('aggregates genres and sorts recent releases', () => {
     const input = buildDiscogsSummaryInput([sampleRelease(1), sampleRelease(2)], 2, 'https://discogs.example/u')
     expect(input.collectionTotal).toBe(2)
@@ -126,6 +133,42 @@ describe('buildDiscogsSummaryInput', () => {
     expect(input.recentReleases[0].title).toBe('Newer')
     expect(input.recentReleases[1].title).toBe('Older')
   })
+
+  it('treats non-string dateAdded and maps artist/format names that are not strings', () => {
+    const row: DiscogsTransformedRelease = {
+      basicInformation: {
+        artists: [{ name: 42 as unknown as string }],
+        formats: [{ name: null as unknown as string }],
+        genres: ['X'],
+        title: 'T',
+        year: 2010,
+      },
+      dateAdded: 2020 as unknown as string,
+      id: 1,
+    }
+    const input = buildDiscogsSummaryInput([row], 1, 'https://u')
+    expect(input.recentReleases[0].artists).toEqual([])
+    expect(input.recentReleases[0].formats).toEqual([])
+  })
+
+  it('uses parseDateAdded fallback for undefined and invalid date strings', () => {
+    const a: DiscogsTransformedRelease = {
+      basicInformation: { title: 'A', year: 2000 },
+      id: 1,
+    }
+    const b: DiscogsTransformedRelease = {
+      basicInformation: { title: 'B', year: 2000 },
+      dateAdded: undefined,
+      id: 2,
+    }
+    const c: DiscogsTransformedRelease = {
+      basicInformation: { title: 'C', year: 2000 },
+      dateAdded: 'not-parseable',
+      id: 3,
+    }
+    const input = buildDiscogsSummaryInput([a, b, c], 3, undefined)
+    expect(input.recentReleases.map((r) => r.title)).toEqual(['A', 'B', 'C'])
+  })
 })
 
 describe('generateDiscogsSummary', () => {
@@ -169,6 +212,32 @@ describe('generateDiscogsSummary', () => {
     const payload = parseFailCall![1] as { tail?: string; charLength: number }
     expect(payload.charLength).toBeLessThan(3100)
     expect(payload.tail).toBeUndefined()
+  })
+
+  it('embeds profileURL in the prompt when provided', async () => {
+    const input = buildDiscogsSummaryInput([sampleRelease(1)], 1, 'https://discogs.example/user/me')
+    await generateDiscogsSummary(input)
+    const init = mockFetch.mock.calls[0]?.[1] as FetchCallInit
+    const parsed = JSON.parse(init.body ?? '{}') as { messages?: { content?: string }[] }
+    expect(parsed.messages?.[0]?.content).toContain('https://discogs.example/user/me')
+  })
+
+  it('uses empty collection URL in the prompt when profileURL is undefined', async () => {
+    const input = buildDiscogsSummaryInput([sampleRelease(1)], 1, undefined)
+    await generateDiscogsSummary(input)
+    const init = mockFetch.mock.calls[0]?.[1] as FetchCallInit
+    const parsed = JSON.parse(init.body ?? '{}') as { messages?: { content?: string }[] }
+    const content = parsed.messages?.[0]?.content ?? ''
+    expect(content).toContain('Collection URL (context only): ')
+    expect(content).not.toMatch(/Collection URL \(context only\):\s*https?:\/\//)
+  })
+
+  it('uses Unknown error when JSON.stringify fails in the error wrapper', async () => {
+    mockFetch.mockRejectedValueOnce({ tag: 1n })
+
+    await expect(generateDiscogsSummary(summaryInput)).rejects.toThrow(
+      'Failed to generate AI summary: Unknown error',
+    )
   })
 
   it('returns assistant HTML when the API responds with JSON', async () => {

--- a/functions/api/ai-summary/generate-discogs-summary.ts
+++ b/functions/api/ai-summary/generate-discogs-summary.ts
@@ -1,0 +1,204 @@
+import { logger } from 'firebase-functions'
+
+import { getAiSummaryApiKey } from '../../config/backend-config.js'
+import type {
+  DiscogsSummaryInput,
+  DiscogsTransformedRelease,
+} from '../../types/discogs.js'
+import { requestAiSummaryCompletion } from '../../utils/ai-summary-messages.js'
+import extractJsonFromAiResponse from '../../utils/extract-json-from-ai-response.js'
+
+const DISCOGS_AI_ASSISTANT_LOG_HEAD = 2400
+const DISCOGS_AI_ASSISTANT_LOG_TAIL = 700
+
+const buildDiscogsAssistantTextLogFields = (assistantText: string) => {
+  const charLength = assistantText.length
+  const trimmedLength = assistantText.trim().length
+  const head = assistantText.slice(0, DISCOGS_AI_ASSISTANT_LOG_HEAD)
+  const tail =
+    charLength > DISCOGS_AI_ASSISTANT_LOG_HEAD + DISCOGS_AI_ASSISTANT_LOG_TAIL
+      ? assistantText.slice(-DISCOGS_AI_ASSISTANT_LOG_TAIL)
+      : undefined
+  return {
+    charLength,
+    trimmedLength,
+    firstCurlyIndex: assistantText.indexOf('{'),
+    lastCurlyIndex: assistantText.lastIndexOf('}'),
+    hasMarkdownFence: /```(?:json)?/i.test(assistantText),
+    head,
+    ...(tail !== undefined ? { tail } : {}),
+  }
+}
+
+function messageFromUnknownError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message
+  }
+  if (typeof error === 'string') {
+    return error
+  }
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    const m = (error as { message: unknown }).message
+    if (typeof m === 'string') {
+      return m
+    }
+  }
+  try {
+    return JSON.stringify(error)
+  } catch {
+    return 'Unknown error'
+  }
+}
+
+const bump = (counts: Record<string, number>, key: string): void => {
+  if (!key) return
+  counts[key] = (counts[key] ?? 0) + 1
+}
+
+const namesFromArtists = (artists: unknown): string[] => {
+  if (!Array.isArray(artists)) return []
+  return artists
+    .map((a) => {
+      if (typeof a === 'object' && a !== null && 'name' in a) {
+        const n = (a as { name: unknown }).name
+        return typeof n === 'string' ? n.trim() : ''
+      }
+      return ''
+    })
+    .filter(Boolean)
+}
+
+const formatNames = (formats: unknown): string[] => {
+  if (!Array.isArray(formats)) return []
+  return formats
+    .map((f) => {
+      if (typeof f === 'object' && f !== null && 'name' in f) {
+        const n = (f as { name: unknown }).name
+        return typeof n === 'string' ? n.trim() : ''
+      }
+      return ''
+    })
+    .filter(Boolean)
+}
+
+const stringTags = (tags: unknown): string[] => {
+  if (!Array.isArray(tags)) return []
+  return tags.map((t) => (typeof t === 'string' ? t.trim() : '')).filter(Boolean)
+}
+
+const decadeFromYear = (year: number | undefined): string => {
+  if (typeof year !== 'number' || year <= 0) {
+    return 'unknown'
+  }
+  return `${Math.floor(year / 10) * 10}s`
+}
+
+const parseDateAdded = (s: string | undefined): number => {
+  if (!s || typeof s !== 'string') return 0
+  const t = Date.parse(s)
+  return Number.isNaN(t) ? 0 : t
+}
+
+/** Compact releases + rollups for the model (handles large collections). */
+export const buildDiscogsSummaryInput = (
+  releases: DiscogsTransformedRelease[],
+  collectionTotal: number,
+  profileURL: string | undefined,
+): DiscogsSummaryInput => {
+  const valid = releases.filter((r) => r.basicInformation)
+  const genreCounts: Record<string, number> = {}
+  const styleCounts: Record<string, number> = {}
+  const decadeCounts: Record<string, number> = {}
+
+  for (const r of valid) {
+    const bi = r.basicInformation
+    bump(decadeCounts, decadeFromYear(bi.year))
+    for (const g of stringTags(bi.genres)) {
+      bump(genreCounts, g)
+    }
+    for (const s of stringTags(bi.styles)) {
+      bump(styleCounts, s)
+    }
+  }
+
+  const sorted = [...valid].sort(
+    (a, b) => parseDateAdded(b.dateAdded) - parseDateAdded(a.dateAdded),
+  )
+  const recentReleases = sorted.slice(0, 72).map((r) => {
+    const bi = r.basicInformation
+    return {
+      artists: namesFromArtists(bi.artists),
+      dateAdded: r.dateAdded,
+      formats: formatNames(bi.formats),
+      genres: stringTags(bi.genres),
+      styles: stringTags(bi.styles),
+      title: bi.title,
+      year: bi.year,
+    }
+  })
+
+  return {
+    collectionTotal,
+    decadeCounts,
+    genreCounts,
+    profileURL,
+    recentReleases,
+    styleCounts,
+  }
+}
+
+/**
+ * Generate AI summary of Discogs collection data (LLM JSON → HTML paragraphs).
+ */
+const generateDiscogsSummary = async (input: DiscogsSummaryInput): Promise<string> => {
+  const apiKey = getAiSummaryApiKey()
+
+  if (!apiKey) {
+    throw new Error('ANTHROPIC_API_KEY environment variable is required')
+  }
+
+  const prompt = `
+You are writing a short, reader-facing “AI collection summary” for Chris Vogt’s physical music collection on Discogs, on his personal homepage (chrisvogt.me). It appears next to live artwork and release rows, so visitors already see titles and formats there.
+
+Return **valid JSON only** (no markdown fences, no commentary) using exactly this shape:
+{
+  "response": "<string: two or three HTML paragraphs, see rules below>"
+}
+
+Rules for the "response" string (strict — the UI is built for this):
+- **JSON-safe HTML:** escape every ASCII double-quote (U+0022) inside the **response** string as a backslash plus double-quote; do not use raw line breaks inside that string (one line of HTML, or JSON-escaped newline as backslash followed by n). The full payload must be valid JSON.
+- **Two or three** <p>...</p> elements, back-to-back, with nothing before, between, or after them (no wrapper <div>, no line breaks outside the tags).
+- **First person** only: Chris Vogt’s own words — **I**, **my**, **me**. Do not describe him in third person (“Chris…”, “he…”). Avoid pivoting to address the visitor as **you**; stay in first-person perspective throughout.
+- **Voice** (match chrisvogt.me editorial tone): calm, specific, a little editorial. Describe **collecting** through-lines: eras, genres, formats (vinyl vs CD), labels or scenes if the data suggests it — without catalog listing. No meta lines about this being an AI summary. No thank-you sign-offs.
+- **recentReleases** is sorted newest-first (subset of the collection). **decadeCounts**, **genreCounts**, and **styleCounts** are rollups over the full synced collection use them for long-run shape; do not recite every bin or count.
+- **Do not** quote exact collection totals unless it serves a sharp point.
+- Optional sparse styling inside paragraphs: <strong>, <em>, <b>, <i>; no hyperlinks, lists, headings, or images.
+
+Collection URL (context only): ${input.profileURL ?? ''}
+Total items in collection (approximate, from Discogs pagination): ${input.collectionTotal}
+
+"decadeCounts": ${JSON.stringify(input.decadeCounts)}
+"genreCounts": ${JSON.stringify(input.genreCounts)}
+"styleCounts": ${JSON.stringify(input.styleCounts)}
+"recentReleases": ${JSON.stringify(input.recentReleases)}
+`
+
+  try {
+    const responseText = await requestAiSummaryCompletion({ apiKey, userMessage: prompt })
+    const parsed = extractJsonFromAiResponse<{ response?: unknown }>(responseText)
+    if (!parsed) {
+      logger.error(
+        'Discogs AI summary: assistant text could not be parsed as JSON (see head/tail/indices).',
+        buildDiscogsAssistantTextLogFields(responseText),
+      )
+      throw new Error('Model response was not valid JSON (no markdown block or raw JSON)')
+    }
+    const raw = parsed.response
+    return typeof raw === 'string' ? raw : ''
+  } catch (error: unknown) {
+    logger.error('Error generating Discogs AI summary:', error)
+    throw new Error(`Failed to generate AI summary: ${messageFromUnknownError(error)}`, { cause: error })
+  }
+}
+
+export default generateDiscogsSummary

--- a/functions/api/ai-summary/generate-discogs-summary.ts
+++ b/functions/api/ai-summary/generate-discogs-summary.ts
@@ -55,6 +55,8 @@ const bump = (counts: Record<string, number>, key: string): void => {
   counts[key] = (counts[key] ?? 0) + 1
 }
 
+export { bump }
+
 const namesFromArtists = (artists: unknown): string[] => {
   if (!Array.isArray(artists)) return []
   return artists

--- a/functions/api/ai-summary/generate-spotify-summary.test.ts
+++ b/functions/api/ai-summary/generate-spotify-summary.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import generateSpotifySummary from './generate-spotify-summary.js'
+
+type FetchCallInit = { body?: string; method?: string; headers?: Record<string, string> }
+
+vi.mock('firebase-functions', () => ({
+  logger: { error: vi.fn() },
+}))
+
+const assistantJson = (text: string) =>
+  JSON.stringify({
+    id: 'msg_test',
+    type: 'message',
+    role: 'assistant',
+    content: [{ type: 'text', text }],
+  })
+
+describe('generateSpotifySummary', () => {
+  const mockData = {
+    metrics: [{ displayName: 'Playlists', id: 'playlists-count', value: 3 }],
+    playlists: [{ name: 'Ambient', public: true, trackCount: 40 }],
+    profile: { displayName: 'Listener', profileURL: 'https://open.spotify.com/user/x' },
+    topTracks: [{ artists: ['A'], name: 'Track 1' }],
+  }
+
+  const mockFetch = vi.fn()
+  const originalFetch = globalThis.fetch
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.ANTHROPIC_API_KEY = 'test-api-key'
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () =>
+        assistantJson('```json\n{"response": "<p>Mock listening summary.</p>"}\n```'),
+    })
+    globalThis.fetch = mockFetch as typeof fetch
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+  })
+
+  it('returns assistant HTML when the API responds with JSON', async () => {
+    const result = await generateSpotifySummary(mockData)
+    expect(result).toBe('<p>Mock listening summary.</p>')
+  })
+
+  it('throws when ANTHROPIC_API_KEY is not set', async () => {
+    delete process.env.ANTHROPIC_API_KEY
+
+    await expect(generateSpotifySummary(mockData)).rejects.toThrow(
+      'ANTHROPIC_API_KEY environment variable is required',
+    )
+  })
+
+  it('sends playlist and track payload in the user message', async () => {
+    await generateSpotifySummary(mockData)
+    const init = mockFetch.mock.calls[0]?.[1] as FetchCallInit
+    const parsed = JSON.parse(init.body as string) as { messages?: { content?: string }[] }
+    const userMsg = parsed.messages?.[0]?.content ?? ''
+    expect(userMsg).toContain('Ambient')
+    expect(userMsg).toContain('Track 1')
+    expect(userMsg).toContain('First person')
+  })
+
+  it('should rethrow API errors with cause', async () => {
+    const { logger } = await import('firebase-functions')
+    const apiError = new Error('API quota exceeded')
+    mockFetch.mockRejectedValueOnce(apiError)
+
+    await expect(generateSpotifySummary(mockData)).rejects.toMatchObject({
+      message: 'Failed to generate AI summary: API quota exceeded',
+      cause: apiError,
+    })
+    expect(logger.error).toHaveBeenCalledWith('Error generating Spotify AI summary:', apiError)
+  })
+
+  it('should rethrow when model response is not valid JSON', async () => {
+    const { logger } = await import('firebase-functions')
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => assistantJson('not valid json at all'),
+    })
+
+    await expect(generateSpotifySummary(mockData)).rejects.toMatchObject({
+      message: expect.stringContaining('Failed to generate AI summary'),
+      cause: {
+        message: 'Model response was not valid JSON (no markdown block or raw JSON)',
+      },
+    })
+    expect(logger.error).toHaveBeenCalledWith(
+      'Error generating Spotify AI summary:',
+      expect.any(Error),
+    )
+  })
+
+  it('logs structured assistant fields when JSON extraction fails', async () => {
+    const { logger } = await import('firebase-functions')
+    const assistantText = 'Plain prose with no parseable JSON object in sight.'
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => assistantJson(assistantText),
+    })
+
+    await expect(generateSpotifySummary(mockData)).rejects.toMatchObject({
+      cause: {
+        message: 'Model response was not valid JSON (no markdown block or raw JSON)',
+      },
+    })
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Spotify AI summary: assistant text could not be parsed as JSON (see head/tail/indices).',
+      expect.objectContaining({
+        charLength: assistantText.length,
+        trimmedLength: assistantText.trim().length,
+        firstCurlyIndex: -1,
+        lastCurlyIndex: -1,
+        hasMarkdownFence: false,
+        head: assistantText,
+      }),
+    )
+  })
+
+  it('includes tail in parse-failure log when assistant text is longer than head plus tail', async () => {
+    const { logger } = await import('firebase-functions')
+    const longNonsense = 'b'.repeat(4000)
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => assistantJson(longNonsense),
+    })
+
+    await expect(generateSpotifySummary(mockData)).rejects.toMatchObject({
+      cause: {
+        message: 'Model response was not valid JSON (no markdown block or raw JSON)',
+      },
+    })
+
+    const parseFailCall = (logger.error as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call) =>
+        call[0] ===
+        'Spotify AI summary: assistant text could not be parsed as JSON (see head/tail/indices).',
+    )
+    expect(parseFailCall).toBeDefined()
+    const payload = parseFailCall![1] as { head: string; tail: string; charLength: number }
+    expect(payload.charLength).toBe(4000)
+    expect(payload.head).toBe(longNonsense.slice(0, 2400))
+    expect(payload.tail).toBe(longNonsense.slice(-700))
+  })
+
+  it('returns empty string when response JSON field is not a string', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () =>
+        assistantJson('```json\n{"response": {"html": "<p>nested</p>"}}\n```'),
+    })
+
+    await expect(generateSpotifySummary(mockData)).resolves.toBe('')
+  })
+
+  it('wraps non-Error rejections from the AI summary request', async () => {
+    mockFetch.mockRejectedValueOnce('rate limited')
+
+    await expect(generateSpotifySummary(mockData)).rejects.toMatchObject({
+      message: 'Failed to generate AI summary: rate limited',
+    })
+  })
+
+  it('surfaces HTTP error bodies from the AI summary API', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      text: async () => JSON.stringify({ error: { message: 'invalid x-api-key' } }),
+    })
+
+    await expect(generateSpotifySummary(mockData)).rejects.toThrow(
+      'Failed to generate AI summary: AI summary API error (401): invalid x-api-key',
+    )
+  })
+
+  it('formats unknown errors with object message and JSON fallbacks', async () => {
+    mockFetch.mockRejectedValueOnce({ message: 404 })
+
+    await expect(generateSpotifySummary(mockData)).rejects.toThrow(
+      'Failed to generate AI summary: {"message":404}',
+    )
+  })
+
+  it('uses string message property on non-Error rejections', async () => {
+    mockFetch.mockRejectedValueOnce({ message: 'from nested message' })
+
+    await expect(generateSpotifySummary(mockData)).rejects.toThrow(
+      'Failed to generate AI summary: from nested message',
+    )
+  })
+
+  it('uses Unknown error when JSON.stringify fails on a thrown value', async () => {
+    const circular: Record<string, unknown> = { a: 1 }
+    circular.self = circular
+    mockFetch.mockRejectedValueOnce(circular)
+
+    await expect(generateSpotifySummary(mockData)).rejects.toThrow(
+      'Failed to generate AI summary: Unknown error',
+    )
+  })
+})

--- a/functions/api/ai-summary/generate-spotify-summary.test.ts
+++ b/functions/api/ai-summary/generate-spotify-summary.test.ts
@@ -47,6 +47,18 @@ describe('generateSpotifySummary', () => {
     expect(result).toBe('<p>Mock listening summary.</p>')
   })
 
+  it('renders empty profile placeholders in the prompt when names are missing', async () => {
+    await generateSpotifySummary({
+      ...mockData,
+      profile: {},
+    })
+    const init = mockFetch.mock.calls[0]?.[1] as FetchCallInit
+    const parsed = JSON.parse(init.body as string) as { messages?: { content?: string }[] }
+    const userMsg = parsed.messages?.[0]?.content ?? ''
+    expect(userMsg).toMatch(/Spotify profile display name:\s*/)
+    expect(userMsg).toContain('Profile URL (context only')
+  })
+
   it('throws when ANTHROPIC_API_KEY is not set', async () => {
     delete process.env.ANTHROPIC_API_KEY
 
@@ -123,6 +135,27 @@ describe('generateSpotifySummary', () => {
         head: assistantText,
       }),
     )
+  })
+
+  it('parse-failure log omits tail for short assistant text', async () => {
+    const { logger } = await import('firebase-functions')
+    const shortText = 'too short for tail slice'
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      text: async () => assistantJson(shortText),
+    })
+
+    await expect(generateSpotifySummary(mockData)).rejects.toThrow()
+
+    const parseFailCall = (logger.error as ReturnType<typeof vi.fn>).mock.calls.find(
+      (call) =>
+        call[0] ===
+        'Spotify AI summary: assistant text could not be parsed as JSON (see head/tail/indices).',
+    )
+    const payload = parseFailCall![1] as { tail?: string; charLength: number }
+    expect(payload.charLength).toBeLessThan(3100)
+    expect(payload.tail).toBeUndefined()
   })
 
   it('includes tail in parse-failure log when assistant text is longer than head plus tail', async () => {

--- a/functions/api/ai-summary/generate-spotify-summary.ts
+++ b/functions/api/ai-summary/generate-spotify-summary.ts
@@ -1,0 +1,107 @@
+import { logger } from 'firebase-functions'
+
+import { getAiSummaryApiKey } from '../../config/backend-config.js'
+import type { SpotifySummaryInput } from '../../types/spotify-summary.js'
+import { requestAiSummaryCompletion } from '../../utils/ai-summary-messages.js'
+import extractJsonFromAiResponse from '../../utils/extract-json-from-ai-response.js'
+
+const SPOTIFY_AI_ASSISTANT_LOG_HEAD = 2400
+const SPOTIFY_AI_ASSISTANT_LOG_TAIL = 700
+
+const buildSpotifyAssistantTextLogFields = (assistantText: string) => {
+  const charLength = assistantText.length
+  const trimmedLength = assistantText.trim().length
+  const head = assistantText.slice(0, SPOTIFY_AI_ASSISTANT_LOG_HEAD)
+  const tail =
+    charLength > SPOTIFY_AI_ASSISTANT_LOG_HEAD + SPOTIFY_AI_ASSISTANT_LOG_TAIL
+      ? assistantText.slice(-SPOTIFY_AI_ASSISTANT_LOG_TAIL)
+      : undefined
+  return {
+    charLength,
+    trimmedLength,
+    firstCurlyIndex: assistantText.indexOf('{'),
+    lastCurlyIndex: assistantText.lastIndexOf('}'),
+    hasMarkdownFence: /```(?:json)?/i.test(assistantText),
+    head,
+    ...(tail !== undefined ? { tail } : {}),
+  }
+}
+
+function messageFromUnknownError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message
+  }
+  if (typeof error === 'string') {
+    return error
+  }
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    const m = (error as { message: unknown }).message
+    if (typeof m === 'string') {
+      return m
+    }
+  }
+  try {
+    return JSON.stringify(error)
+  } catch {
+    return 'Unknown error'
+  }
+}
+
+/**
+ * Generate AI summary of Spotify listening data (LLM JSON → HTML paragraphs).
+ */
+const generateSpotifySummary = async (spotifyData: SpotifySummaryInput): Promise<string> => {
+  const apiKey = getAiSummaryApiKey()
+
+  if (!apiKey) {
+    throw new Error('ANTHROPIC_API_KEY environment variable is required')
+  }
+
+  const { metrics, playlists, profile, topTracks } = spotifyData
+
+  const prompt = `
+You are writing a short, reader-facing “AI listening summary” for Chris Vogt’s Spotify activity on his personal homepage (chrisvogt.me). It appears next to live playlists and top tracks, so visitors already see names and artwork there.
+
+Return **valid JSON only** (no markdown fences, no commentary) using exactly this shape:
+{
+  "response": "<string: two or three HTML paragraphs, see rules below>"
+}
+
+Rules for the "response" string (strict — the UI is built for this):
+- **JSON-safe HTML:** escape every ASCII double-quote (U+0022) inside the **response** string as a backslash plus double-quote; do not use raw line breaks inside that string (one line of HTML, or JSON-escaped newline as backslash followed by n). The full payload must be valid JSON.
+- **Two or three** <p>...</p> elements, back-to-back, with nothing before, between, or after them (no wrapper <div>, no line breaks outside the tags).
+- **First person** only: Chris Vogt’s own words — **I**, **my**, **me**. Do not describe him in third person (“Chris…”, “he…”). Avoid pivoting to address the visitor as **you**; stay in first-person perspective throughout.
+- **Voice** (match chrisvogt.me editorial tone): calm, specific, a little editorial — like a sharp one-column blurb, not marketing. Lead with listening habits, playlist “lanes,” or recurring artists when you can; avoid empty platitudes (“music is my life”). No meta lines about this being an AI summary or a widget. No thank-you sign-offs. At most one metaphor or framing detail per paragraph.
+- Summarize **top tracks** (who and what registers) and how **playlists** suggest curation or mood — without re-listing every title or playlist name.
+- **Do not** quote follower counts, playlist totals, or other metrics unless they sharpen a point (visitors can see metrics elsewhere).
+- Optional sparse styling inside paragraphs: <strong>, <em>, <b>, <i>; no hyperlinks, lists, headings, or images.
+
+Spotify profile display name: ${profile.displayName ?? ''}
+Profile URL (context only, do not echo as a naked link): ${profile.profileURL ?? ''}
+
+"metrics": ${JSON.stringify(metrics)}
+
+"topTracks": ${JSON.stringify(topTracks)}
+
+"playlists": ${JSON.stringify(playlists)}
+`
+
+  try {
+    const responseText = await requestAiSummaryCompletion({ apiKey, userMessage: prompt })
+    const parsed = extractJsonFromAiResponse<{ response?: unknown }>(responseText)
+    if (!parsed) {
+      logger.error(
+        'Spotify AI summary: assistant text could not be parsed as JSON (see head/tail/indices).',
+        buildSpotifyAssistantTextLogFields(responseText),
+      )
+      throw new Error('Model response was not valid JSON (no markdown block or raw JSON)')
+    }
+    const raw = parsed.response
+    return typeof raw === 'string' ? raw : ''
+  } catch (error: unknown) {
+    logger.error('Error generating Spotify AI summary:', error)
+    throw new Error(`Failed to generate AI summary: ${messageFromUnknownError(error)}`, { cause: error })
+  }
+}
+
+export default generateSpotifySummary

--- a/functions/jobs/sync-discogs-data.test.ts
+++ b/functions/jobs/sync-discogs-data.test.ts
@@ -36,7 +36,22 @@ vi.mock('../services/media/media-service.js', () => ({
 }))
 
 vi.mock('../transformers/transform-discogs-release.js', () => ({
-  default: vi.fn((release) => ({ ...release, transformed: true })),
+  default: vi.fn((release) => {
+    const bi = release.basic_information
+    return {
+      basicInformation: {
+        artists: Array.isArray(bi?.artists) ? bi.artists : [{ name: 'Artist' }],
+        formats: Array.isArray(bi?.formats) ? bi.formats : [{ name: 'Vinyl' }],
+        genres: Array.isArray(bi?.genres) ? bi.genres : ['Rock'],
+        styles: Array.isArray(bi?.styles) ? bi.styles : [],
+        title: typeof bi?.title === 'string' ? bi.title : 'Test',
+        year: typeof bi?.year === 'number' ? bi.year : 2020,
+      },
+      dateAdded: typeof release.date_added === 'string' ? release.date_added : undefined,
+      id: release.id,
+      transformed: true,
+    }
+  }),
 }))
 
 vi.mock('../transformers/to-discogs-destination-path.js', () => ({
@@ -47,6 +62,16 @@ vi.mock('../services/discogs-integration-credentials.js', () => ({
   loadDiscogsAuthForUser: vi.fn().mockResolvedValue(null),
 }))
 
+vi.mock('../api/ai-summary/generate-discogs-summary.js', async (importOriginal) => {
+  const mod =
+    await importOriginal<typeof import('../api/ai-summary/generate-discogs-summary.js')>()
+  return {
+    ...mod,
+    default: vi.fn().mockResolvedValue('<p>Mock Discogs AI summary.</p>'),
+  }
+})
+
+import generateDiscogsSummary from '../api/ai-summary/generate-discogs-summary.js'
 import fetchDiscogsReleases from '../api/discogs/fetch-releases.js'
 import fetchReleasesBatch from '../api/discogs/fetch-releases-batch.js'
 import { listStoredMedia, storeRemoteMedia } from '../services/media/media-service.js'
@@ -117,11 +142,63 @@ describe('syncDiscogsData', () => {
       2,
       'users/chrisvogt/discogs/widget-content',
       expect.objectContaining({
+        aiSummary: '<p>Mock Discogs AI summary.</p>',
         meta: {
           synced: expect.any(String),
         },
       })
     )
+    expect(documentStore.setDocument).toHaveBeenNthCalledWith(
+      3,
+      'users/chrisvogt/discogs/last-response_ai-summary',
+      expect.objectContaining({
+        generatedAt: expect.any(String),
+        summary: '<p>Mock Discogs AI summary.</p>',
+      })
+    )
+  })
+
+  it('continues when AI summary generation fails', async () => {
+    vi.mocked(generateDiscogsSummary).mockRejectedValueOnce(new Error('AI unavailable'))
+    const mockDiscogsResponse = {
+      pagination: { items: 2, page: 1, pages: 1, per_page: 2, urls: {} },
+      releases: [
+        {
+          id: 1,
+          basic_information: {
+            thumb: 'https://example.com/thumb1.jpg',
+            cover_image: 'https://example.com/cover1.jpg',
+          },
+        },
+        {
+          id: 2,
+          basic_information: {
+            thumb: 'https://example.com/thumb2.jpg',
+            cover_image: 'https://example.com/cover2.jpg',
+          },
+        },
+      ],
+    }
+
+    vi.mocked(fetchDiscogsReleases).mockResolvedValue(mockDiscogsResponse)
+    vi.mocked(listStoredMedia).mockResolvedValue([])
+
+    const result = await syncDiscogsData(documentStore)
+
+    expect(result.result).toBe('SUCCESS')
+    expect(logger.error).toHaveBeenCalledWith(
+      'Failed to generate Discogs AI summary.',
+      expect.any(Error),
+    )
+    const widgetPayload = vi.mocked(documentStore.setDocument).mock.calls.find(
+      (c) => c[0] === 'users/chrisvogt/discogs/widget-content',
+    )?.[1] as { aiSummary?: string }
+    expect(widgetPayload.aiSummary).toBeUndefined()
+    expect(
+      vi.mocked(documentStore.setDocument).mock.calls.some(
+        (c) => c[0] === 'users/chrisvogt/discogs/last-response_ai-summary',
+      ),
+    ).toBe(false)
   })
 
   it('should handle API errors gracefully', async () => {
@@ -219,6 +296,7 @@ describe('syncDiscogsData', () => {
       'discogs.auth',
       'discogs.collection',
       'discogs.save_raw',
+      'discogs.ai',
       'discogs.save_widget',
       'discogs.artwork',
       'discogs.artwork',

--- a/functions/jobs/sync-discogs-data.test.ts
+++ b/functions/jobs/sync-discogs-data.test.ts
@@ -74,7 +74,9 @@ vi.mock('../api/ai-summary/generate-discogs-summary.js', async (importOriginal) 
 import generateDiscogsSummary from '../api/ai-summary/generate-discogs-summary.js'
 import fetchDiscogsReleases from '../api/discogs/fetch-releases.js'
 import fetchReleasesBatch from '../api/discogs/fetch-releases-batch.js'
+import transformDiscogsRelease from '../transformers/transform-discogs-release.js'
 import { listStoredMedia, storeRemoteMedia } from '../services/media/media-service.js'
+import { loadDiscogsAuthForUser } from '../services/discogs-integration-credentials.js'
 
 describe('syncDiscogsData', () => {
   let documentStore: DocumentStore
@@ -516,5 +518,53 @@ describe('syncDiscogsData', () => {
       'users/chrisvogt/discogs/widget-content',
       expect.any(Object)
     )
+  })
+
+  it('uses OAuth Discogs username in the widget profile URL when linked', async () => {
+    vi.mocked(loadDiscogsAuthForUser).mockResolvedValueOnce({
+      consumerKey: 'ck',
+      consumerSecret: 'cs',
+      discogsUsername: 'oauthuser',
+      mode: 'oauth',
+      oauthToken: 't',
+      oauthTokenSecret: 'ts',
+    })
+    vi.mocked(fetchDiscogsReleases).mockResolvedValue({
+      pagination: { items: 0, page: 1, pages: 1, per_page: 0, urls: {} },
+      releases: [],
+    })
+    vi.mocked(listStoredMedia).mockResolvedValue([])
+
+    await syncDiscogsData(documentStore)
+
+    const widgetCall = vi.mocked(documentStore.setDocument).mock.calls.find((c) =>
+      c[0].endsWith('/widget-content'),
+    )
+    expect((widgetCall?.[1] as { profile?: { profileURL?: string } }).profile?.profileURL).toContain(
+      'oauthuser',
+    )
+  })
+
+  it('skips Discogs AI summary when compact summary input has no signals', async () => {
+    vi.mocked(transformDiscogsRelease).mockImplementationOnce(
+      () => ({ id: 1 }) as import('../types/discogs.js').DiscogsTransformedRelease,
+    )
+    vi.mocked(fetchDiscogsReleases).mockResolvedValue({
+      pagination: { items: 1, page: 1, pages: 1, per_page: 1, urls: {} },
+      releases: [
+        {
+          id: 1,
+          basic_information: {
+            thumb: 'https://example.com/thumb.jpg',
+            cover_image: 'https://example.com/cover.jpg',
+          },
+        },
+      ],
+    })
+    vi.mocked(listStoredMedia).mockResolvedValue([])
+
+    await syncDiscogsData(documentStore)
+
+    expect(vi.mocked(generateDiscogsSummary)).not.toHaveBeenCalled()
   })
 })

--- a/functions/jobs/sync-discogs-data.ts
+++ b/functions/jobs/sync-discogs-data.ts
@@ -13,6 +13,7 @@ import { getLogger } from '../services/logger.js'
 import { loadDiscogsAuthForUser } from '../services/discogs-integration-credentials.js'
 import toDiscogsDestinationPath from '../transformers/to-discogs-destination-path.js'
 import transformDiscogsRelease from '../transformers/transform-discogs-release.js'
+import generateDiscogsSummary, { buildDiscogsSummaryInput } from '../api/ai-summary/generate-discogs-summary.js'
 import { toStoredDateTime } from '../utils/time.js'
 import { getDefaultWidgetUserId, toProviderCollectionPath } from '../config/backend-paths.js'
 import type {
@@ -193,12 +194,50 @@ const syncDiscogsData = async (
       }
     }
 
+    let aiSummary: string | null = null
+    if (transformedReleases.length > 0) {
+      try {
+        onProgress?.({
+          phase: 'discogs.ai',
+          message: 'Generating Discogs collection summary (AI).',
+        })
+        const summaryInput = buildDiscogsSummaryInput(
+          transformedReleases,
+          pagination.items,
+          updatedWidgetContent.profile?.profileURL,
+        )
+        const hasTextSignal =
+          summaryInput.recentReleases.length > 0 ||
+          Object.keys(summaryInput.genreCounts).length > 0 ||
+          Object.keys(summaryInput.styleCounts).length > 0 ||
+          Object.keys(summaryInput.decadeCounts).length > 0
+        if (hasTextSignal) {
+          aiSummary = await generateDiscogsSummary(summaryInput)
+          updatedWidgetContent.aiSummary = aiSummary
+        }
+      } catch (error: unknown) {
+        logger.error('Failed to generate Discogs AI summary.', error)
+      }
+    }
+
     onProgress?.({
       phase: 'discogs.save_widget',
       message: 'Saving Discogs widget document.',
     })
-    // Save the widget content
-    await documentStore.setDocument(`${discogsCollectionPath}/widget-content`, updatedWidgetContent)
+    const saveWidgetContent = async () =>
+      await documentStore.setDocument(`${discogsCollectionPath}/widget-content`, updatedWidgetContent)
+
+    const saveAISummary = async () => {
+      if (aiSummary) {
+        await documentStore.setDocument(`${discogsCollectionPath}/last-response_ai-summary`, {
+          generatedAt: toStoredDateTime(),
+          summary: aiSummary,
+        })
+      }
+    }
+
+    await saveWidgetContent()
+    await saveAISummary()
 
     const titleByReleaseId = new Map<string, string>()
     for (const raw of enhancedReleases) {

--- a/functions/jobs/sync-spotify-data.test.ts
+++ b/functions/jobs/sync-spotify-data.test.ts
@@ -44,6 +44,11 @@ vi.mock('../transformers/track-to-collection-item.js', () => ({
   default: vi.fn((track) => ({ id: track.id, displayName: track.name })),
 }))
 
+vi.mock('../api/ai-summary/generate-spotify-summary.js', () => ({
+  default: vi.fn().mockResolvedValue('<p>Mock Spotify AI summary.</p>'),
+}))
+
+import generateSpotifySummary from '../api/ai-summary/generate-spotify-summary.js'
 import getSpotifyAccessToken from '../api/spotify/get-access-token.js'
 import getSpotifyPlaylists from '../api/spotify/get-playlists.js'
 import getSpotifyTopTracks from '../api/spotify/get-top-tracks.js'
@@ -117,12 +122,61 @@ describe('syncSpotifyData', () => {
     expect(documentStore.setDocument).toHaveBeenCalledWith(
       'users/chrisvogt/spotify/widget-content',
       expect.objectContaining({
+        aiSummary: '<p>Mock Spotify AI summary.</p>',
         meta: {
           synced: expect.any(String),
           totalUploadedMediaCount: 1,
         },
       })
     )
+    expect(documentStore.setDocument).toHaveBeenCalledWith(
+      'users/chrisvogt/spotify/last-response_ai-summary',
+      expect.objectContaining({
+        generatedAt: expect.any(String),
+        summary: '<p>Mock Spotify AI summary.</p>',
+      })
+    )
+  })
+
+  it('continues when AI summary generation fails', async () => {
+    vi.mocked(generateSpotifySummary).mockRejectedValueOnce(new Error('AI unavailable'))
+    vi.mocked(getSpotifyAccessToken).mockResolvedValue({ accessToken: 'spotify-token' })
+    vi.mocked(getSpotifyUserProfile).mockResolvedValue({
+      display_name: 'Test User',
+      external_urls: { spotify: 'https://open.spotify.com/user/test' },
+      followers: { total: 100 },
+      id: 'user123',
+      images: [{ url: 'https://example.com/avatar.jpg' }],
+    })
+    vi.mocked(getSpotifyTopTracks).mockResolvedValue([{ id: 'track1', name: 'Track 1' }])
+    vi.mocked(getSpotifyPlaylists).mockResolvedValue({
+      total: 1,
+      items: [
+        {
+          id: 'playlist1',
+          name: 'Playlist 1',
+          images: [{ url: 'https://mosaic.scdn.co/300/hash123', height: 300, width: 300 }],
+        },
+      ],
+    })
+    vi.mocked(listStoredMedia).mockResolvedValue([])
+
+    const result = await syncSpotifyData(documentStore)
+
+    expect(result.result).toBe('SUCCESS')
+    expect(logger.error).toHaveBeenCalledWith(
+      'Failed to generate Spotify AI summary.',
+      expect.any(Error),
+    )
+    const widgetPayload = vi.mocked(documentStore.setDocument).mock.calls.find(
+      (c) => c[0] === 'users/chrisvogt/spotify/widget-content',
+    )?.[1] as { aiSummary?: string }
+    expect(widgetPayload.aiSummary).toBeUndefined()
+    expect(
+      vi.mocked(documentStore.setDocument).mock.calls.some(
+        (c) => c[0] === 'users/chrisvogt/spotify/last-response_ai-summary',
+      ),
+    ).toBe(false)
   })
 
   it('should not re-download playlist covers already in storage', async () => {
@@ -303,6 +357,7 @@ describe('syncSpotifyData', () => {
       'spotify.top_tracks',
       'spotify.playlists',
       'spotify.covers',
+      'spotify.ai',
       'spotify.persist',
     ])
   })

--- a/functions/jobs/sync-spotify-data.test.ts
+++ b/functions/jobs/sync-spotify-data.test.ts
@@ -489,6 +489,33 @@ describe('syncSpotifyData', () => {
     expect(result.totalUploadedMediaCount).toBe(1)
   })
 
+  it('selects mosaic art when height is 300 but width is not', async () => {
+    vi.mocked(getSpotifyAccessToken).mockResolvedValue({ accessToken: 'spotify-token' })
+    vi.mocked(getSpotifyUserProfile).mockResolvedValue({
+      display_name: 'Test',
+      external_urls: {},
+      followers: { total: 1 },
+      id: 'id',
+      images: [{ url: 'https://example.com/a.jpg' }],
+    })
+    vi.mocked(getSpotifyTopTracks).mockResolvedValue([])
+    vi.mocked(getSpotifyPlaylists).mockResolvedValue({
+      total: 1,
+      items: [
+        {
+          id: 'pl2',
+          name: 'Tall tile',
+          images: [{ url: 'https://mosaic.scdn.co/300/def', height: 300, width: 64 }],
+        },
+      ],
+    })
+    vi.mocked(listStoredMedia).mockResolvedValue([])
+
+    const result = await syncSpotifyData(documentStore)
+    expect(result.result).toBe('SUCCESS')
+    expect(result.totalUploadedMediaCount).toBe(1)
+  })
+
   it('forwards truncated playlist descriptions into the AI summary input', async () => {
     const spy = vi.fn().mockResolvedValue('<p>ok</p>')
     vi.mocked(generateSpotifySummary).mockImplementation(spy)

--- a/functions/jobs/sync-spotify-data.test.ts
+++ b/functions/jobs/sync-spotify-data.test.ts
@@ -417,4 +417,108 @@ describe('syncSpotifyData', () => {
       expect.any(Object)
     )
   })
+
+  it('omits followers metric and spotify.covers when there is no 300px art and zero followers', async () => {
+    const onProgress = vi.fn()
+    vi.mocked(generateSpotifySummary).mockResolvedValue('<p>AI</p>')
+    vi.mocked(getSpotifyAccessToken).mockResolvedValue({ accessToken: 'spotify-token' })
+    vi.mocked(getSpotifyUserProfile).mockResolvedValue({
+      display_name: 'No Followers',
+      external_urls: { spotify: 'https://open.spotify.com/user/x' },
+      followers: { total: 0 },
+      id: 'user123',
+      images: [{ url: '' }],
+    })
+    vi.mocked(getSpotifyTopTracks).mockResolvedValue([{ id: 't1', name: 'Track' }])
+    vi.mocked(getSpotifyPlaylists).mockResolvedValue({
+      total: 1,
+      items: [
+        {
+          id: 'p1',
+          name: 'No mosaic',
+          images: [{ url: 'https://i.scdn.co/image/x', height: 64, width: 64 }],
+        },
+      ],
+    })
+    vi.mocked(listStoredMedia).mockResolvedValue([])
+
+    const result = await syncSpotifyData(documentStore, { onProgress })
+
+    expect(result.result).toBe('SUCCESS')
+    const widget = (
+      vi.mocked(documentStore.setDocument).mock.calls.find(
+        (c) => c[0] === 'users/chrisvogt/spotify/widget-content',
+      )?.[1] as { metrics?: { id: string }[]; profile: { avatarURL?: unknown } }
+    )
+    expect(widget.metrics?.some((m) => m.id === 'followers-count')).toBe(false)
+    expect(widget.profile.avatarURL).toBeUndefined()
+    expect(onProgress.mock.calls.map((c) => c[0].phase)).toEqual([
+      'spotify.token',
+      'spotify.profile',
+      'spotify.top_tracks',
+      'spotify.playlists',
+      'spotify.ai',
+      'spotify.persist',
+    ])
+  })
+
+  it('selects mosaic art when width is 300 but height is not', async () => {
+    vi.mocked(getSpotifyAccessToken).mockResolvedValue({ accessToken: 'spotify-token' })
+    vi.mocked(getSpotifyUserProfile).mockResolvedValue({
+      display_name: 'Test',
+      external_urls: {},
+      followers: { total: 1 },
+      id: 'id',
+      images: [{ url: 'https://example.com/a.jpg' }],
+    })
+    vi.mocked(getSpotifyTopTracks).mockResolvedValue([])
+    vi.mocked(getSpotifyPlaylists).mockResolvedValue({
+      total: 1,
+      items: [
+        {
+          id: 'pl1',
+          name: 'Wide tile',
+          images: [{ url: 'https://mosaic.scdn.co/300/abc', height: 200, width: 300 }],
+        },
+      ],
+    })
+    vi.mocked(listStoredMedia).mockResolvedValue([])
+
+    const result = await syncSpotifyData(documentStore)
+    expect(result.result).toBe('SUCCESS')
+    expect(result.totalUploadedMediaCount).toBe(1)
+  })
+
+  it('forwards truncated playlist descriptions into the AI summary input', async () => {
+    const spy = vi.fn().mockResolvedValue('<p>ok</p>')
+    vi.mocked(generateSpotifySummary).mockImplementation(spy)
+    const longDesc = `z${'b'.repeat(260)}`
+    vi.mocked(getSpotifyAccessToken).mockResolvedValue({ accessToken: 'spotify-token' })
+    vi.mocked(getSpotifyUserProfile).mockResolvedValue({
+      display_name: 'Test',
+      external_urls: {},
+      followers: { total: 1 },
+      id: 'id',
+      images: [{ url: 'https://example.com/a.jpg' }],
+    })
+    vi.mocked(getSpotifyTopTracks).mockResolvedValue([{ id: 't1', name: 'N' }])
+    vi.mocked(getSpotifyPlaylists).mockResolvedValue({
+      total: 1,
+      items: [
+        {
+          description: longDesc,
+          id: 'pl1',
+          name: 'P',
+          images: [{ url: 'https://mosaic.scdn.co/300/h', height: 300, width: 300 }],
+        },
+      ],
+    })
+    vi.mocked(listStoredMedia).mockResolvedValue([])
+
+    await syncSpotifyData(documentStore)
+
+    const arg = spy.mock.calls[0]?.[0]
+    expect(arg?.playlists[0].description?.endsWith('…')).toBe(true)
+    expect(arg?.playlists[0].description?.length).toBeLessThanOrEqual(240)
+  })
 })

--- a/functions/jobs/sync-spotify-data.ts
+++ b/functions/jobs/sync-spotify-data.ts
@@ -25,7 +25,8 @@ import { toStoredDateTime } from '../utils/time.js'
 import type { SyncJobExecutionOptions } from '../types/sync-pipeline.js'
 import generateSpotifySummary from '../api/ai-summary/generate-spotify-summary.js'
 
-const toSpotifySummaryInput = (content: SpotifyWidgetDocument): SpotifySummaryInput => {
+/** Exported for unit tests (Codecov patch branches on playlist/profile shaping). */
+export const toSpotifySummaryInput = (content: SpotifyWidgetDocument): SpotifySummaryInput => {
   const playlistsRaw = (content.collections?.playlists ?? []) as Array<{
     description?: string
     name?: string

--- a/functions/jobs/sync-spotify-data.ts
+++ b/functions/jobs/sync-spotify-data.ts
@@ -1,5 +1,7 @@
 import pMap from 'p-map'
 import type { DocumentStore } from '../ports/document-store.js'
+import type { SpotifySummaryInput } from '../types/spotify-summary.js'
+import type { SpotifyWidgetDocument } from '../types/widget-content.js'
 import {
   describeMediaStore,
   listStoredMedia,
@@ -21,6 +23,45 @@ import { getLogger } from '../services/logger.js'
 import transformTrackToCollectionItem from '../transformers/track-to-collection-item.js'
 import { toStoredDateTime } from '../utils/time.js'
 import type { SyncJobExecutionOptions } from '../types/sync-pipeline.js'
+import generateSpotifySummary from '../api/ai-summary/generate-spotify-summary.js'
+
+const toSpotifySummaryInput = (content: SpotifyWidgetDocument): SpotifySummaryInput => {
+  const playlistsRaw = (content.collections?.playlists ?? []) as Array<{
+    description?: string
+    name?: string
+    public?: boolean
+    tracks?: { total?: number }
+  }>
+  const topTracksRaw = (content.collections?.topTracks ?? []) as Array<{
+    artists?: string[]
+    name?: string
+  }>
+
+  return {
+    metrics: content.metrics ?? [],
+    playlists: playlistsRaw.slice(0, 50).map((p) => ({
+      description:
+        typeof p.description === 'string' && p.description.length > 240
+          ? `${p.description.slice(0, 239)}…`
+          : p.description,
+      name: typeof p.name === 'string' ? p.name : 'Playlist',
+      public: p.public,
+      trackCount: p.tracks?.total,
+    })),
+    profile: {
+      displayName: content.profile?.displayName,
+      followersCount: content.profile?.followersCount,
+      id: typeof content.profile?.id === 'string' ? content.profile.id : undefined,
+      profileURL: content.profile?.profileURL,
+    },
+    topTracks: topTracksRaw
+      .map((t) => ({
+        artists: Array.isArray(t.artists) ? t.artists : [],
+        name: typeof t.name === 'string' ? t.name : '',
+      }))
+      .filter((t) => t.name.length > 0),
+  }
+}
 
 const SPOTIFY_MOSAIC_BASE_URL = 'https://mosaic.scdn.co/300/'
 
@@ -180,7 +221,7 @@ const syncSpotifyTopTracks = async (
 
   const avatarURL = images.find(({ url }) => !!url)
 
-  const widgetContent = {
+  const widgetContent: SpotifyWidgetDocument = {
     collections: {
       playlists,
       topTracks: topTracks.map(transformTrackToCollectionItem),
@@ -214,6 +255,18 @@ const syncSpotifyTopTracks = async (
     },
   }
 
+  let aiSummary: string | null = null
+  try {
+    onProgress?.({
+      phase: 'spotify.ai',
+      message: 'Generating Spotify listening summary (AI).',
+    })
+    aiSummary = await generateSpotifySummary(toSpotifySummaryInput(widgetContent))
+    widgetContent.aiSummary = aiSummary
+  } catch (error) {
+    logger.error('Failed to generate Spotify AI summary.', error)
+  }
+
   const savePlaylists = async () => await documentStore.setDocument(
     `${spotifyCollectionPath}/last-response_playlists`,
     {
@@ -241,6 +294,15 @@ const syncSpotifyTopTracks = async (
   const saveWidgetContent = async () =>
     await documentStore.setDocument(`${spotifyCollectionPath}/widget-content`, widgetContent)
 
+  const saveAISummary = async () => {
+    if (aiSummary) {
+      await documentStore.setDocument(`${spotifyCollectionPath}/last-response_ai-summary`, {
+        generatedAt: toStoredDateTime(),
+        summary: aiSummary,
+      })
+    }
+  }
+
   try {
     onProgress?.({
       phase: 'spotify.persist',
@@ -251,6 +313,7 @@ const syncSpotifyTopTracks = async (
       saveTopTracksResponse(),
       saveUserProfileResponse(),
       saveWidgetContent(),
+      saveAISummary(),
     ])
 
     logger.info('Spotify sync finished successfully.', {

--- a/functions/jobs/sync-spotify-summary-input.test.ts
+++ b/functions/jobs/sync-spotify-summary-input.test.ts
@@ -64,4 +64,54 @@ describe('toSpotifySummaryInput', () => {
     expect(input.profile.displayName).toBeUndefined()
     expect(input.profile.profileURL).toBeUndefined()
   })
+
+  it('does not truncate description at exactly 240 chars, but does at 241', () => {
+    const d240 = 'y'.repeat(240)
+    const d241 = `z${'y'.repeat(240)}`
+    const doc = {
+      collections: {
+        playlists: [
+          { description: d240, name: 'A', tracks: { total: 1 } },
+          { description: d241, name: 'B', tracks: { total: 2 } },
+        ],
+      },
+    } as SpotifyWidgetDocument
+    const input = toSpotifySummaryInput(doc)
+    expect(input.playlists[0].description).toBe(d240)
+    expect(input.playlists[0].description?.endsWith('…')).toBe(false)
+    expect(input.playlists[1].description).toBe(`${d241.slice(0, 239)}…`)
+  })
+
+  it('passes through non-string description and preserves undefined public and tracks', () => {
+    const doc: SpotifyWidgetDocument = {
+      collections: {
+        playlists: [
+          {
+            description: 99 as unknown as string,
+            name: 'P',
+            public: undefined,
+            tracks: undefined,
+          },
+          { name: 'Q', tracks: {} },
+        ],
+      },
+      profile: {},
+    } as SpotifyWidgetDocument
+    const input = toSpotifySummaryInput(doc)
+    expect(input.playlists[0].description).toBe(99)
+    expect(input.playlists[0].public).toBeUndefined()
+    expect(input.playlists[0].trackCount).toBeUndefined()
+    expect(input.playlists[1].trackCount).toBeUndefined()
+  })
+
+  it('uses empty playlists when collections or playlists are absent', () => {
+    const noCollections = { profile: { displayName: 'solo' } } as SpotifyWidgetDocument
+    expect(toSpotifySummaryInput(noCollections).playlists).toEqual([])
+
+    const emptyCollections = {
+      collections: {},
+      profile: {},
+    } as SpotifyWidgetDocument
+    expect(toSpotifySummaryInput(emptyCollections).playlists).toEqual([])
+  })
 })

--- a/functions/jobs/sync-spotify-summary-input.test.ts
+++ b/functions/jobs/sync-spotify-summary-input.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+
+import { toSpotifySummaryInput } from './sync-spotify-data.js'
+import type { SpotifyWidgetDocument } from '../types/widget-content.js'
+
+describe('toSpotifySummaryInput', () => {
+  it('defaults metrics to an empty array and slices playlists to 50', () => {
+    const longDesc = `x${'a'.repeat(250)}`
+    const playlists = Array.from({ length: 52 }, (_, i) => ({
+      description: i === 0 ? longDesc : undefined,
+      name: `P${i}`,
+      public: i % 2 === 0,
+      tracks: { total: i },
+    }))
+
+    const doc = {
+      collections: {
+        playlists,
+        topTracks: [
+          { artists: ['A'], name: 'One' },
+          { artists: 'bad' as unknown as string[], name: 'Two' },
+          { name: '' },
+        ],
+      },
+      metrics: undefined,
+      profile: {
+        displayName: 'Me',
+        followersCount: 1,
+        id: 12345,
+        profileURL: 'https://open.spotify.com/user/me',
+      },
+    } as SpotifyWidgetDocument
+
+    const input = toSpotifySummaryInput(doc)
+    expect(input.metrics).toEqual([])
+    expect(input.playlists).toHaveLength(50)
+    expect(input.playlists[0].description?.endsWith('…')).toBe(true)
+    expect(input.playlists[0].description?.length).toBeLessThanOrEqual(240)
+    expect(input.playlists[1].trackCount).toBe(1)
+    expect(input.profile.id).toBeUndefined()
+    expect(input.topTracks).toEqual([
+      { artists: ['A'], name: 'One' },
+      { artists: [], name: 'Two' },
+    ])
+  })
+
+  it('uses fallback playlist title and omits trackCount when missing', () => {
+    const doc: SpotifyWidgetDocument = {
+      collections: {
+        playlists: [
+          {
+            description: 'Short',
+            name: 123 as unknown as string,
+            public: true,
+          },
+        ],
+        topTracks: [{ name: 'Only' }],
+      },
+      profile: {},
+    } as SpotifyWidgetDocument
+    const input = toSpotifySummaryInput(doc)
+    expect(input.playlists[0].name).toBe('Playlist')
+    expect(input.playlists[0].trackCount).toBeUndefined()
+    expect(input.profile.displayName).toBeUndefined()
+    expect(input.profile.profileURL).toBeUndefined()
+  })
+})

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chronogrove-functions",
-  "version": "0.30.10",
+  "version": "0.31.0",
   "license": "Apache-2.0",
   "description": "Chronogrove server: Firebase Cloud Functions for the public widget API, authenticated admin routes, and provider sync jobs.",
   "type": "module",

--- a/functions/types/discogs.ts
+++ b/functions/types/discogs.ts
@@ -89,3 +89,24 @@ export interface DiscogsMediaDownloadTask {
   id: string
   mediaURL: string
 }
+
+/** One release row compacted for the Discogs AI summary prompt. */
+export interface DiscogsSummaryCompactRelease {
+  artists: string[]
+  dateAdded?: string
+  formats: string[]
+  genres: string[]
+  styles: string[]
+  title?: string
+  year?: number
+}
+
+/** Payload for Discogs “AI collection summary”. */
+export interface DiscogsSummaryInput {
+  collectionTotal: number
+  decadeCounts: Record<string, number>
+  genreCounts: Record<string, number>
+  profileURL?: string
+  recentReleases: DiscogsSummaryCompactRelease[]
+  styleCounts: Record<string, number>
+}

--- a/functions/types/spotify-summary.ts
+++ b/functions/types/spotify-summary.ts
@@ -1,0 +1,22 @@
+import type { WidgetMetricValue } from './widget-content.js'
+
+/** Payload for Spotify “AI listening summary” (subset of persisted widget data). */
+export interface SpotifySummaryInput {
+  metrics: WidgetMetricValue[]
+  playlists: {
+    description?: string
+    name: string
+    public?: boolean
+    trackCount?: number
+  }[]
+  profile: {
+    displayName?: string
+    followersCount?: number
+    id?: string
+    profileURL?: string
+  }
+  topTracks: {
+    artists: string[]
+    name: string
+  }[]
+}

--- a/functions/types/widget-content.ts
+++ b/functions/types/widget-content.ts
@@ -50,6 +50,7 @@ export interface WidgetMetricValue {
 }
 
 export interface DiscogsWidgetDocument {
+  aiSummary?: string | null
   collections?: {
     releases?: DiscogsTransformedRelease[]
   }
@@ -127,15 +128,25 @@ export interface InstagramWidgetContent {
 }
 
 export interface SpotifyWidgetDocument {
-  collections?: unknown
-  meta?: WidgetMeta
+  aiSummary?: string | null
+  collections?: {
+    playlists?: unknown[]
+    topTracks?: unknown[]
+  }
+  meta?: WidgetMeta & { totalUploadedMediaCount?: number }
   metrics?: WidgetMetricValue[]
-  profile?: unknown
+  profile?: {
+    avatarURL?: { url?: string } | unknown
+    displayName?: string
+    followersCount?: number
+    id?: string
+    profileURL?: string
+  }
 }
 
 export interface SpotifyWidgetContent
   extends Omit<SpotifyWidgetDocument, 'meta'> {
-  meta: WidgetMeta<Date>
+  meta: WidgetMeta<Date> & { totalUploadedMediaCount?: number }
 }
 
 export interface SteamWidgetDocument {


### PR DESCRIPTION
## Summary

Adds Anthropic-powered **AI summaries** for **Spotify** and **Discogs** on successful sync, matching the Goodreads/Steam pattern: `aiSummary` on `widget-content` plus `last-response_ai-summary` in Firestore.

## Changes

- **Spotify** — `generate-spotify-summary.ts` uses profile, metrics, top tracks, and playlist metadata.
- **Discogs** — `generate-discogs-summary.ts` + `buildDiscogsSummaryInput` roll up genres/styles/decades and the newest 72 releases (compact).
- **Tests** — Broad Vitest coverage (including sync continuation when AI fails); **Codecov patch** target raised to **99%**.
- **Versions** — Functions **0.31.0**, console **0.6.28**; changelogs updated.

## How to verify

- `pnpm exec vitest run --coverage` in `functions/` (line coverage at 100% for tracked lines).
- After deploy, run Spotify/Discogs sync with `ANTHROPIC_API_KEY` set and confirm widget payloads include `aiSummary`.

Made with [Cursor](https://cursor.com)