### PR TITLE
fix(functions): redact API secrets from sync errors and logs (0.31.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Package-specific changes:
 
 ### Changed
 
+- **Workspace** — **Functions 0.31.4**: redact sensitive query params from sync job errors (**`sync_jobs.error`**, manual sync JSON, Cloud Logging) when **`got`** embeds secrets in request URLs; omit token-bearing Instagram Graph **`paging`** URLs from **`last-response`**. See **[functions/CHANGELOG.md](functions/CHANGELOG.md)**.
+
 - **Workspace** — **Functions 0.31.3**: CSRF salt prefix uses **`crypto.randomBytes`** (**hex**); Vitest disk paths use **`os.tmpdir`** / **`mkdtemp`** instead of literal **`/tmp`**; **Discogs** / **Instagram** sync **`reduce`** callbacks wrap **`mediaReducer`**. See **[functions/CHANGELOG.md](functions/CHANGELOG.md)**.
 
 - **Workspace** — **Console 0.6.31**: **`SonoranDuskScene`** mulberry32 uses **`Math.trunc`**-based signed **32-bit** wrap (**`coerceSignedInt32`**); **`SettingsProfileIdentity`** **`swallowSettingsProfileFloatingPromiseRejection`** uses an early-return guard on **`reason`** for an intentional no-op catch handler. See **[apps/console/CHANGELOG.md](apps/console/CHANGELOG.md)**.

--- a/functions/CHANGELOG.md
+++ b/functions/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.4] - 2026-05-30
+
+### Fixed
+
+- **Sync job errors** — **`got`** HTTP failures embed the full request URL (including query secrets) in **`Error.message`**. Sync jobs now redact sensitive query params (**`access_token`**, **`token`**, **`key`**, **`api_key`**, OAuth tokens, etc.) before writing **`sync_jobs.error`**, returning manual sync **`afterJob.error`**, and logging via **`sync-worker`** / provider jobs. New **`utils/redact-secrets.ts`** (**`redactSecretsInText`**, **`safeErrorMessageFromUnknown`**) is applied in **`firestore-sync-job-queue`**, **`create-express-app`** (**`formatUnknownFailureMessage`** / failure responses), and **`sync-instagram-data`**.
+
+- **Instagram `last-response`** — Successful syncs no longer persist **`media.paging.next`** / **`previous`** URLs from the Graph API (those URLs embed **`access_token`**). Stored snapshot keeps profile fields and **`media.data`** only.
+
+### Tests
+
+- **`redact-secrets.test.ts`** — URL redaction for Instagram, Steam, Discogs, Goodreads, Flickr, and JSON-stringified errors.
+- **`firestore-sync-job-queue.test.ts`** — **`failJob`** stores redacted error strings.
+- **`sync-instagram-data.test.ts`** — Omits paging from **`last-response`**; redacts tokens in failure messages.
+
 ## [0.31.3] - 2026-05-12
 
 ### Changed

--- a/functions/CHANGELOG.md
+++ b/functions/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Sync job errors** — **`got`** HTTP failures embed the full request URL (including query secrets) in **`Error.message`**. Sync jobs now redact sensitive query params (**`access_token`**, **`token`**, **`key`**, **`api_key`**, OAuth tokens, etc.) before writing **`sync_jobs.error`**, returning manual sync **`afterJob.error`**, and logging via **`sync-worker`** / provider jobs. New **`utils/redact-secrets.ts`** (**`redactSecretsInText`**, **`safeErrorMessageFromUnknown`**) is applied in **`firestore-sync-job-queue`**, **`create-express-app`** (**`formatUnknownFailureMessage`** / failure responses), and **`sync-instagram-data`**.
+- **Sync job errors** — **`got`** HTTP failures embed the full request URL (including query secrets) in **`Error.message`**. Sync jobs now redact sensitive query params (**`access_token`**, **`token`**, **`key`**, **`api_key`**, OAuth tokens, etc.) before writing **`sync_jobs.error`**, returning manual sync **`afterJob.error`**, and logging via **`sync-worker`** / provider jobs. New **`utils/redact-secrets.ts`** (**`redactSecretsInText`**, **`safeErrorMessageFromUnknown`**) is applied in **`firestore-sync-job-queue`**, **`create-express-app`** (**`buildFailureResponse`**), and **`sync-instagram-data`**.
 
 - **Instagram `last-response`** — Successful syncs no longer persist **`media.paging.next`** / **`previous`** URLs from the Graph API (those URLs embed **`access_token`**). Stored snapshot keeps profile fields and **`media.data`** only.
 

--- a/functions/adapters/sync/firestore-sync-job-queue.test.ts
+++ b/functions/adapters/sync/firestore-sync-job-queue.test.ts
@@ -369,6 +369,28 @@ describe('FirestoreSyncJobQueue', () => {
     )
   })
 
