### PR TITLE
refactor(functions): CSRF salt via randomBytes hex (0.31.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Package-specific changes:
 
 ### Changed
 
+- **Workspace** — **Functions 0.31.3**: CSRF salt prefix generated with **`crypto.randomBytes`** and **hex** encoding (replaces a custom alphanumeric alphabet; avoids **Sonar** **S6418** hard-coded secret false positives). See **[functions/CHANGELOG.md](functions/CHANGELOG.md)**.
+
 - **Workspace** — **Functions 0.31.2** and **Console 0.6.30**: Sonar-driven refactors (cognitive complexity, **`void`**, redundant types/casts), **`parseSessionBearerAuth`** for **`POST /api/auth/session`**, **OAuth 1.0a** UTF-8 parameter ordering (**`compareOAuthParamUtf8Octets`**), **Vitest** **100%** Functions line/statement coverage. See **[functions/CHANGELOG.md](functions/CHANGELOG.md)** and **[apps/console/CHANGELOG.md](apps/console/CHANGELOG.md)**.
 
 - **Workspace** — **Functions 0.31.1** and **Console 0.6.29**: Sonar/static-analysis cleanups (promise handling, accessibility, type unions, widget getter argument order, Express HTTP typings, shared sync/error helpers), expanded unit tests, **100%** Vitest line/statement coverage on Functions sources, **Console** test coverage meeting Vitest thresholds (including **`SettingsProfileIdentity`**), with **Codecov patch** target **99%**. See **[functions/CHANGELOG.md](functions/CHANGELOG.md)** and **[apps/console/CHANGELOG.md](apps/console/CHANGELOG.md)**.

--- a/functions/CHANGELOG.md
+++ b/functions/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.3] - 2026-05-12
+
+### Changed
+
+- **CSRF** — Cookie-backed CSRF salt prefix uses **`crypto.randomBytes(TOKEN_SALT_RANDOM_BYTES).toString('hex')`** instead of drawing characters from a fixed alphanumeric alphabet. This matches common Node patterns, preserves a **10**-character salt prefix for **`tokenize`** / **`validate`**, and avoids static-analysis false positives for hard-coded secrets (**Sonar** **S6418**). Binding strength remains from the **`HttpOnly`** secret cookie and **HMAC-SHA256** over the salt.
+
+### Tests
+
+- **`cookie-backed-csrf.test.ts`** — Existing **create** / **validate** round-trip coverage unchanged.
+
 ## [0.31.2] - 2026-05-12
 
 ### Fixed
@@ -885,6 +895,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _This changelog was started with v0.8.0._
 
+[0.31.3]: https://github.com/chrisvogt/chronogrove/compare/v0.31.2...v0.31.3
+[0.31.2]: https://github.com/chrisvogt/chronogrove/compare/v0.31.1...v0.31.2
+[0.31.1]: https://github.com/chrisvogt/chronogrove/compare/v0.31.0...v0.31.1
 [0.31.0]: https://github.com/chrisvogt/chronogrove/compare/v0.30.10...v0.31.0
 [0.30.10]: https://github.com/chrisvogt/chronogrove/compare/v0.30.9...v0.30.10
 [0.30.9]: https://github.com/chrisvogt/chronogrove/compare/v0.30.8...v0.30.9

--- a/functions/app/cookie-backed-csrf.ts
+++ b/functions/app/cookie-backed-csrf.ts
@@ -15,18 +15,12 @@ interface CsrfTokenState {
 }
 
 const SECRET_LENGTH = 18
-const TOKEN_SALT_LENGTH = 10
-const TOKEN_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+/** Unpredictable salt prefix length in characters (hex: two chars per random byte). */
+const TOKEN_SALT_RANDOM_BYTES = 5
+const TOKEN_SALT_LENGTH = TOKEN_SALT_RANDOM_BYTES * 2
 
-function createRandomToken(length: number): string {
-  let value = ''
-
-  for (let index = 0; index < length; index += 1) {
-    const randomIndex = crypto.randomInt(0, TOKEN_CHARS.length)
-    value += TOKEN_CHARS[randomIndex]
-  }
-
-  return value
+function createSaltPrefix(): string {
+  return crypto.randomBytes(TOKEN_SALT_RANDOM_BYTES).toString('hex')
 }
 
 function tokenize(salt: string, secret: string): string {
@@ -43,7 +37,7 @@ export function createCookieBackedCsrfImpl(cookieOptions: CookieOptions) {
         req.res?.cookie(secretKey, secret, cookieOptions)
       }
 
-      const token = tokenize(createRandomToken(TOKEN_SALT_LENGTH), secret)
+      const token = tokenize(createSaltPrefix(), secret)
 
       return {
         secret,

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chronogrove-functions",
-  "version": "0.31.2",
+  "version": "0.31.3",
   "license": "Apache-2.0",
   "description": "Chronogrove server: Firebase Cloud Functions for the public widget API, authenticated admin routes, and provider sync jobs.",
   "type": "module",


### PR DESCRIPTION
## Summary

Replace the cookie-backed CSRF **salt prefix** implementation: instead of building 10 characters from a fixed alphanumeric alphabet with `crypto.randomInt`, we now use `crypto.randomBytes(5).toString('hex')`, which yields a **10-character** hex prefix. The **`HttpOnly`** secret cookie and **HMAC-SHA256** over the salt are unchanged; validation still uses the first **10** characters as the salt (`TOKEN_SALT_LENGTH`).

## Why

- Aligns with common Node patterns (`randomBytes` + hex) without a long literal string and a `TOKEN_*` constant that tripped **Sonar S6418** (hard-coded secret false positive).
- **chronogrove-functions** bumped to **0.31.3** with entries in **`functions/CHANGELOG.md`** and the root **`CHANGELOG.md`**.

## How to test

1. **Unit tests** (from repo root):

   ```bash
   pnpm --filter chronogrove-functions exec vitest run app/cookie-backed-csrf.test.ts
   ```

   Or from `functions/`: `npm test -- --run app/cookie-backed-csrf.test.ts`

2. **Regression sanity**: any flow that uses **cookie-backed CSRF** should still mint and validate tokens (same cookie + HMAC design; only the salt character set changed from mixed alphanumerics to lowercase hex `0-9a-f`).

Made with [Cursor](https://cursor.com)