+
+  it('redacts sensitive query params from stored job errors', async () => {
+    const queue = new FirestoreSyncJobQueue()
+    const summary = {
+      durationMs: 134,
+      result: 'FAILURE' as const,
+    }
+    const error = new Error(
+      'Request failed with status code 400: GET https://graph.instagram.com/v25.0/123/media?access_token=IGAAsecret&fields=id',
+    )
+
+    await queue.failJob('sync-chrisvogt-instagram', error, summary)
+
+    expect(mockDocSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error:
+          'Request failed with status code 400: GET https://graph.instagram.com/v25.0/123/media?access_token=[REDACTED]&fields=id',
+      }),
+      { merge: true },
+    )
+  })
+
   it('stores Error instances as their message when failing a job', async () => {
     const queue = new FirestoreSyncJobQueue()
     const summary = {

--- a/functions/adapters/sync/firestore-sync-job-queue.ts
+++ b/functions/adapters/sync/firestore-sync-job-queue.ts
@@ -14,6 +14,7 @@ import type {
   QueuedSyncJobDescriptor,
   SyncJobSummary,
 } from '../../types/sync-pipeline.js'
+import { safeErrorMessageFromUnknown } from '../../utils/redact-secrets.js'
 import { toStoredDateTime } from '../../utils/time.js'
 
 const SYNC_JOBS_COLLECTION = 'sync_jobs'
@@ -21,27 +22,7 @@ const SYNC_JOBS_COLLECTION = 'sync_jobs'
 const toSyncJobId = ({ mode, provider, userId }: QueuedSyncJobDescriptor) =>
   `${mode}-${userId}-${provider}`
 
-const toErrorMessage = (error: unknown): string => {
-  if (error instanceof Error) {
-    return error.message
-  }
-  if (typeof error === 'string') {
-    return error
-  }
-  if (
-    typeof error === 'object' &&
-    error !== null &&
-    'message' in error &&
-    typeof (error as { message: unknown }).message === 'string'
-  ) {
-    return (error as { message: string }).message
-  }
-  try {
-    return JSON.stringify(error)
-  } catch {
-    return 'Unknown error'
-  }
-}
+const toErrorMessage = (error: unknown): string => safeErrorMessageFromUnknown(error)
 
 export class FirestoreSyncJobQueue implements SyncJobQueue {
   async getJob(jobId: string): Promise<QueuedSyncJob | null> {

--- a/functions/app/create-express-app.manual-sync-helpers.test.ts
+++ b/functions/app/create-express-app.manual-sync-helpers.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest'
 import type { Request } from 'express'
 
 import {
-  formatUnknownFailureMessage,
   isInfrastructurePublicWidgetHostname,
   normalizeExpressPathParam,
   parseManualSyncProviderSegmentFromRequest,
@@ -20,47 +19,6 @@ describe('isInfrastructurePublicWidgetHostname', () => {
 
   it('treats normal tenant hostnames as non-infrastructure', () => {
     expect(isInfrastructurePublicWidgetHostname('api.example.com')).toBe(false)
-  })
-})
-
-describe('formatUnknownFailureMessage', () => {
-  it('returns message for Error instances', () => {
-    expect(formatUnknownFailureMessage(new Error('boom'))).toBe('boom')
-  })
-
-  it('returns string message field when present', () => {
-    expect(formatUnknownFailureMessage({ message: 'from object' })).toBe('from object')
-  })
-
-  it('JSON-stringifies plain objects when message is absent or non-string', () => {
-    expect(formatUnknownFailureMessage({ code: 418 })).toBe('{"code":418}')
-    expect(formatUnknownFailureMessage({ message: 99 })).toBe('{"message":99}')
-  })
-
-  it('returns a fixed label when JSON.stringify fails (e.g. circular structure)', () => {
-    const circular: Record<string, unknown> = { a: 1 }
-    circular.self = circular
-    expect(formatUnknownFailureMessage(circular)).toBe('Unserializable error')
-  })
-
-  it('redacts sensitive query params from Error messages', () => {
-    expect(
-      formatUnknownFailureMessage(
-        new Error('GET https://graph.instagram.com/me?access_token=secret'),
-      ),
-    ).toBe('GET https://graph.instagram.com/me?access_token=[REDACTED]')
-  })
-
-  it('redacts sensitive query params from string message fields', () => {
-    expect(formatUnknownFailureMessage({ message: 'failed?key=api-secret' })).toBe(
-      'failed?key=[REDACTED]',
-    )
-  })
-
-  it('redacts sensitive query params from JSON-stringified objects', () => {
-    expect(formatUnknownFailureMessage({ detail: 'https://x?token=abc' })).toBe(
-      '{"detail":"https://x?token=[REDACTED]"}',
-    )
   })
 })
 

--- a/functions/app/create-express-app.manual-sync-helpers.test.ts
+++ b/functions/app/create-express-app.manual-sync-helpers.test.ts
@@ -42,6 +42,26 @@ describe('formatUnknownFailureMessage', () => {
     circular.self = circular
     expect(formatUnknownFailureMessage(circular)).toBe('Unserializable error')
   })
+
+  it('redacts sensitive query params from Error messages', () => {
+    expect(
+      formatUnknownFailureMessage(
+        new Error('GET https://graph.instagram.com/me?access_token=secret'),
+      ),
+    ).toBe('GET https://graph.instagram.com/me?access_token=[REDACTED]')
+  })
+
+  it('redacts sensitive query params from string message fields', () => {
+    expect(formatUnknownFailureMessage({ message: 'failed?key=api-secret' })).toBe(
+      'failed?key=[REDACTED]',
+    )
+  })
+
+  it('redacts sensitive query params from JSON-stringified objects', () => {
+    expect(formatUnknownFailureMessage({ detail: 'https://x?token=abc' })).toBe(
+      '{"detail":"https://x?token=[REDACTED]"}',
+    )
+  })
 })
 
 describe('normalizeExpressPathParam', () => {

--- a/functions/app/create-express-app.ts
+++ b/functions/app/create-express-app.ts
@@ -81,21 +81,6 @@ const buildSuccessResponse = <TPayload>(
     payload,
   })
 
-export function formatUnknownFailureMessage(err: unknown): string {
-  if (err instanceof Error) {
-    return safeErrorMessageFromUnknown(err)
-  }
-  const message = (err as { message?: unknown })?.message
-  if (typeof message === 'string') {
-    return safeErrorMessageFromUnknown(message)
-  }
-  try {
-    return safeErrorMessageFromUnknown(JSON.stringify(err))
-  } catch {
-    return 'Unserializable error'
-  }
-}
-
 const buildFailureResponse = (err: unknown = {}): { ok: false; error: string } => ({
   ok: false,
   error: safeErrorMessageFromUnknown(err),

--- a/functions/app/create-express-app.ts
+++ b/functions/app/create-express-app.ts
@@ -33,6 +33,7 @@ import {
 import { registerDiscogsOAuthRoutes } from './oauth-discogs.js'
 import { registerFlickrOAuthRoutes } from './oauth-flickr.js'
 import { registerGitHubOAuthRoutes } from './oauth-github.js'
+import { safeErrorMessageFromUnknown } from '../utils/redact-secrets.js'
 import { toStoredDateTime } from '../utils/time.js'
 import { hostnameCnameChainsTo } from '../utils/dns-cname-verify.js'
 import { resolveWidgetDataUserIdFromPublicQuery } from './resolve-widget-data-user-id.js'
@@ -82,14 +83,14 @@ const buildSuccessResponse = <TPayload>(
 
 export function formatUnknownFailureMessage(err: unknown): string {
   if (err instanceof Error) {
-    return err.message
+    return safeErrorMessageFromUnknown(err)
   }
   const message = (err as { message?: unknown })?.message
   if (typeof message === 'string') {
-    return message
+    return safeErrorMessageFromUnknown(message)
   }
   try {
-    return JSON.stringify(err)
+    return safeErrorMessageFromUnknown(JSON.stringify(err))
   } catch {
     return 'Unserializable error'
   }
@@ -97,7 +98,7 @@ export function formatUnknownFailureMessage(err: unknown): string {
 
 const buildFailureResponse = (err: unknown = {}): { ok: false; error: string } => ({
   ok: false,
-  error: err instanceof Error ? err.message : formatUnknownFailureMessage(err),
+  error: safeErrorMessageFromUnknown(err),
 })
 
 /** Production gate: revisit domain allowlist, MFA, and Firebase Auth policies before a public launch. */

--- a/functions/index.test.ts
+++ b/functions/index.test.ts
@@ -161,11 +161,13 @@ describe('index.js', () => {
     vi.spyOn(console, 'log').mockImplementation(() => {})
     vi.spyOn(console, 'error').mockImplementation(() => {})
 
-    // Set NODE_ENV to test to avoid dotenv loading
-    process.env.NODE_ENV = 'test'
+    // Isolate NODE_ENV per test; parallel files must not leak production/development.
+    vi.unstubAllEnvs()
+    vi.stubEnv('NODE_ENV', 'test')
   })
 
   afterEach(() => {
+    vi.unstubAllEnvs()
     vi.restoreAllMocks()
   })
 
@@ -608,37 +610,29 @@ describe('index.js', () => {
     })
 
     it('should allow localhost requests in development mode', async () => {
-      // Set NODE_ENV to development to test localhost CORS
-      process.env.NODE_ENV = 'development'
-      
+      vi.stubEnv('NODE_ENV', 'development')
+
       const { expressApp } = await import('./index.js')
-      
+
       const response = await request(expressApp)
         .get('/api/widgets/spotify')
         .set('Origin', 'http://localhost:3000')
         .expect(200)
 
       expect(response.body.ok).toBe(true)
-      
-      // Reset NODE_ENV
-      process.env.NODE_ENV = 'test'
     })
 
     it('should not allow localhost requests in production mode', async () => {
-      // Set NODE_ENV to production to test localhost CORS restriction
-      process.env.NODE_ENV = 'production'
-      
+      vi.stubEnv('NODE_ENV', 'production')
+
       const { expressApp } = await import('./index.js')
-      
+
       const response = await request(expressApp)
         .get('/api/widgets/spotify')
         .set('Origin', 'http://localhost:3000')
         .expect(200) // This will still work because the CORS check is permissive
 
       expect(response.body.ok).toBe(true)
-      
-      // Reset NODE_ENV
-      process.env.NODE_ENV = 'test'
     })
   })
 
@@ -716,8 +710,7 @@ describe('index.js', () => {
 
       it('should reject request from non-allowed email domain', async () => {
         // Domain check only runs in production
-        const prevEnv = process.env.NODE_ENV
-        process.env.NODE_ENV = 'production'
+        vi.stubEnv('NODE_ENV', 'production')
         try {
           const mockVerifyIdToken = vi.fn().mockResolvedValue({
             uid: 'test-uid',
@@ -740,7 +733,8 @@ describe('index.js', () => {
           expect(response.body.ok).toBe(false)
           expect(response.body.error).toBe('Access denied. Only chrisvogt.me or chronogrove.com domain users are allowed.')
         } finally {
-          process.env.NODE_ENV = prevEnv
+          vi.unstubAllEnvs()
+          vi.stubEnv('NODE_ENV', 'test')
         }
       })
 
@@ -944,8 +938,7 @@ describe('index.js', () => {
       })
 
       it('should reject session cookie with disallowed email in production', async () => {
-        const prevEnv = process.env.NODE_ENV
-        process.env.NODE_ENV = 'production'
+        vi.stubEnv('NODE_ENV', 'production')
         const mockVerifySessionCookie = vi.fn().mockResolvedValue({
           uid: 'cookie-uid',
           email: 'test@example.com',
@@ -963,7 +956,6 @@ describe('index.js', () => {
 
         expect(response.body.ok).toBe(false)
         expect(response.body.error).toContain('Access denied')
-        process.env.NODE_ENV = prevEnv
       })
 
       it('should fall back to 401 when session cookie verification fails and no Bearer', async () => {
@@ -997,8 +989,7 @@ describe('index.js', () => {
       })
 
       it('should return 403 when Bearer token has disallowed email domain in production', async () => {
-        const prevEnv = process.env.NODE_ENV
-        process.env.NODE_ENV = 'production'
+        vi.stubEnv('NODE_ENV', 'production')
         try {
           const admin = await import('firebase-admin')
           admin.default.auth = vi.fn(() => ({
@@ -1017,7 +1008,8 @@ describe('index.js', () => {
           expect(response.body.ok).toBe(false)
           expect(response.body.error).toContain('Access denied')
         } finally {
-          process.env.NODE_ENV = prevEnv
+          vi.unstubAllEnvs()
+          vi.stubEnv('NODE_ENV', 'test')
         }
       })
     })
@@ -1401,8 +1393,7 @@ describe('index.js', () => {
     })
 
     it('should use applicationDefault credential when NODE_ENV is production', async () => {
-      const prevEnv = process.env.NODE_ENV
-      process.env.NODE_ENV = 'production'
+      vi.stubEnv('NODE_ENV', 'production')
       vi.clearAllMocks()
       vi.resetModules()
       await import('firebase-admin')
@@ -1414,7 +1405,6 @@ describe('index.js', () => {
         databaseURL: 'mock-database-url',
         projectId: 'personal-stats-chrisvogt',
       })
-      process.env.NODE_ENV = prevEnv
     })
 
     it('should use applicationDefault credential when token.json is missing', async () => {

--- a/functions/jobs/sync-instagram-data.test.ts
+++ b/functions/jobs/sync-instagram-data.test.ts
@@ -202,6 +202,77 @@ describe('syncInstagramData', () => {
     )
   })
 
+
+  it('omits token-bearing paging URLs from last-response', async () => {
+    vi.mocked(fetchInstagramData).mockResolvedValue({
+      media: {
+        data: [],
+        paging: {
+          next: 'https://graph.instagram.com/v25.0/123/media?access_token=secret-token&fields=id',
+        },
+      },
+      followers_count: 1,
+      media_count: 0,
+      username: 'testuser',
+    })
+    vi.mocked(listStoredMedia).mockResolvedValue([])
+
+    await syncInstagramData(documentStore)
+
+    expect(documentStore.setDocument).toHaveBeenNthCalledWith(
+      1,
+      'users/chrisvogt/instagram/last-response',
+      expect.objectContaining({
+        media: { data: [] },
+        fetchedAt: expect.any(String),
+      }),
+    )
+    const lastResponsePayload = vi.mocked(documentStore.setDocument).mock.calls[0][1] as {
+      media?: { paging?: unknown }
+    }
+    expect(lastResponsePayload.media?.paging).toBeUndefined()
+  })
+
+  it('redacts access tokens from API error messages', async () => {
+    vi.mocked(fetchInstagramData).mockRejectedValue(
+      new Error(
+        'Request failed with status code 400: GET https://graph.instagram.com/me?access_token=secret-token',
+      ),
+    )
+
+    const result = await syncInstagramData(documentStore)
+
+    expect(result).toEqual({
+      result: 'FAILURE',
+      error: 'Request failed with status code 400: GET https://graph.instagram.com/me?access_token=[REDACTED]',
+    })
+    expect(logger.error).toHaveBeenCalledWith('Failed to sync Instagram data.', {
+      error: 'Request failed with status code 400: GET https://graph.instagram.com/me?access_token=[REDACTED]',
+    })
+  })
+
+  it('stores profile-only last-response when media is absent', async () => {
+    vi.mocked(fetchInstagramData).mockResolvedValue({
+      followers_count: 10,
+      follows_count: 5,
+      media_count: 0,
+      username: 'testuser',
+    })
+    vi.mocked(listStoredMedia).mockResolvedValue([])
+
+    await syncInstagramData(documentStore)
+
+    expect(documentStore.setDocument).toHaveBeenNthCalledWith(
+      1,
+      'users/chrisvogt/instagram/last-response',
+      expect.objectContaining({
+        media: undefined,
+        username: 'testuser',
+        fetchedAt: expect.any(String),
+      }),
+    )
+  })
+
   it('should handle API errors gracefully', async () => {
     vi.mocked(fetchInstagramData).mockRejectedValue(new Error('Instagram API Error'))
 

--- a/functions/jobs/sync-instagram-data.ts
+++ b/functions/jobs/sync-instagram-data.ts
@@ -10,6 +10,7 @@ import fetchInstagramData from '../api/instagram/fetch-instagram-data.js'
 import { getLogger } from '../services/logger.js'
 import toIGDestinationPath from '../transformers/to-ig-destination-path.js'
 import transformInstagramMedia from '../transformers/transform-instagram-media.js'
+import { safeErrorMessageFromUnknown } from '../utils/redact-secrets.js'
 import { toStoredDateTime } from '../utils/time.js'
 import { getDefaultWidgetUserId, toProviderCollectionPath } from '../config/backend-paths.js'
 import type {
@@ -124,9 +125,11 @@ const syncInstagramData = async (
       phase: 'instagram.persist',
       message: 'Reticulating splines.',
     })
-    // Save the raw Instagram response data
+    // Save the raw Instagram response data (omit paging URLs that embed access tokens)
+    const { media, ...instagramProfile } = instagramResponse
     await documentStore.setDocument(`${instagramCollectionPath}/last-response`, {
-      ...instagramResponse,
+      ...instagramProfile,
+      media: media ? { data: media.data } : undefined,
       fetchedAt: toStoredDateTime(),
     })
 
@@ -192,10 +195,11 @@ const syncInstagramData = async (
       data: updatedWidgetContent,
     }
   } catch (error: unknown) {
-    logger.error('Failed to sync Instagram data.', error)
+    const safeError = safeErrorMessageFromUnknown(error)
+    logger.error('Failed to sync Instagram data.', { error: safeError })
     return {
       result: 'FAILURE',
-      error: error instanceof Error ? error.message : error,
+      error: safeError,
     }
   }
 }

--- a/functions/package.json
+++ b/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chronogrove-functions",
-  "version": "0.31.3",
+  "version": "0.31.4",
   "license": "Apache-2.0",
   "description": "Chronogrove server: Firebase Cloud Functions for the public widget API, authenticated admin routes, and provider sync jobs.",
   "type": "module",

--- a/functions/services/sync-worker.test.ts
+++ b/functions/services/sync-worker.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { DocumentStore } from '../ports/document-store.js'
 import type { SyncJobQueue } from '../ports/sync-job-queue.js'
-import { configureLogger } from './logger.js'
+import { configureLogger, getLogger } from './logger.js'
 import { processSyncJob, runNextSyncJob } from './sync-worker.js'
 
 vi.mock('../jobs/sync-discogs-data.js', () => ({
@@ -254,6 +254,37 @@ describe('runNextSyncJob', () => {
     )
   })
 
+  it('redacts secrets from logged errors when the sync job returns FAILURE', async () => {
+    const tokenError =
+      'Request failed: GET https://api.steampowered.com/?key=steam-secret&steamid=1'
+    vi.mocked(syncSteamData).mockResolvedValue({
+      error: tokenError,
+      result: 'FAILURE',
+    })
+
+    await processSyncJob({
+      documentStore,
+      job: {
+        runCount: 1,
+        enqueuedAt: '2026-03-21T02:00:00.000Z',
+        jobId: 'sync-chrisvogt-steam',
+        mode: 'sync',
+        provider: 'steam',
+        status: 'processing',
+        updatedAt: '2026-03-21T02:00:00.000Z',
+        userId: 'chrisvogt',
+      },
+      syncJobQueue,
+    })
+
+    expect(getLogger().error).toHaveBeenCalledWith(
+      'Sync job failed',
+      expect.objectContaining({
+        error: 'Request failed: GET https://api.steampowered.com/?key=[REDACTED]&steamid=1',
+      }),
+    )
+  })
+
   it('processes an already claimed sync job directly', async () => {
     vi.mocked(syncSteamData).mockResolvedValue({
       data: {
@@ -423,7 +454,9 @@ describe('runNextSyncJob', () => {
   })
 
   it('fails the job when the sync handler throws unexpectedly', async () => {
-    vi.mocked(syncSteamData).mockRejectedValueOnce(new Error('Steam exploded'))
+    vi.mocked(syncSteamData).mockRejectedValueOnce(
+      new Error('GET https://api.steampowered.com/?key=steam-secret'),
+    )
 
     await expect(processSyncJob({
       documentStore,
@@ -446,11 +479,17 @@ describe('runNextSyncJob', () => {
     expect(syncJobQueue.failJob).toHaveBeenCalledWith(
       'sync-chrisvogt-steam',
       expect.objectContaining({
-        message: 'Steam exploded',
+        message: 'GET https://api.steampowered.com/?key=steam-secret',
       }),
       expect.objectContaining({
         result: 'FAILURE',
       })
+    )
+    expect(getLogger().error).toHaveBeenCalledWith(
+      'Sync job threw unexpectedly',
+      expect.objectContaining({
+        error: 'GET https://api.steampowered.com/?key=[REDACTED]',
+      }),
     )
   })
 })

--- a/functions/services/sync-worker.ts
+++ b/functions/services/sync-worker.ts
@@ -10,6 +10,7 @@ import syncSpotifyData from '../jobs/sync-spotify-data.js'
 import syncSteamData from '../jobs/sync-steam-data.js'
 import type { DocumentStore } from '../ports/document-store.js'
 import type { SyncJobQueue } from '../ports/sync-job-queue.js'
+import { safeErrorMessageFromUnknown } from '../utils/redact-secrets.js'
 import { getLogger } from './logger.js'
 import type {
   QueuedSyncJob,
@@ -147,7 +148,7 @@ export const processSyncJob = async ({
     await syncJobQueue.failJob(job.jobId, result.error, summary)
     logger.error('Sync job failed', {
       durationMs,
-      error: result.error,
+      error: safeErrorMessageFromUnknown(result.error),
       jobId: job.jobId,
       provider: job.provider,
       userId: job.userId,
@@ -165,7 +166,7 @@ export const processSyncJob = async ({
     await syncJobQueue.failJob(job.jobId, error, summary)
     logger.error('Sync job threw unexpectedly', {
       durationMs,
-      error,
+      error: safeErrorMessageFromUnknown(error),
       jobId: job.jobId,
       provider: job.provider,
       userId: job.userId,

--- a/functions/utils/redact-secrets.test.ts
+++ b/functions/utils/redact-secrets.test.ts
@@ -79,6 +79,10 @@ describe('safeErrorMessageFromUnknown', () => {
     )
   })
 
+  it('stringifies objects with a non-string message property', () => {
+    expect(safeErrorMessageFromUnknown({ message: 99 })).toBe('{"message":99}')
+  })
+
   it('redacts sensitive params in JSON-stringified objects', () => {
     expect(safeErrorMessageFromUnknown({ url: 'https://x?key=secret', code: 418 })).toBe(
       '{"url":"https://x?key=[REDACTED]","code":418}',

--- a/functions/utils/redact-secrets.test.ts
+++ b/functions/utils/redact-secrets.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+
+import { redactSecretsInText, safeErrorMessageFromUnknown } from './redact-secrets.js'
+
+describe('redactSecretsInText', () => {
+  it('redacts Instagram-style access_token query params', () => {
+    const input =
+      'Request failed with status code 400: GET https://graph.instagram.com/v25.0/123/media?access_token=IGAAsecret&fields=id'
+
+    expect(redactSecretsInText(input)).toBe(
+      'Request failed with status code 400: GET https://graph.instagram.com/v25.0/123/media?access_token=[REDACTED]&fields=id',
+    )
+  })
+
+  it('redacts Steam, Discogs, Goodreads, and Flickr param names', () => {
+    expect(redactSecretsInText('https://api.steampowered.com/?key=steam-secret&steamid=1')).toBe(
+      'https://api.steampowered.com/?key=[REDACTED]&steamid=1',
+    )
+    expect(redactSecretsInText('https://api.discogs.com/releases/1?token=discogs-secret')).toBe(
+      'https://api.discogs.com/releases/1?token=[REDACTED]',
+    )
+    expect(redactSecretsInText('https://www.goodreads.com/user/show/1?key=gr-secret')).toBe(
+      'https://www.goodreads.com/user/show/1?key=[REDACTED]',
+    )
+    expect(redactSecretsInText('https://www.flickr.com/services/rest?api_key=flickr-secret')).toBe(
+      'https://www.flickr.com/services/rest?api_key=[REDACTED]',
+    )
+  })
+
+  it('redacts multiple sensitive params in one string', () => {
+    expect(
+      redactSecretsInText(
+        'GET https://example.com?access_token=a&oauth_token=b&fields=id',
+      ),
+    ).toBe('GET https://example.com?access_token=[REDACTED]&oauth_token=[REDACTED]&fields=id')
+  })
+
+  it('is case-insensitive for param names', () => {
+    expect(redactSecretsInText('https://example.com?ACCESS_TOKEN=secret')).toBe(
+      'https://example.com?ACCESS_TOKEN=[REDACTED]',
+    )
+  })
+
+  it('leaves strings without sensitive params unchanged', () => {
+    const plain = 'Steam unavailable'
+    expect(redactSecretsInText(plain)).toBe(plain)
+  })
+
+  it('redacts client_secret, refresh_token, and oauth_token_secret query params', () => {
+    expect(
+      redactSecretsInText(
+        'https://example.com?client_secret=cs&refresh_token=rt&oauth_token_secret=ots',
+      ),
+    ).toBe(
+      'https://example.com?client_secret=[REDACTED]&refresh_token=[REDACTED]&oauth_token_secret=[REDACTED]',
+    )
+  })
+
+  it('handles empty strings', () => {
+    expect(redactSecretsInText('')).toBe('')
+  })
+})
+
+describe('safeErrorMessageFromUnknown', () => {
+  it('redacts Error messages', () => {
+    const error = new Error(
+      'Request failed: GET https://graph.instagram.com/me?access_token=secret-token',
+    )
+
+    expect(safeErrorMessageFromUnknown(error)).toBe(
+      'Request failed: GET https://graph.instagram.com/me?access_token=[REDACTED]',
+    )
+  })
+
+  it('redacts plain strings and message-like objects', () => {
+    expect(safeErrorMessageFromUnknown('failed?key=abc')).toBe('failed?key=[REDACTED]')
+    expect(safeErrorMessageFromUnknown({ message: 'failed?token=xyz' })).toBe(
+      'failed?token=[REDACTED]',
+    )
+  })
+
+  it('redacts sensitive params in JSON-stringified objects', () => {
+    expect(safeErrorMessageFromUnknown({ url: 'https://x?key=secret', code: 418 })).toBe(
+      '{"url":"https://x?key=[REDACTED]","code":418}',
+    )
+  })
+
+  it('returns Unknown error when JSON.stringify throws', () => {
+    const circular: Record<string, unknown> = { a: 1 }
+    circular.self = circular
+
+    expect(safeErrorMessageFromUnknown(circular)).toBe('Unknown error')
+  })
+})

--- a/functions/utils/redact-secrets.test.ts
+++ b/functions/utils/redact-secrets.test.ts
@@ -95,4 +95,9 @@ describe('safeErrorMessageFromUnknown', () => {
 
     expect(safeErrorMessageFromUnknown(circular)).toBe('Unknown error')
   })
+
+  it('returns Unknown error for undefined and unstringifiable values', () => {
+    expect(safeErrorMessageFromUnknown(undefined)).toBe('Unknown error')
+    expect(safeErrorMessageFromUnknown(() => {})).toBe('Unknown error')
+  })
 })

--- a/functions/utils/redact-secrets.ts
+++ b/functions/utils/redact-secrets.ts
@@ -13,7 +13,7 @@ const SENSITIVE_QUERY_PARAM_NAMES = [
 ] as const
 
 const sensitiveQueryParamPattern = new RegExp(
-  `([?&](?:${SENSITIVE_QUERY_PARAM_NAMES.join('|')})=)([^&\\s"']+)`,
+  String.raw`([?&](?:${SENSITIVE_QUERY_PARAM_NAMES.join('|')})=)([^&\s"']+)`,
   'gi',
 )
 
@@ -35,13 +35,11 @@ const extractErrorMessage = (error: unknown): string => {
   if (typeof error === 'string') {
     return error
   }
-  if (
-    typeof error === 'object' &&
-    error !== null &&
-    'message' in error &&
-    typeof (error as { message: unknown }).message === 'string'
-  ) {
-    return (error as { message: string }).message
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    const message = (error as { message: unknown }).message
+    if (typeof message === 'string') {
+      return message
+    }
   }
   try {
     return JSON.stringify(error)

--- a/functions/utils/redact-secrets.ts
+++ b/functions/utils/redact-secrets.ts
@@ -42,7 +42,9 @@ const extractErrorMessage = (error: unknown): string => {
     }
   }
   try {
-    return JSON.stringify(error)
+    const serialized = JSON.stringify(error)
+    // JSON.stringify returns undefined for undefined, functions, symbols, etc.
+    return typeof serialized === 'string' ? serialized : 'Unknown error'
   } catch {
     return 'Unknown error'
   }

--- a/functions/utils/redact-secrets.ts
+++ b/functions/utils/redact-secrets.ts
@@ -36,7 +36,7 @@ const extractErrorMessage = (error: unknown): string => {
     return error
   }
   if (typeof error === 'object' && error !== null && 'message' in error) {
-    const message = (error as { message: unknown }).message
+    const message = error.message
     if (typeof message === 'string') {
       return message
     }

--- a/functions/utils/redact-secrets.ts
+++ b/functions/utils/redact-secrets.ts
@@ -1,0 +1,55 @@
+const REDACTED = '[REDACTED]'
+
+/** Query parameter names whose values must not appear in logs, APIs, or persisted errors. */
+const SENSITIVE_QUERY_PARAM_NAMES = [
+  'access_token',
+  'api_key',
+  'client_secret',
+  'key',
+  'oauth_token',
+  'oauth_token_secret',
+  'refresh_token',
+  'token',
+] as const
+
+const sensitiveQueryParamPattern = new RegExp(
+  `([?&](?:${SENSITIVE_QUERY_PARAM_NAMES.join('|')})=)([^&\\s"']+)`,
+  'gi',
+)
+
+/**
+ * Replace secret values in URL query strings (e.g. got HTTPError messages) with a fixed placeholder.
+ */
+export const redactSecretsInText = (text: string): string => {
+  if (text.length === 0) {
+    return text
+  }
+
+  return text.replace(sensitiveQueryParamPattern, `$1${REDACTED}`)
+}
+
+const extractErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) {
+    return error.message
+  }
+  if (typeof error === 'string') {
+    return error
+  }
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'message' in error &&
+    typeof (error as { message: unknown }).message === 'string'
+  ) {
+    return (error as { message: string }).message
+  }
+  try {
+    return JSON.stringify(error)
+  } catch {
+    return 'Unknown error'
+  }
+}
+
+/** Normalize an unknown error to a string safe for logs, APIs, and Firestore job records. */
+export const safeErrorMessageFromUnknown = (error: unknown): string =>
+  redactSecretsInText(extractErrorMessage(error))

--- a/functions/vitest.config.js
+++ b/functions/vitest.config.js
@@ -3,6 +3,8 @@ import { defineConfig } from 'vitest/config'
 export default defineConfig({
   test: {
     environment: 'node',
+    // Fork per file so global env (NODE_ENV) cannot leak across parallel suites.
+    pool: 'forks',
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],


### PR DESCRIPTION
## Summary

- Add `utils/redact-secrets.ts` to scrub sensitive query params (`access_token`, `token`, `key`, `api_key`, OAuth tokens, etc.) from error strings before they reach Firestore, manual sync API responses, or Cloud Logging.
- Apply redaction at sync job queue `failJob`, Express failure helpers, sync worker logging, and Instagram sync error handling.
- Stop persisting Instagram Graph `media.paging` URLs in `last-response` (those URLs embed access tokens; paging is unused).
- Bump **functions** to **0.31.4** with changelog entries.

## Test plan

- [x] `pnpm --filter chronogrove-functions test:coverage` — 100% line/statement coverage; 100% patch coverage on changed source lines
- [x] Run a manual Instagram sync that fails (expired token) and confirm `afterJob.error` shows `access_token=[REDACTED]`
- [x] After deploy, rotate any Instagram token that was previously exposed in logs/DB
- [x] Optional: clear stale tokens from existing `sync_jobs.error` / `instagram/last-response` documents


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Security-focused change to error/logging/Firestore paths; behavior is safer but existing stored errors and SSE error events may still contain secrets where redaction was not wired in this PR.
> 
> **Overview**
> **Functions 0.31.4** stops API credentials from leaking when **`got`** puts full request URLs (with query secrets) into error text.
> 
> A new **`utils/redact-secrets`** module scrubs sensitive query params (`access_token`, `token`, `key`, `api_key`, OAuth fields, etc.) via **`redactSecretsInText`** and **`safeErrorMessageFromUnknown`**. That runs wherever failures are surfaced: **`sync_jobs.error`** (`FirestoreSyncJobQueue.failJob`), Express **`formatUnknownFailureMessage`** / **`buildFailureResponse`**, **`sync-worker`** Cloud Logging, and Instagram sync failure returns/logs.
> 
> Instagram successful syncs no longer write Graph **`media.paging`** links into **`last-response`**—only profile fields and **`media.data`**, since paging URLs embed tokens.
> 
> Changelogs and **`package.json`** bump to **0.31.4**; Vitest covers redaction and the Instagram persistence/error paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18814aa48fea57a209b3fe10f1d6ac846efc600f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->